### PR TITLE
S0007 npi algorithm

### DIFF
--- a/CheckDigits.Net.Tests.Benchmarks/NpiAlgorithmTryCalculateBenchmarks.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/NpiAlgorithmTryCalculateBenchmarks.cs
@@ -1,0 +1,18 @@
+﻿// Ignore Spelling: Npi
+
+namespace CheckDigits.Net.Tests.Benchmarks;
+
+[MemoryDiagnoser]
+public class NpiAlgorithmTryCalculateBenchmarks
+{
+   private static readonly NpiAlgorithm _algorithm = new();
+
+   [Params("123456789", "124531959")]
+   public String Value { get; set; } = String.Empty;
+
+   [Benchmark]
+   public void TryCalculateCheckDigit()
+   {
+      _ = _algorithm.TryCalculateCheckDigit(Value, out var checkDigit);
+   }
+}

--- a/CheckDigits.Net.Tests.Benchmarks/NpiAlgorithmValidateBenchmarks.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/NpiAlgorithmValidateBenchmarks.cs
@@ -1,0 +1,18 @@
+﻿// Ignore Spelling: Npi
+
+namespace CheckDigits.Net.Tests.Benchmarks;
+
+[MemoryDiagnoser]
+public class NpiAlgorithmValidateBenchmarks
+{
+   private static readonly NpiAlgorithm _algorithm = new();
+
+   [Params("1234567893", "1245319599")]
+   public String Value { get; set; } = String.Empty;
+
+   [Benchmark]
+   public void Validate()
+   {
+      _ = _algorithm.Validate(Value);
+   }
+}

--- a/CheckDigits.Net.Tests.Benchmarks/Program.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/Program.cs
@@ -1,5 +1,5 @@
-﻿BenchmarkRunner.Run<AbaRtnAlgorithmTryCalculateBenchmarks>();
-BenchmarkRunner.Run<AbaRtnAlgorithmValidateBenchmarks>();
+﻿//BenchmarkRunner.Run<AbaRtnAlgorithmTryCalculateBenchmarks>();
+//BenchmarkRunner.Run<AbaRtnAlgorithmValidateBenchmarks>();
 //BenchmarkRunner.Run<DammAlgorithmTryCalculateBenchmarks>();
 //BenchmarkRunner.Run<DammAlgorithmValidateBenchmarks>();
 //BenchmarkRunner.Run<LuhnAlgorithmTryCalculateBenchmarks>();
@@ -8,5 +8,7 @@ BenchmarkRunner.Run<AbaRtnAlgorithmValidateBenchmarks>();
 //BenchmarkRunner.Run<Modulus10_13AlgorithmValidateBenchmarks>();
 //BenchmarkRunner.Run<Modulus11AlgorithmTryCalculateBenchmarks>();
 //BenchmarkRunner.Run<Modulus11AlgorithmValidateBenchmarks>();
+BenchmarkRunner.Run<NpiAlgorithmTryCalculateBenchmarks>();
+BenchmarkRunner.Run<NpiAlgorithmValidateBenchmarks>();
 //BenchmarkRunner.Run<VerhoeffAlgorithmTryCalculateBenchmarks>();
 //BenchmarkRunner.Run<VerhoeffAlgorithmValidateBenchmarks>();

--- a/CheckDigits.Net.Tests.Unit/AlgorithmsTests.cs
+++ b/CheckDigits.Net.Tests.Unit/AlgorithmsTests.cs
@@ -1,4 +1,4 @@
-﻿// Ignore Spelling: Aba Damm Luhn Rtn Verhoeff
+﻿// Ignore Spelling: Aba Damm Luhn Npi Rtn Verhoeff
 
 namespace CheckDigits.Net.Tests.Unit;
 
@@ -57,6 +57,20 @@ public class AlgorithmsTests
    [Fact]
    public void Algorithms_Modulus10_13Algorithm_ShouldBeExpectedType()
       => Algorithms.Modulus10_13Algorithm.Should().BeOfType<Modulus10_13Algorithm>();
+
+   #endregion
+
+   #region Npi Algorithm Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void Algorithms_NpiAlgorithm_ShouldNotBeNull()
+      => Algorithms.NpiAlgorithm.Should().NotBeNull();
+
+   [Fact]
+   public void Algorithms_NpiAlgorithm_ShouldBeExpectedType()
+      => Algorithms.NpiAlgorithm.Should().BeOfType<NpiAlgorithm>();
 
    #endregion
 

--- a/CheckDigits.Net.Tests.Unit/NpiAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/NpiAlgorithmTests.cs
@@ -1,0 +1,237 @@
+﻿// Ignore Spelling: Npi
+
+namespace CheckDigits.Net.Tests.Unit;
+
+public class NpiAlgorithmTests
+{
+   private readonly NpiAlgorithm _sut = new();
+
+   #region AlgorithmDescription Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void NpiAlgorithm_AlgorithmDescription_ShouldReturnExpectedValue()
+      => _sut.AlgorithmDescription.Should().Be(Resources.NpiAlgorithmDescription);
+
+   #endregion
+
+   #region AlgorithmName Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void NpiAlgorithm_AlgorithmName_ShouldReturnExpectedValue()
+      => _sut.AlgorithmName.Should().Be(Resources.NpiAlgorithmName);
+
+   #endregion
+
+   #region TryCalculateCheckDigit Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void NpiAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenInputIsNull()
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(null!, out var checkDigit).Should().BeFalse();
+      checkDigit.Should().Be('\0');
+   }
+
+   [Fact]
+   public void NpiAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenInputIsEmpty()
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(String.Empty, out var checkDigit).Should().BeFalse();
+      checkDigit.Should().Be('\0');
+   }
+
+   [Fact]
+   public void NpiAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenInputHasLengthLessThanNine()
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit("12345678", out var checkDigit).Should().BeFalse();
+      checkDigit.Should().Be('\0');
+   }
+
+   [Fact]
+   public void NpiAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenInputHasLengthGreaterThanNine()
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit("1234567890", out var checkDigit).Should().BeFalse();
+      checkDigit.Should().Be('\0');
+   }
+
+   [Theory]
+   [InlineData("000000001", '4')]
+   [InlineData("000000100", '4')]
+   [InlineData("000010000", '4')]
+   [InlineData("001000000", '4')]
+   [InlineData("100000000", '4')]
+   public void NpiAlgorithm_TryCalculateCheckDigit_ShouldCorrectlyWeightOddPositionCharacters(
+      String value,
+      Char expectedCheckDigit)
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
+      checkDigit.Should().Be(expectedCheckDigit);
+   }
+
+   [Theory]
+   [InlineData("000000010", '5')]
+   [InlineData("000001000", '5')]
+   [InlineData("000100000", '5')]
+   [InlineData("010000000", '5')]
+   public void NpiAlgorithm_TryCalculateCheckDigit_ShouldCorrectlyWeightEvenPositionCharacters(
+      String value,
+      Char expectedCheckDigit)
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
+      checkDigit.Should().Be(expectedCheckDigit);
+   }
+
+   [Theory]
+   [InlineData("000000000", '6')]
+   [InlineData("000000001", '4')]
+   [InlineData("000000002", '2')]
+   [InlineData("000000003", '0')]
+   [InlineData("000000004", '8')]
+   [InlineData("000000005", '5')]
+   [InlineData("000000006", '3')]
+   [InlineData("000000007", '1')]
+   [InlineData("000000008", '9')]
+   [InlineData("000000009", '7')]
+   public void NpiAlgorithm_TryCalculateCheckDigit_ShouldCalculateCorrectDoubleForOddPositionCharacters(
+      String value,
+      Char expectedCheckDigit)
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
+      checkDigit.Should().Be(expectedCheckDigit);
+   }
+
+   [Theory]
+   [InlineData("123456789", '3')]
+   [InlineData("124531959", '9')]    // Example from www.hippaspace.com
+   public void NpiAlgorithm_TryCalculateCheckDigit_ShouldCalculateExpectedCheckDigit(
+      String value,
+      Char expectedCheckDigit)
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
+      checkDigit.Should().Be(expectedCheckDigit);
+   }
+
+   [Fact]
+   public void NpiAlgorithm_TryCalculateCheckDigit_ShouldCalculateExpectedCheckDigit_WhenInputIsAllZeros()
+   {
+      // Arrange.
+      var value = "000000000";
+      var expectedCheckDigit = '6';
+
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
+      checkDigit.Should().Be(expectedCheckDigit);
+   }
+
+   [Theory]
+   [InlineData("0000000I0")]     // Value 000000050 would have check digit = 5. I is 20 positions later in ASCII table than 5 and would also calculate check digit 5 unless code explicitly checks for non-digit
+   [InlineData("0000000+0")]     // + is 10 positions earlier in ASCII table than 5 and would also calculate check digit 5 unless code explicitly checks for non-digit
+   public void NpiAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenInputContainsNonDigitCharacter(String value)
+   {
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeFalse();
+      checkDigit.Should().Be('\0');
+   }
+
+   #endregion
+
+   #region Validate Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void NpiAlgorithm_Validate_ShouldReturnFalse_WhenInputIsNull()
+      => _sut.Validate(null!).Should().BeFalse();
+
+   [Fact]
+   public void NpiAlgorithm_Validate_ShouldReturnFalse_WhenInputIsEmpty()
+      => _sut.Validate(String.Empty).Should().BeFalse();
+
+   [Fact]
+   public void NpiAlgorithm_Validate_ShouldReturnFalse_WhenInputHasLengthLessThanTen()
+      => _sut.Validate("123456789").Should().BeFalse();
+
+   [Fact]
+   public void NpiAlgorithm_Validate_ShouldReturnFalse_WhenInputHasLengthGreaterThanTen()
+      => _sut.Validate("12345678901").Should().BeFalse();
+
+   [Fact]
+   public void NpiAlgorithm_Validate_ShouldCorrectlyPrefixValueWithConstant80840()
+      => _sut.Validate("0000000006").Should().BeTrue();
+
+   [Theory]
+   [InlineData("0000000014")]
+   [InlineData("0000001004")]
+   [InlineData("0000100004")]
+   [InlineData("0010000004")]
+   [InlineData("1000000004")]
+   public void NpiAlgorithm_Validate_ShouldCorrectlyWeightOddPositionCharacters(String value)
+      => _sut.Validate(value).Should().BeTrue();
+
+   [Theory]
+   [InlineData("0000000105")]
+   [InlineData("0000010005")]
+   [InlineData("0001000005")]
+   [InlineData("0100000005")]
+   public void NpiAlgorithm_Validate_ShouldCorrectlyWeightEvenPositionCharacters(String value)
+      => _sut.Validate(value).Should().BeTrue();
+
+   [Theory]
+   [InlineData("0000000006")]
+   [InlineData("0000000014")]
+   [InlineData("0000000022")]
+   [InlineData("0000000030")]
+   [InlineData("0000000048")]
+   [InlineData("0000000055")]
+   [InlineData("0000000063")]
+   [InlineData("0000000071")]
+   [InlineData("0000000089")]
+   [InlineData("0000000097")]
+   public void NpiAlgorithm_Validate_ShouldCalculateCorrectDoubleForOddPositionCharacters(String value)
+      => _sut.Validate(value).Should().BeTrue();
+
+   [Theory]
+   [InlineData("1234567893")]
+   [InlineData("1245319599")]    // Example from www.hippaspace.com
+   public void NpiAlgorithm_Validate_ShouldReturnTrue_WhenValueContainsValidCheckDigit(String value)
+      => _sut.Validate(value).Should().BeTrue();
+
+   [Theory]
+   [InlineData("1234569071")]    // Valid NPI 1234560971 with two digit transposition 09 -> 90
+   [InlineData("1230967899")]    // Valid NPI 1239067899 with two digit transposition 90 -> 09
+   [InlineData("1122334497")]    // Valid NPI 1122334497 with two digit twin error 22 -> 55
+   [InlineData("1122337797")]    // Valid NPI 1122334497 with two digit twin error 44 -> 77
+   [InlineData("1122664497")]    // Valid NPI 1122334497 with two digit twin error 33 -> 66
+   public void NpiAlgorithm_Validate_ShouldReturnTrue_WhenValueContainsUndetectableError(String value)
+      => _sut.Validate(value).Should().BeTrue();
+
+   [Theory]
+   [InlineData("1238560971")]    // Valid NPI 1234560971 with single digit transcription error 4 -> 8
+   [InlineData("1243560971")]    // Valid NPI 1234560971 with two digit transposition error 34 -> 43
+   [InlineData("4422334497")]    // Valid NPI 1122334497 with two digit twin error 11 -> 44
+   public void NpiAlgorithm_Validate_ShouldReturnFalse_WhenInputContainsDetectableError(String value)
+      => _sut.Validate(value).Should().BeFalse();
+
+   [Fact]
+   public void NpiAlgorithm_Validate_ShouldReturnTrue_WhenCheckDigitIsCalculatesAsZero()
+      => _sut.Validate("0000000600").Should().BeTrue();
+
+   [Theory]
+   [InlineData("0000000I05")]     // Value 0000000505 would have check digit = 5. I is 20 positions later in ASCII table than 5 and would also calculate check digit 5 unless code explicitly checks for non-digit
+   [InlineData("0000000+05")]     // + is 10 positions earlier in ASCII table than 5 and would also calculate check digit 5 unless code explicitly checks for non-digit
+   public void NpiAlgorithm_Validate_ShouldReturnFalse_WhenInputContainsNonDigitCharacter(String value)
+      => _sut.Validate(value).Should().BeFalse();
+
+   #endregion
+}

--- a/CheckDigits.Net/AbaRtnAlgorithm.cs
+++ b/CheckDigits.Net/AbaRtnAlgorithm.cs
@@ -9,6 +9,9 @@ namespace CheckDigits.Net;
 /// </summary>
 /// <remarks>
 ///   <para>
+///   Value length = 9.
+///   </para>
+///   <para>
 ///   Valid characters are decimal digits (0-9).
 ///   </para>
 ///   <para>
@@ -27,7 +30,6 @@ public class AbaRtnAlgorithm : ISingleCheckDigitAlgorithm
 {
    private const Int32 _calculateLength = 8;
    private const Int32 _validateLength = 9;
-
    private static readonly Int32[] _weights = new Int32[9] { 3, 7, 1, 3, 7, 1, 3, 7, 1 };
 
    /// <inheritdoc/>

--- a/CheckDigits.Net/Algorithms.cs
+++ b/CheckDigits.Net/Algorithms.cs
@@ -1,4 +1,4 @@
-﻿// Ignore Spelling: Aba Damm Luhn Rtn Verhoeff
+﻿// Ignore Spelling: Aba Damm Luhn Npi Rtn Verhoeff
 
 namespace CheckDigits.Net;
 
@@ -19,6 +19,9 @@ public class Algorithms
 
    private static readonly Lazy<ISingleCheckDigitAlgorithm> _modulus10_13 =
      new(() => new Modulus10_13Algorithm());
+
+   private static readonly Lazy<ISingleCheckDigitAlgorithm> _npi =
+     new(() => new NpiAlgorithm());
 
    private static readonly Lazy<ISingleCheckDigitAlgorithm> _verhoeff =
      new(() => new VerhoeffAlgorithm());
@@ -43,6 +46,11 @@ public class Algorithms
    ///   Modulus10_13 algorithm.
    /// </summary>
    public static ISingleCheckDigitAlgorithm Modulus10_13Algorithm => _modulus10_13.Value;
+
+   /// <summary>
+   ///   US National Provider Identifier (NPI) algorithm.
+   /// </summary>
+   public static ISingleCheckDigitAlgorithm NpiAlgorithm => _npi.Value;
 
    /// <summary>
    ///   Verhoeff algorithm.

--- a/CheckDigits.Net/NpiAlgorithm.cs
+++ b/CheckDigits.Net/NpiAlgorithm.cs
@@ -1,0 +1,93 @@
+﻿// Ignore Spelling: Npi
+
+namespace CheckDigits.Net;
+
+/// <summary>
+///   US National Provider Identifier (NPI) algorithm. Internally, uses the Luhn
+///   algorithm with a constant "80840" prefix added to the value.
+/// </summary>
+/// <remarks>
+///   <para>
+///   Value length = 10.
+///   </para>
+///   <para>
+///   Valid characters are decimal digits (0-9).
+///   </para>
+///   <para>
+///   Check digit calculated by the algorithm is a decimal digit (0-9).
+///   </para>
+///   <para>
+///   Assumes that the check digit (if present) is the right-most digit in the
+///   input value.
+///   </para>
+///   <para>
+///   Will detect all single-digit transcription errors and most two digit 
+///   transpositions of adjacent digits (except 09 <-> 90). Will detect most
+///   twin errors (i.e. 11 <-> 44) except 22 <-> 55,  33 <-> 66 and 44 <-> 77.
+///   </para>
+/// </remarks>
+public class NpiAlgorithm : ISingleCheckDigitAlgorithm
+{
+   private const Int32 _calculateLength = 9;
+   private const Int32 _validateLength = 10;
+   private const Int32 _prefix = 24;
+   private static readonly Int32[] _doubledValues = new Int32[] { 0, 2, 4, 6, 8, 1, 3, 5, 7, 9 };
+
+   /// <inheritdoc/>
+   public String AlgorithmDescription => Resources.NpiAlgorithmDescription;
+
+   /// <inheritdoc/>
+   public String AlgorithmName => Resources.NpiAlgorithmName;
+
+   /// <inheritdoc/>
+   public Boolean TryCalculateCheckDigit(String value, out Char checkDigit)
+   {
+      checkDigit = CharConstants.NUL;
+      if (String.IsNullOrEmpty(value) || value.Length != _calculateLength)
+      {
+         return false;
+      }
+
+      var sum = _prefix;         // Initializing to prefix (24) has the same effect as prefixing the value with "80840"
+      var oddPosition = true;
+      for (var index = value.Length - 1; index >= 0; index--)
+      {
+         var digit = value[index].ToIntegerDigit();
+         if (digit < 0 || digit > 9)
+         {
+            return false;
+         }
+         sum += oddPosition ? _doubledValues[digit] : digit;
+         oddPosition = !oddPosition;
+      }
+      var mod = (10 - (sum % 10)) % 10;
+      checkDigit = mod.ToDigitChar();
+
+      return true;
+   }
+
+   /// <inheritdoc/>
+   public Boolean Validate(String value)
+   {
+      if (String.IsNullOrEmpty(value) || value.Length != _validateLength)
+      {
+         return false;
+      }
+
+      var sum = _prefix;         // Initializing to prefix (24) has the same effect as prefixing the value with "80840"
+      var oddPosition = true;
+      for (var index = value.Length - 2; index >= 0; index--)
+      {
+         var digit = value[index].ToIntegerDigit();
+         if (digit < 0 || digit > 9)
+         {
+            return false;
+         }
+         sum += oddPosition ? _doubledValues[digit] : digit;
+         oddPosition = !oddPosition;
+      }
+      var checkDigit = (10 - (sum % 10)) % 10;
+
+      return value[^1].ToIntegerDigit() == checkDigit;
+   }
+}

--- a/CheckDigits.Net/Resources.Designer.cs
+++ b/CheckDigits.Net/Resources.Designer.cs
@@ -151,6 +151,24 @@ namespace CheckDigits.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to NPI - Luhn algorithm with constant &quot;80840&quot; prefix.
+        /// </summary>
+        internal static string NpiAlgorithmDescription {
+            get {
+                return ResourceManager.GetString("NpiAlgorithmDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to NPI (National Provider Identifier).
+        /// </summary>
+        internal static string NpiAlgorithmName {
+            get {
+                return ResourceManager.GetString("NpiAlgorithmName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Verhoeff&apos;s dihedral algorithm.
         /// </summary>
         internal static string VerhoeffAlgorithmDescription {

--- a/CheckDigits.Net/Resources.resx
+++ b/CheckDigits.Net/Resources.resx
@@ -147,6 +147,12 @@
   <data name="Modulus11AlgorithmName" xml:space="preserve">
     <value>Modulus11</value>
   </data>
+  <data name="NpiAlgorithmDescription" xml:space="preserve">
+    <value>NPI - Luhn algorithm with constant "80840" prefix</value>
+  </data>
+  <data name="NpiAlgorithmName" xml:space="preserve">
+    <value>NPI (National Provider Identifier)</value>
+  </data>
   <data name="VerhoeffAlgorithmDescription" xml:space="preserve">
     <value>Verhoeff's dihedral algorithm</value>
   </data>

--- a/README.md
+++ b/README.md
@@ -121,11 +121,11 @@ those where the transposed digits differ by 5 (i.e. *1 <-> 6*, *2 <-> 7*, etc.).
 
 #### Details
 
-* Value size - nine digits
 * Valid characters - decimal digits ('0' - '9')
 * Check digit size - one character
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - ninth digit
+* Max length - 8 characters when generating a check digit; 9 characters when validating
 
 #### Links
 
@@ -265,11 +265,11 @@ allocating an extra string.)
 
 #### Details
 
-* Value size - ten digits
 * Valid characters - decimal digits ('0' - '9')
 * Check digit size - one character
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - assumed to be the trailing (right-most) character when validating
+* Max length - 9 characters when generating a check digit; 10 characters when validating
 
 #### Links
 
@@ -373,6 +373,13 @@ Wikipedia: https://en.wikipedia.org/wiki/Verhoeff_algorithm
 | Validate               | 050027293X | 10.052 ns | 0.1027 ns | 0.0911 ns |         - |
 
 ### NPI Algorithm Benchmarks
+
+| Method                 | Value      | Mean     | Error    | StdDev   | Allocated |
+|----------------------- |----------- |---------:|---------:|---------:|----------:|
+| TryCalculateCheckDigit | 123456789  | 14.87 ns | 0.231 ns | 0.216 ns |         - |
+| TryCalculateCheckDigit | 124531959  | 13.33 ns | 0.186 ns | 0.174 ns |         - |
+| Validate               | 1234567893 | 15.59 ns | 0.296 ns | 0.277 ns |         - |
+| Validate               | 1245319599 | 14.51 ns | 0.256 ns | 0.239 ns |         - |
 
 ### Verhoeff Algorithm Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ execution time and/or the complexity to implement.
 * [Luhn Algorithm](#luhn-algorithm)
 * [Modulus10_13 Algorithm (UPC/EAN/ISBN-13/etc.)](#modulus10_13-algorithm)
 * [Modulus11 Algorithm (ISBN-10/ISSN/etc.)](#modulus11-algorithm)
+* [NPI (US National Provider Identifier) Algorithm](#npi-algorithm)
 * [Verhoeff Algorithm](#verhoeff-algorithm)
 
 ## Value/Identifier Type and Associated Algorithm
@@ -49,6 +50,7 @@ execution time and/or the complexity to implement.
 | ISBN-13				| [Modulus10_13 Algorithm](#modulus10_13-algorithm) |
 | ISMN					| [Modulus10_13 Algorithm](#modulus10_13-algorithm) |
 | ISSN   				| [Modulus11 Algorithm](#modulus11-algorithm) |
+| NPI   				| [NPI Algorithm](#npi-algorithm) |
 | SSCC					| [Modulus10_13 Algorithm](#modulus10_13-algorithm) |
 | UPC-A					| [Modulus10_13 Algorithm](#modulus10_13-algorithm) |
 | UPC-E					| [Modulus10_13 Algorithm](#modulus10_13-algorithm) |
@@ -159,8 +161,8 @@ Wikipedia: https://en.wikipedia.org/wiki/Damm_algorithm
 
 The Luhn algorithm is a modulus 10 algorithm that was developed in 1960 by Hans
 Peter Luhn. It can detect all single digit transcription errors and most two digit
-transposition errors except 09 -> 90 and vice versa. It can also detect
-most twin errors (i.e. 11 <-> 44) except 22 <-> 55,  33 <-> 66 and 44 <-> 77.
+transposition errors except *09 -> 90* and vice versa. It can also detect most
+twin errors (i.e. *11 <-> 44*) except *22 <-> 55*,  *33 <-> 66* and *44 <-> 77*.
 
 #### Details
 
@@ -243,6 +245,36 @@ Wikipedia:
   https://en.wikipedia.org/wiki/ISBN#ISBN-10_check_digits
   https://en.wikipedia.org/wiki/ISSN
 
+### NPI Algorithm
+
+#### Description
+
+US National Provider Identifiers (NPI) use the Luhn algorithm to calculate the
+check digit located in the trailing (right-most) position. However, before 
+calculating, the value is prefixed with a constant "80840" and the check digit
+is calculated using the entire 15 digit string. The resulting check digit has all
+the capabilities of the base Luhn algorithm (detecting all single digit transcription 
+errors and most two digit transposition errors except *09 -> 90* and vice versa
+as well as most twin errors (i.e. *11 <-> 44*) except *22 <-> 55*,  *33 <-> 66* 
+and *44 <-> 77*.
+
+(You can create and validate NPI check digits using the standard Luhn algorithm 
+by first prefixing your value with "80840". However, CheckDigits.Net's 
+implementation of the NPI algorithm handles the prefix internally and without 
+allocating an extra string.)
+
+#### Details
+
+* Value size - ten digits
+* Valid characters - decimal digits ('0' - '9')
+* Check digit size - one character
+* Check digit value - decimal digit ('0' - '9')
+* Check digit location - assumed to be the trailing (right-most) character when validating
+
+#### Links
+
+Wikipedia: https://en.wikipedia.org/wiki/National_Provider_Identifier
+
 ### Verhoeff Algorithm
 
 #### Description
@@ -276,6 +308,7 @@ Wikipedia: https://en.wikipedia.org/wiki/Verhoeff_algorithm
 * [Luhn Algorithm](#luhn-algorithm-benchmarks)
 * [Modulus10_13 Algorithm](#modulus10_13-algorithm-benchmarks)
 * [Modulus11 Algorithm](#modulus11-algorithm-benchmarks)
+* [NPI Algorithm](#npi-algorithm-benchmarks)
 * [Verhoeff Algorithm](#verhoeff-algorithm-benchmarks)
 
 ### ABA RTN Algorithm Benchmarks
@@ -338,6 +371,8 @@ Wikipedia: https://en.wikipedia.org/wiki/Verhoeff_algorithm
 | Validate               | 1235       |  5.634 ns | 0.0657 ns | 0.0549 ns |         - |
 | Validate               | 03178471   |  9.295 ns | 0.1752 ns | 0.1874 ns |         - |
 | Validate               | 050027293X | 10.052 ns | 0.1027 ns | 0.0911 ns |         - |
+
+### NPI Algorithm Benchmarks
 
 ### Verhoeff Algorithm Benchmarks
 


### PR DESCRIPTION
# S0007-NpiAlgorithm

As a developer of CheckDigits.Net, I want CheckDigits.Net to include the US 
National Provider Identifier (NPI)check digit algorithm in the list of supported 
algorithms. The NPI algorithm employs the Luhn algorithm but first prefixes the 
value with a constant "80840" before calculating the check digit.

## Requirements

* NpiAlgorithm class that implements the following interfaces:
	- ICheckDigitAlgorithm
	- ISingleCheckDigitAlgorithm
* Resiliency. Invalid input should not throw an exception and instead should simply return Boolean false to indicate failure. Invalid input will include:
	- null
	- String.Empty
	- Strings of invalid length (9 for TryGenerateCheckDigit and 10 for Validate)
	- Strings containing non-digit characters (i.e. not 0-9).
* Should not allocate additional memory (i.e. should not create a new copy of the value) while calculating the check digit

## Definition of DONE

1. NpiAlgorithm class
1. Full unit tests
1. README updates
1. Performance benchmarks