### PR TITLE
S0010 ca sin algorithm

### DIFF
--- a/CheckDigits.Net.Tests.Unit/LuhnAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/LuhnAlgorithmTests.cs
@@ -104,6 +104,8 @@ public class LuhnAlgorithmTests
    [InlineData("356611111111111", '3')]    // JCB test credit card number
    [InlineData("80840123456789", '3')]     // NPI (National Provider Identifier), including 80840 prefix
    [InlineData("49015420323751", '8')]     // IMEI (International Mobile Equipment Identity)
+   [InlineData("29344343", '8')]           // Canadian Social Insurance Number from https://www.ibm.com/docs/en/sga?topic=patterns-canada-social-insurance-number
+   [InlineData("51170095", '7')]           // "
    public void LuhnAlgorithm_TryCalculateCheckDigit_ShouldCalculateExpectedCheckDigit(
       String value,
       Char expectedCheckDigit)
@@ -194,6 +196,8 @@ public class LuhnAlgorithmTests
    [InlineData("3566111111111113")]    // JCB test credit card number
    [InlineData("808401234567893")]     // NPI (National Provider Identifier), including 80840 prefix
    [InlineData("490154203237518")]     // IMEI (International Mobile Equipment Identity)
+   [InlineData("293443438")]           // Canadian Social Insurance Number from https://www.ibm.com/docs/en/sga?topic=patterns-canada-social-insurance-number
+   [InlineData("511700957")]           // "
    public void LuhnAlgorithm_Validate_ShouldReturnTrue_WhenValueContainsValidCheckDigit(String value)
       => _sut.Validate(value).Should().BeTrue();
 

--- a/Documentation/Stories/S0010-CaSinAlgorithm.md
+++ b/Documentation/Stories/S0010-CaSinAlgorithm.md
@@ -1,21 +1,25 @@
 # S0010-CaSinAlgorithm
 
-As a developer of CheckDigits.Net, I want CheckDigits.Net to include the algorithm
-used for Canadian Social Insurance Number (SIN) in the list of supported algorithms.
+~~As a developer of CheckDigits.Net, I want CheckDigits.Net to include the algorithm
+used for Canadian Social Insurance Number (SIN) in the list of supported algorithms.~~
 
 ## Requirements
 
-*CaSinAlgorithm class that implements the following interfaces:
-	- ICheckDigitAlgorithm
-	- ISingleCheckDigitAlgorithm
-* Resiliency. Invalid input should not throw an exception and instead should simply return Boolean false to indicate failure. Invalid input will include:
-	- null
-	- String.Empty
-	- Strings of invalid length (9 characters)
+*~~CaSinAlgorithm class that implements the following interfaces:~~
+	- ~~ICheckDigitAlgorithm~~
+	- ~~ISingleCheckDigitAlgorithm~~
+* ~~Resiliency. Invalid input should not throw an exception and instead should simply return Boolean false to indicate failure. Invalid input will include:~~
+	- ~~null~~
+	- ~~String.Empty~~
+	- ~~Strings of invalid length (9 characters)~~
 
 ## Definition of DONE
 
-1. CaSinAlgorithm class
-1. Full unit tests
-1. README updates
-1. Performance benchmarks
+1. ~~CaSinAlgorithm class~~
+1. ~~Full unit tests~~
+1. ~~README updates~~
+1. ~~Performance benchmarks~~
+
+It turns out that Canadian Social Insurance Numbers can be handled by the existing Luhn algorithm implementation.
+
+Updated readme.md and added tests to Luhn algorithm that use CA SIN values.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ a valid check digit to be considered incorrect/invalid.
 
 | Value/Identifier Type | Algorithm |
 | --------------------- | ----------|
-| ABA RTN				| [ABA RTN Algorithm](#aba-rtn-algorithm) |
+| ABA Routing Transit Number | [ABA RTN Algorithm](#aba-rtn-algorithm) |
+| CA Social Insurance Number | [Luhn Algorithm](#luhn-algorithm) |
 | Credit card number    | [Luhn Algorithm](#luhn-algorithm) |
 | EAN-8					| [Modulus10_13 Algorithm](#modulus10_13-algorithm) |
 | EAN-13				| [Modulus10_13 Algorithm](#modulus10_13-algorithm) |
@@ -57,10 +58,10 @@ a valid check digit to be considered incorrect/invalid.
 | ISBN-13				| [Modulus10_13 Algorithm](#modulus10_13-algorithm) |
 | ISMN					| [Modulus10_13 Algorithm](#modulus10_13-algorithm) |
 | ISSN   				| [Modulus11 Algorithm](#modulus11-algorithm) |
-| NHS                   | [NHS Algorithm](#nhs-algorithm) |
-| NPI   				| [NPI Algorithm](#npi-algorithm) |
+| UK National Health Service Number | [NHS Algorithm](#nhs-algorithm) |
+| US National Provider Identifier | [NPI Algorithm](#npi-algorithm) |
 | SSCC					| [Modulus10_13 Algorithm](#modulus10_13-algorithm) |
-| VIN                   | [VIN Algorithm](#vin-algorithm) |
+| Vehicle Identification Number | [VIN Algorithm](#vin-algorithm) |
 | UPC-A					| [Modulus10_13 Algorithm](#modulus10_13-algorithm) |
 | UPC-E					| [Modulus10_13 Algorithm](#modulus10_13-algorithm) |
 
@@ -195,7 +196,7 @@ twin errors (i.e. *11 <-> 44*) except *22 <-> 55*,  *33 <-> 66* and *44 <-> 77*.
 
 * Credit card numbers
 * International Mobile Equipment Identity (IMEI) numbers
-* A wide variety of government identifiers. See Wikipedia link for more info.
+* Canadian Social Insurance Number (SIN)
 
 #### Links
 


### PR DESCRIPTION
It turns out that Canadian Social Insurance Numbers can be handled by the existing Luhn algorithm implementation.

Updated readme.md and added tests to Luhn algorithm that use CA SIN values.