### PR TITLE
S0022 isan algorithm

### DIFF
--- a/CheckDigits.Net.Tests.Benchmarks/IsanBenchmarks.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/IsanBenchmarks.cs
@@ -1,0 +1,63 @@
+﻿// Ignore Spelling: Isan
+
+namespace CheckDigits.Net.Tests.Benchmarks;
+
+[MemoryDiagnoser]
+public class IsanBenchmarks
+{
+   public static readonly IsanAlgorithm _mod37_36 = new();
+   public static readonly IsanAlgorithm _isan = new();
+
+   //[Params("D02C42E954183EE2Q1291C8AEO", "C594660A8B2E5D22X6DDA3272E", "E9530C32BC0EE83B269867B20F")]
+   //[Params("ISAN D02C-42E9-5418-3EE2-Q-1291-C8AE-O", "ISAN C594-660A-8B2E-5D22-X-6DDA-3272-E", "ISAN E953-0C32-BC0E-E83B-2-6986-7B20-F")]
+   //public String Value { get; set; }
+
+   public IEnumerable<Object[]> ValidateArguments()
+   {
+      yield return new Object[] { "D02C42E954183EE2Q1291C8AEO" };
+      yield return new Object[] { "C594660A8B2E5D22X6DDA3272E" };
+      yield return new Object[] { "E9530C32BC0EE83B269867B20F" };
+   }
+
+   public IEnumerable<Object[]> ValidateShortFormattedArguments()
+   {
+      yield return new Object[] { "ISAN D02C-42E9-5418-3EE2-Q" };
+      yield return new Object[] { "ISAN C594-660A-8B2E-5D22-X" };
+      yield return new Object[] { "ISAN E953-0C32-BC0E-E83B-2" };
+   }
+
+   public IEnumerable<Object[]> ValidateFormattedArguments()
+   {
+      yield return new Object[] { "ISAN D02C-42E9-5418-3EE2-Q-1291-C8AE-O" };
+      yield return new Object[] { "ISAN C594-660A-8B2E-5D22-X-6DDA-3272-E" };
+      yield return new Object[] { "ISAN E953-0C32-BC0E-E83B-2-6986-7B20-F" };
+   }
+
+   [Benchmark(Baseline = true)]
+   [ArgumentsSource(nameof(ValidateArguments))]
+   public void Mod36_36(String value)
+   {
+      _ = _mod37_36.Validate(value);
+   }
+
+   [Benchmark]
+   [ArgumentsSource(nameof(ValidateArguments))]
+   public void Isan(String value)
+   {
+      _ = _isan.Validate(value);
+   }
+
+   [Benchmark]
+   [ArgumentsSource(nameof(ValidateFormattedArguments))]
+   public void IsanFormatted(String value)
+   {
+      _ = _isan.ValidateFormatted(value);
+   }
+
+   [Benchmark]
+   [ArgumentsSource(nameof(ValidateShortFormattedArguments))]
+   public void IsanShortFormatted(String value)
+   {
+      _ = _isan.ValidateFormatted(value);
+   }
+}

--- a/CheckDigits.Net.Tests.Benchmarks/Program.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/Program.cs
@@ -3,6 +3,6 @@
 
 //BenchmarkRunner.Run<AlphabeticAlgorithmsBenchmarks>();
 
-BenchmarkRunner.Run<AlphanumericAlgorithmBenchmarks>();
+//BenchmarkRunner.Run<AlphanumericAlgorithmBenchmarks>();
 
-//BenchmarkRunner.Run<ValueSpecificAlgorithmBenchmarks>();
+BenchmarkRunner.Run<ValueSpecificAlgorithmBenchmarks>();

--- a/CheckDigits.Net.Tests.Benchmarks/ValueSpecificAlgorithmBenchmarks.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/ValueSpecificAlgorithmBenchmarks.cs
@@ -14,12 +14,12 @@ public class ValueSpecificAlgorithmBenchmarks
    //   yield return new Object[] { Algorithms.Vin, Algorithms.Vin.AlgorithmName, "1HGEM212_2L047875" };
    //}
 
-   public IEnumerable<Object[]> TryCalculateCheckDigitsArguments()
-   {
-      yield return new Object[] { Algorithms.Iban, Algorithms.Iban.AlgorithmName, "BE00096123456769" };
-      yield return new Object[] { Algorithms.Iban, Algorithms.Iban.AlgorithmName, "GB00WEST12345698765432" };
-      yield return new Object[] { Algorithms.Iban, Algorithms.Iban.AlgorithmName, "SC00MCBL01031234567890123456USD" };
-   }
+   //public IEnumerable<Object[]> TryCalculateCheckDigitsArguments()
+   //{
+   //   yield return new Object[] { Algorithms.Iban, Algorithms.Iban.AlgorithmName, "BE00096123456769" };
+   //   yield return new Object[] { Algorithms.Iban, Algorithms.Iban.AlgorithmName, "GB00WEST12345698765432" };
+   //   yield return new Object[] { Algorithms.Iban, Algorithms.Iban.AlgorithmName, "SC00MCBL01031234567890123456USD" };
+   //}
 
    public IEnumerable<Object[]> ValidateArguments()
    {
@@ -27,9 +27,13 @@ public class ValueSpecificAlgorithmBenchmarks
       //yield return new Object[] { Algorithms.AbaRtn, Algorithms.AbaRtn.AlgorithmName, "122235821" };
       //yield return new Object[] { Algorithms.AbaRtn, Algorithms.AbaRtn.AlgorithmName, "325081403" };
 
-      yield return new Object[] { Algorithms.Iban, Algorithms.Iban.AlgorithmName, "BE71096123456769" };
-      yield return new Object[] { Algorithms.Iban, Algorithms.Iban.AlgorithmName, "GB82WEST12345698765432" };
-      yield return new Object[] { Algorithms.Iban, Algorithms.Iban.AlgorithmName, "SC74MCBL01031234567890123456USD" };
+      //yield return new Object[] { Algorithms.Iban, Algorithms.Iban.AlgorithmName, "BE71096123456769" };
+      //yield return new Object[] { Algorithms.Iban, Algorithms.Iban.AlgorithmName, "GB82WEST12345698765432" };
+      //yield return new Object[] { Algorithms.Iban, Algorithms.Iban.AlgorithmName, "SC74MCBL01031234567890123456USD" };
+
+      yield return new Object[] { Algorithms.Isan, Algorithms.Isan.AlgorithmName, "D02C42E954183EE2Q1291C8AEO" };
+      yield return new Object[] { Algorithms.Isan, Algorithms.Isan.AlgorithmName, "C594660A8B2E5D22X6DDA3272E" };
+      yield return new Object[] { Algorithms.Isan, Algorithms.Isan.AlgorithmName, "E9530C32BC0EE83B269867B20F" };
 
       //yield return new Object[] { Algorithms.Isin, Algorithms.Isin.AlgorithmName, "US0378331005" };
       //yield return new Object[] { Algorithms.Isin, Algorithms.Isin.AlgorithmName, "AU0000XVGZA3" };
@@ -48,6 +52,16 @@ public class ValueSpecificAlgorithmBenchmarks
       //yield return new Object[] { Algorithms.Vin, Algorithms.Vin.AlgorithmName, "1HGEM21292L047875" };
    }
 
+   public IEnumerable<Object[]> ValidateFormattedArguments()
+   {
+      yield return new Object[] { Algorithms.Isan, Algorithms.Isan.AlgorithmName, "ISAN D02C-42E9-5418-3EE2-Q" };
+      yield return new Object[] { Algorithms.Isan, Algorithms.Isan.AlgorithmName, "ISAN C594-660A-8B2E-5D22-X" };
+      yield return new Object[] { Algorithms.Isan, Algorithms.Isan.AlgorithmName, "ISAN E953-0C32-BC0E-E83B-2" };
+      yield return new Object[] { Algorithms.Isan, Algorithms.Isan.AlgorithmName, "ISAN D02C-42E9-5418-3EE2-Q-1291-C8AE-O" };
+      yield return new Object[] { Algorithms.Isan, Algorithms.Isan.AlgorithmName, "ISAN C594-660A-8B2E-5D22-X-6DDA-3272-E" };
+      yield return new Object[] { Algorithms.Isan, Algorithms.Isan.AlgorithmName, "ISAN E953-0C32-BC0E-E83B-2-6986-7B20-F" };
+   }
+
    //[Benchmark]
    //[ArgumentsSource(nameof(TryCalculateCheckDigitArguments))]
    //public void TryCalculateCheckDigit(ISingleCheckDigitAlgorithm algorithm, String name, String value)
@@ -55,17 +69,24 @@ public class ValueSpecificAlgorithmBenchmarks
    //   algorithm.TryCalculateCheckDigit(value, out var checkDigit);
    //}
 
-   [Benchmark]
-   [ArgumentsSource(nameof(TryCalculateCheckDigitsArguments))]
-   public void TryCalculateCheckDigits(IDoubleCheckDigitAlgorithm algorithm, String name, String value)
-   {
-      algorithm.TryCalculateCheckDigits(value, out var first, out var second);
-   }
+   //[Benchmark]
+   //[ArgumentsSource(nameof(TryCalculateCheckDigitsArguments))]
+   //public void TryCalculateCheckDigits(IDoubleCheckDigitAlgorithm algorithm, String name, String value)
+   //{
+   //   algorithm.TryCalculateCheckDigits(value, out var first, out var second);
+   //}
 
    [Benchmark]
    [ArgumentsSource(nameof(ValidateArguments))]
    public void Validate(ICheckDigitAlgorithm algorithm, String name, String value)
    {
       algorithm.Validate(value);
+   }
+
+   [Benchmark]
+   [ArgumentsSource(nameof(ValidateFormattedArguments))]
+   public void ValidateFormatted(IsanAlgorithm algorithm, String name, String value)
+   {
+      algorithm.ValidateFormatted(value);
    }
 }

--- a/CheckDigits.Net.Tests.Unit/AlgorithmsTests.cs
+++ b/CheckDigits.Net.Tests.Unit/AlgorithmsTests.cs
@@ -1,4 +1,4 @@
-﻿// Ignore Spelling: Aba Damm Iban Isin Luhn Ncd Nhs Npi Rtn Verhoeff
+﻿// Ignore Spelling: Aba Damm Iban Isan Isin Luhn Ncd Nhs Npi Rtn Verhoeff
 
 namespace CheckDigits.Net.Tests.Unit;
 
@@ -57,6 +57,20 @@ public class AlgorithmsTests
    [Fact]
    public void Algorithms_Iban_ShouldBeExpectedType()
       => Algorithms.Iban.Should().BeOfType<IbanAlgorithm>();
+
+   #endregion
+
+   #region Isan Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void Algorithms_Isan_ShouldNotBeNull()
+      => Algorithms.Isan.Should().NotBeNull();
+
+   [Fact]
+   public void Algorithms_Isan_ShouldBeExpectedType()
+      => Algorithms.Isan.Should().BeOfType<IsanAlgorithm>();
 
    #endregion
 

--- a/CheckDigits.Net.Tests.Unit/TestData/BenchmarkData.cs
+++ b/CheckDigits.Net.Tests.Unit/TestData/BenchmarkData.cs
@@ -69,6 +69,23 @@ public class BenchmarkData
    }
 
    [Fact]
+   public void BenchmarkData_GenerateIsanData()
+   {
+      var chars = "0123456789ABCDEF";
+
+      foreach (var n in Enumerable.Range(0, 3))
+      {
+         var full = String.Concat(Enumerable.Range(0, 24)
+            .Select(x => chars[Random.Shared.Next(0, 15)].ToString()));
+         var root = full[..16];
+         Algorithms.Iso7064Mod37_36.TryCalculateCheckDigit(root, out var rootCheckChar);
+         Algorithms.Iso7064Mod37_36.TryCalculateCheckDigit(full, out var fullCheckChar);
+
+         _outputHelper.WriteLine($"{root}{rootCheckChar} {full[16..]}{fullCheckChar}");
+      }
+   }
+
+   [Fact]
    public void BenchmarkData_NumericAlgorithms()
    {
       const String digits = "14066253804255102826542671";

--- a/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/IsanAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/IsanAlgorithmTests.cs
@@ -68,7 +68,6 @@ public class IsanAlgorithmTests
    public void IsanAlgorithm_Validate_ShouldCorrectlyMapCharacterValues(String value)
    => _sut.Validate(value).Should().BeTrue();
 
-
    [Theory]
    [InlineData("00000000C36D002BK00000000E")]         // Full ISAN for Star Trek episode "Amok Time"
    [InlineData("00000000C36D004BC000000001")]         // Full ISAN for Star Trek episode "The Trouble With Tribbles"
@@ -83,7 +82,7 @@ public class IsanAlgorithmTests
    [InlineData("0000000042D70009L00000000B")]         // 00000000D2D70009L00000000B with single char transcription error D -> 4
    [InlineData("00000000C63D004BC000000001")]         // 00000000C36D004BC000000001 with two digit transposition error 36 -> 63
    [InlineData("0000ACBD1234FEDC700000000G")]         // 0000ABCD1234FEDC700000000G with two char transposition error BC -> CB
-   [InlineData("0000ABC1D234FEDC700000000G")]         // 0000ABCD1234FEDC700000000G with two char transposition error D! -> 1D
+   [InlineData("0000ABC1D234FEDC700000000G")]         // 0000ABCD1234FEDC700000000G with two char transposition error D1 -> 1D
    [InlineData("1155AABB3344CCDD500000000M")]         // 1122AABB3344CCDD500000000M with two digit twin error 22 -> 55
    [InlineData("1122AAEE3344CCDD500000000M")]         // 1122AABB3344CCDD500000000M with two char twin error BB -> EE
    [InlineData("2112AABB3344CCDD500000000M")]         // 1122AABB3344CCDD500000000M with jump transposition error 112 -> 211
@@ -126,25 +125,6 @@ public class IsanAlgorithmTests
    public void IsanAlgorithm_Validate_ShouldReturnFalse_WhenInputContainsInvalidCheckCharacter(String value)
       => _sut.Validate(value).Should().BeFalse();
 
-   //[Fact]
-   //public void GenerateTestData()
-   //{
-   //   //r value = "0000ABCD1234FEDC";
-   //   var value = "1111222233334444ABCDEFGH";
-   //   Algorithms.Iso7064Mod37_36.TryCalculateCheckDigit(value, out var checkChar);
-
-   //   _outputHelper.WriteLine($"{value}{checkChar}");
-
-   //   //foreach (Char ch in "0123456789ABCDEF")
-   //   //{
-   //   //   //        12341234123412341234123
-   //   //   value = $"00000000000000000000000{ch}";
-   //   //   Algorithms.Iso7064Mod37_36.TryCalculateCheckDigit(value, out var checkChar);
-
-   //   //   _outputHelper.WriteLine($"{value}{checkChar}");
-   //   //}
-   //}
-
    #endregion
 
    #region ValidateFormatted Tests
@@ -160,37 +140,70 @@ public class IsanAlgorithmTests
       => _sut.ValidateFormatted(String.Empty).Should().BeFalse();
 
    [Theory]
-   [InlineData("ISAN 0000-0000-C36D-002B-")]
-   [InlineData("ISAN 0000-0000-C36D-002B-K-")]
-   [InlineData("ISAN 0000-0000-C36D-002B-K-0000-0000-")]
-   [InlineData("ISAN 0000-0000-C36D-002B-K-0000-0000-E-")]
+   [InlineData("ISAN 0000-ABCD-1234-FEDY")]                    // Valid MOD 37,36 value but incorrect length for formatted ISAN
+   [InlineData("ISAN 0000-ABCD-1234-FEDC-B-R")]                // "
+   [InlineData("ISAN 0000-ABCD-1234-FEDC-7-0000-0008")]        // "
+   [InlineData("ISAN 0000-ABCD-1234-FEDC-7-0000-00000W")]      // "
    public void IsanAlgorithm_ValidateFormatted_ShouldReturnFalse_WhenValueIsInvalidLength(String value)
       => _sut.ValidateFormatted(value).Should().BeFalse();
 
    [Theory]
-   [InlineData("SAN 0000-0000-C36D-002B-K-0000-0000-E-")]
-   [InlineData("AN 0000-0000-C36D-002B-K-0000-0000-E--")]
-   [InlineData("N 0000-0000-C36D-002B-K-0000-0000-E---")]
-   [InlineData(" 0000-0000-C36D-002B-K-0000-0000-E----")]
-   [InlineData("0000-0000-C36D-002B-K-0000-0000-E-----")]
-   [InlineData("I-AN 0000-0000-C36D-002B-K-0000-0000-E")]
-   [InlineData("ISIN 0000-0000-C36D-002B-K-0000-0000-E")]
-   public void IsanAlgorithm_ValidateFormatted_ShouldReturnFalse_WhenInputDoesNotStartWithIsanPrefix(String value)
-      => _sut.ValidateFormatted(value).Should().BeFalse();
+   [InlineData("ISAN 0000-0000-0000-0000-9-0000-0000-A")]
+   [InlineData("ISAN 0000-0000-0000-0000-9-0000-0001-8")]
+   [InlineData("ISAN 0000-0000-0000-0000-9-0000-0002-6")]
+   [InlineData("ISAN 0000-0000-0000-0000-9-0000-0003-4")]
+   [InlineData("ISAN 0000-0000-0000-0000-9-0000-0004-2")]
+   [InlineData("ISAN 0000-0000-0000-0000-9-0000-0005-Z")]
+   [InlineData("ISAN 0000-0000-0000-0000-9-0000-0006-X")]
+   [InlineData("ISAN 0000-0000-0000-0000-9-0000-0007-V")]
+   [InlineData("ISAN 0000-0000-0000-0000-9-0000-0008-T")]
+   [InlineData("ISAN 0000-0000-0000-0000-9-0000-0009-R")]
+   [InlineData("ISAN 0000-0000-0000-0000-9-0000-000A-P")]
+   [InlineData("ISAN 0000-0000-0000-0000-9-0000-000B-N")]
+   [InlineData("ISAN 0000-0000-0000-0000-9-0000-000C-L")]
+   [InlineData("ISAN 0000-0000-0000-0000-9-0000-000D-J")]
+   [InlineData("ISAN 0000-0000-0000-0000-9-0000-000E-H")]
+   [InlineData("ISAN 0000-0000-0000-0000-9-0000-000F-F")]
+   public void IsanAlgorithm_ValidateFormatted_ShouldCorrectlyMapCharacterValues(String value)
+   => _sut.ValidateFormatted(value).Should().BeTrue();
 
    [Theory]
-   [InlineData("ISAN 00000-000-C36D-002B-K-0000-0000-E")]   // Would pass unless formatting explicitly checked
-   [InlineData("ISAN 0000-0000C-36D-002B-K-0000-0000-E")]   // Valid digit in dash location
-   [InlineData("ISAN 0000-0000-C36D0-02B-K-0000-0000-E")]
-   [InlineData("ISAN 0000-0000-C36D-002B-K0-000-0000-E")]
-
-   [InlineData("ISAN 000-00000-C36D-002B-K-0000-0000-E")]   // Dash in digit location
+   [InlineData("isan 0000-0001-8947-0000-8")]
+   [InlineData("HSAN 0000-0001-8947-0000-8")]
+   [InlineData("ITAN 0000-0001-8947-0000-8")]
+   [InlineData("ISBN 0000-0001-8947-0000-8")]
+   [InlineData("ISAO 0000-0001-8947-0000-8")]
+   [InlineData("0000-0001-8947-0000-8")]
+   [InlineData("ISAN0000-0001-8947-0000-8")]
+   [InlineData("ISAN 00000001-8947-0000-8")]
+   [InlineData("ISAN 0000-00018947-0000-8")]
+   [InlineData("ISAN 0000-0001-89470000-8")]
+   [InlineData("ISAN 0000-0001-8947-00008")]
+   [InlineData("ISAN 00000-001-8947-0000-8")]
+   [InlineData("ISAN 0000-000-18947-0000-8")]
+   [InlineData("ISAN 0000-0001-894-70000-8")]
+   [InlineData("ISAN 0000-0001-8947-000-08")]
+   [InlineData("isan 0000-0000-C36D-002B-K-0000-0000-E")]
+   [InlineData("HSAN 0000-0000-C36D-002B-K-0000-0000-E")]
+   [InlineData("ITAN 0000-0000-C36D-002B-K-0000-0000-E")]
+   [InlineData("ISBN 0000-0000-C36D-002B-K-0000-0000-E")]
+   [InlineData("ISAO 0000-0000-C36D-002B-K-0000-0000-E")]
+   [InlineData("ISAN0000-0000-C36D-002B-K-0000-0000-E")]
+   [InlineData("ISAN 00000000-C36D-002B-K-0000-0000-E")]
+   [InlineData("ISAN 0000-0000C36D-002B-K-0000-0000-E")]
+   [InlineData("ISAN 0000-0000-C36D002B-K-0000-0000-E")]
+   [InlineData("ISAN 0000-0000-C36D-002BK-0000-0000-E")]
+   [InlineData("ISAN 0000-0000-C36D-002B-K0000-0000-E")]
+   [InlineData("ISAN 0000-0000-C36D-002B-K-00000000-E")]
+   [InlineData("ISAN 0000-0000-C36D-002B-K-0000-0000E")]
+   [InlineData("ISAN 000-00000-C36D-002B-K-0000-0000-E")]
    [InlineData("ISAN 0000-000-0C36D-002B-K-0000-0000-E")]
    [InlineData("ISAN 0000-0000-C36-D002B-K-0000-0000-E")]
    [InlineData("ISAN 0000-0000-C36D-002-BK-0000-0000-E")]
+   [InlineData("ISAN 0000-0000-C36D-002B--K0000-0000-E")]
    [InlineData("ISAN 0000-0000-C36D-002B-K-000-00000-E")]
    [InlineData("ISAN 0000-0000-C36D-002B-K-0000-000-0E")]
-   public void IsanAlgorithm_ValidateFormatted_ShouldReturnFalse_WhenInputContainsOutOfPlaceGroupSeparator(String value)
+   public void IsanAlgorithm_ValidateFormatted_ShouldReturnFalse_WhenValueHasInvalidFormat(String value)
       => _sut.ValidateFormatted(value).Should().BeFalse();
 
    [Theory]
@@ -198,14 +211,69 @@ public class IsanAlgorithmTests
    [InlineData("ISAN B159-D8FA-0124-0000-K")]               // Example from https://www.isan.org/docs/isan_check_digit_calculation_v2.0.pdf
    [InlineData("ISAN 0000-0000-C36D-002B-K-0000-0000-E")]   // Full ISAN for Star Trek episode "Amok Time"
    [InlineData("ISAN 0000-0000-C36D-004B-C-0000-0000-1")]   // Full ISAN for Star Trek episode "The Trouble With Tribbles"
+   [InlineData("ISAN 0000-0000-D0A9-0011-C-0000-0000-1")]   // Full ISAN for Star Trek Next Gen episode "Yesterday's Enterprise"
    [InlineData("ISAN 0000-0000-D2D7-0009-L-0000-0000-B")]   // Full ISAN for Star Trek DS9 episode "Trials And Tribble-ations"
    public void IsanAlgorithm_ValidateFormatted_ShouldReturnTrue_WhenValueContainsValidCheckDigit(String value)
       => _sut.ValidateFormatted(value).Should().BeTrue();
 
    [Theory]
-   [InlineData("ISAN 0000-0000-0000-000G-E")]               // Would pass unless explicitly checked for hexadecimal value
-   [InlineData("ISAN 0000-0000-0000-000F-G-0000-000G-T")]
-   public void IsanAlgorithm_ValidateFormatted_ShouldReturnFalse_WhenValueContainsNonHexadecimalDigit(String value)
+   [InlineData("ISAN 0000-0000-C37D-002B-K")]               // ISAN 0000-0000-C36D-002B-K with single digit transcription error 6 -> 7
+   [InlineData("ISAN 0000-0000-B36D-002B-K")]               // ISAN 0000-0000-C36D-002B-K with single char transcription error C -> B
+   [InlineData("ISAN 0000-0000-42D7-0009-L")]               // ISAN 0000-0000-D2D7-0009-L with single char transcription error D -> 4
+   [InlineData("ISAN 0000-0000-C63D-004B-C")]               // ISAN 0000-0000-C36D-004B-C with two digit transposition error 36 -> 63
+   [InlineData("ISAN 0000-ACBD-1234-FEDC-7")]               // ISAN 0000-ABCD-1234-FEDC-7 with two char transposition error BC -> CB
+   [InlineData("ISAN 0000-ABC1-D234-FEDC-7")]               // ISAN 0000-ABCD-1234-FEDC-7 with two char transposition error D1 -> 1D
+   [InlineData("ISAN 1155-AABB-3344-CCDD-5")]               // ISAN 1122-AABB-3344-CCDD-5 with two digit twin error 22 -> 55
+   [InlineData("ISAN 1122-AAEE-3344-CCDD-5")]               // ISAN 1122-AABB-3344-CCDD-5 with two char twin error BB -> EE
+   [InlineData("ISAN 2112-AABB-3344-CCDD-5")]               // ISAN 1122-AABB-3344-CCDD-5 with jump transposition error 112 -> 211
+   [InlineData("ISAN 1122-BAAB-3344-CCDD-5")]               // ISAN 1122-AABB-3344-CCDD-5 with jump transposition error AAB -> BAA
+
+   [InlineData("ISAN 0000-0000-C37D-002B-K-0000-0000-E")]   // ISAN 0000-0000-C36D-002B-K-0000-0000E with single digit transcription error 6 -> 7
+   [InlineData("ISAN 0000-0000-B36D-002B-K-0000-0000-E")]   // ISAN 0000-0000-C36D-002B-K-0000-0000E with single char transcription error C -> B
+   [InlineData("ISAN 0000-0000-42D7-0009-L-0000-0000-B")]   // ISAN 0000-0000-D2D7-0009-L-0000-0000B with single char transcription error D -> 4
+   [InlineData("ISAN 0000-0000-C63D-004B-C-0000-0000-1")]   // ISAN 0000-0000-C36D-004B-C-0000-00001 with two digit transposition error 36 -> 63
+   [InlineData("ISAN 0000-ACBD-1234-FEDC-7-0000-0000-G")]   // ISAN 0000-ABCD-1234-FEDC-7-0000-0000G with two char transposition error BC -> CB
+   [InlineData("ISAN 0000-ABC1-D234-FEDC-7-0000-0000-G")]   // ISAN 0000-ABCD-1234-FEDC-7-0000-0000G with two char transposition error D1 -> 1D
+   [InlineData("ISAN 1155-AABB-3344-CCDD-5-0000-0000-M")]   // ISAN 1122-AABB-3344-CCDD-5-0000-0000M with two digit twin error 22 -> 55
+   [InlineData("ISAN 1122-AAEE-3344-CCDD-5-0000-0000-M")]   // ISAN 1122-AABB-3344-CCDD-5-0000-0000M with two char twin error BB -> EE
+   [InlineData("ISAN 2112-AABB-3344-CCDD-5-0000-0000-M")]   // ISAN 1122-AABB-3344-CCDD-5-0000-0000M with jump transposition error 112 -> 211
+   [InlineData("ISAN 1122-BAAB-3344-CCDD-5-0000-0000-M")]   // ISAN 1122-AABB-3344-CCDD-5-0000-0000M with jump transposition error AAB -> BAA
+   public void IsanAlgorithm_ValidateFormatted_ShouldReturnFalse_WhenInputContainsDetectableFirstCheckDigitError(String value)
+      => _sut.ValidateFormatted(value).Should().BeFalse();
+
+   [Theory]
+   [InlineData("ISAN 0000-ABCD-1234-FEDC-7-1634-ABCD-9")]   // ISAN 0000-ABCD-1234-FEDC-7-1234-ABCD-9 with single digit transcription error 2 -> 6
+   [InlineData("ISAN 0000-ABCD-1234-FEDC-7-1234-EBCD-9")]   // ISAN 0000-ABCD-1234-FEDC-7-1234-ABCD-9 with single char transcription error A -> E
+   [InlineData("ISAN 0000-ABCD-1234-FEDC-7-1234-A9CD-9")]   // ISAN 0000-ABCD-1234-FEDC-7-1234-ABCD-9 with single char transcription error B -> 9
+   [InlineData("ISAN 0000-ABCD-1234-FEDC-7-1243-ABCD-9")]   // ISAN 0000-ABCD-1234-FEDC-7-1234-ABCD-9 with two digit transposition error 34 -> 43
+   [InlineData("ISAN 0000-ABCD-1234-FEDC-7-1234-ACBD-9")]   // ISAN 0000-ABCD-1234-FEDC-7-1234-ABCD-9 with two char transposition error BC -> CB
+   [InlineData("ISAN 0000-ABCD-1234-FEDC-7-1155-AABB-6")]   // ISAN 0000-ABCD-1234-FEDC-7-1122-AABB-6 with two digit twin error 22 -> 55
+   [InlineData("ISAN 0000-ABCD-1234-FEDC-7-1122-AAEE-6")]   // ISAN 0000-ABCD-1234-FEDC-7-1122-AABB-6 with two char twin error BB -> EE
+   [InlineData("ISAN 0000-ABCD-1234-FEDC-7-2112-AABB-6")]   // ISAN 0000-ABCD-1234-FEDC-7-1122-AABB-6 with jump transposition error 112 -> 211
+   [InlineData("ISAN 0000-ABCD-1234-FEDC-7-1122-BAAB-6")]   // ISAN 0000-ABCD-1234-FEDC-7-1122-AABB-6 with jump transposition error AAB -> BAA
+   public void IsanAlgorithm_ValidateFormatted_ShouldReturnFalse_WhenInputContainsDetectableSecondCheckDigitError(String value)
+      => _sut.ValidateFormatted(value).Should().BeFalse();
+
+   [Theory]
+   [InlineData("ISAN 1234-5678-9ABC-DEFG-N-0000-0000-5")]   // Valid MOD 37,36 value but not ISAN - G is out of range
+   [InlineData("ISAN 1111-2222-3333-4444-7-ABCD-EFGH-B")]   // Valid MOD 37,36 value but not ISAN - G,H are out of range
+   [InlineData("ISAN 1234-5678-9ABC-DEF+-N-0000-0000-5")]
+   [InlineData("ISAN 1234-5678-9ABC-DEF:-N-0000-0000-5")]
+   [InlineData("ISAN 1234-5678-9ABC-DEF^-N-0000-0000-5")]
+   [InlineData("ISAN 1111-2222-3333-4444-7-ABCD-EFA+-B")]
+   [InlineData("ISAN 1111-2222-3333-4444-7-ABCD-EFA:-B")]
+   [InlineData("ISAN 1111-2222-3333-4444-7-ABCD-EFA^-B")]
+   public void IsanAlgorithm_ValidateFormatted_ShouldReturnFalse_WhenInputContainsInvalidCharacter(String value)
+      => _sut.ValidateFormatted(value).Should().BeFalse();
+
+   [Theory]
+   [InlineData("ISAN 0000-0000-C36D-002B-+-0000-0000-E")]
+   [InlineData("ISAN 0000-0000-C36D-002B-:-0000-0000-E")]
+   [InlineData("ISAN 0000-0000-C36D-002B-^-0000-0000-E")]
+   [InlineData("ISAN 0000-0000-C36D-002B-K-0000-0000-+")]
+   [InlineData("ISAN 0000-0000-C36D-002B-K-0000-0000-:")]
+   [InlineData("ISAN 0000-0000-C36D-002B-K-0000-0000-^")]
+   public void IsanAlgorithm_ValidateFormatted_ShouldReturnFalse_WhenInputContainsInvalidCheckCharacter(String value)
       => _sut.ValidateFormatted(value).Should().BeFalse();
 
    #endregion

--- a/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/IsanAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/IsanAlgorithmTests.cs
@@ -1,0 +1,212 @@
+﻿// Ignore Spelling: Isan
+
+namespace CheckDigits.Net.Tests.Unit.ValueSpecificAlgorithms;
+
+public class IsanAlgorithmTests
+{
+   private readonly IsanAlgorithm _sut = new();
+   private readonly ITestOutputHelper _outputHelper;
+
+   public IsanAlgorithmTests(ITestOutputHelper outputHelper) => _outputHelper = outputHelper;
+
+
+   #region AlgorithmDescription Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void IsanAlgorithm_AlgorithmDescription_ShouldReturnExpectedValue()
+      => _sut.AlgorithmDescription.Should().Be(Resources.IsanAlgorithmDescription);
+
+   #endregion
+
+   #region AlgorithmName Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void IsanAlgorithm_AlgorithmName_ShouldReturnExpectedValue()
+      => _sut.AlgorithmName.Should().Be(Resources.IsanAlgorithmName);
+
+   #endregion
+
+   #region Validate Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void IsanAlgorithm_Validate_ShouldReturnFalse_WhenInputIsNull()
+      => _sut.Validate(null!).Should().BeFalse();
+
+   [Fact]
+   public void IsanAlgorithm_Validate_ShouldReturnFalse_WhenInputIsEmpty()
+      => _sut.Validate(String.Empty).Should().BeFalse();
+
+   [Theory]
+   [InlineData("0000ABCD1234FEDC700000008")]          // Valid MOD 37,36 value but incorrect length for unformatted ISAN
+   [InlineData("0000ABCD1234FEDC7000000000W")]        // "
+   public void IsanAlgorithm_Validate_ShouldReturnFalse_WhenInputIsNot17CharactersInLength(String value)
+      => _sut.Validate(value).Should().BeFalse();
+
+   [Theory]
+   [InlineData("0000000000000000900000000A")]
+   [InlineData("00000000000000009000000018")]
+   [InlineData("00000000000000009000000026")]
+   [InlineData("00000000000000009000000034")]
+   [InlineData("00000000000000009000000042")]
+   [InlineData("0000000000000000900000005Z")]
+   [InlineData("0000000000000000900000006X")]
+   [InlineData("0000000000000000900000007V")]
+   [InlineData("0000000000000000900000008T")]
+   [InlineData("0000000000000000900000009R")]
+   [InlineData("000000000000000090000000AP")]
+   [InlineData("000000000000000090000000BN")]
+   [InlineData("000000000000000090000000CL")]
+   [InlineData("000000000000000090000000DJ")]
+   [InlineData("000000000000000090000000EH")]
+   [InlineData("000000000000000090000000FF")]
+   public void IsanAlgorithm_Validate_ShouldCorrectlyMapCharacterValues(String value)
+   => _sut.Validate(value).Should().BeTrue();
+
+
+   [Theory]
+   [InlineData("00000000C36D002BK00000000E")]         // Full ISAN for Star Trek episode "Amok Time"
+   [InlineData("00000000C36D004BC000000001")]         // Full ISAN for Star Trek episode "The Trouble With Tribbles"
+   [InlineData("00000000D0A90011C000000001")]         // Full ISAN for Star Trek Next Gen episode "Yesterday's Enterprise"
+   [InlineData("00000000D2D70009L00000000B")]         // Full ISAN for Star Trek DS9 episode "Trials And Tribble-ations"
+   public void IsanAlgorithm_Validate_ShouldReturnTrue_WhenInputContainsValidCheckDigits(String value)
+      => _sut.Validate(value).Should().BeTrue();
+
+   [Theory]
+   [InlineData("00000000C37D002BK00000000E")]         // 00000000C36D002BK00000000E with single digit transcription error 6 -> 7
+   [InlineData("00000000B36D002BK00000000E")]         // 00000000C36D002BK00000000E with single char transcription error C -> B
+   [InlineData("0000000042D70009L00000000B")]         // 00000000D2D70009L00000000B with single char transcription error D -> 4
+   [InlineData("00000000C63D004BC000000001")]         // 00000000C36D004BC000000001 with two digit transposition error 36 -> 63
+   [InlineData("0000ACBD1234FEDC700000000G")]         // 0000ABCD1234FEDC700000000G with two char transposition error BC -> CB
+   [InlineData("0000ABC1D234FEDC700000000G")]         // 0000ABCD1234FEDC700000000G with two char transposition error D! -> 1D
+   [InlineData("1155AABB3344CCDD500000000M")]         // 1122AABB3344CCDD500000000M with two digit twin error 22 -> 55
+   [InlineData("1122AAEE3344CCDD500000000M")]         // 1122AABB3344CCDD500000000M with two char twin error BB -> EE
+   [InlineData("2112AABB3344CCDD500000000M")]         // 1122AABB3344CCDD500000000M with jump transposition error 112 -> 211
+   [InlineData("1122BAAB3344CCDD500000000M")]         // 1122AABB3344CCDD500000000M with jump transposition error AAB -> BAA
+   public void IsanAlgorithm_Validate_ShouldReturnFalse_WhenInputContainsDetectableFirstCheckDigitError(String value)
+      => _sut.Validate(value).Should().BeFalse();
+
+   [Theory]
+   [InlineData("0000ABCD1234FEDC71634ABCD9")]         // 0000ABCD1234FEDC71234ABCD9 with single digit transcription error 2 -> 6
+   [InlineData("0000ABCD1234FEDC71234EBCD9")]         // 0000ABCD1234FEDC71234ABCD9 with single char transcription error A -> E
+   [InlineData("0000ABCD1234FEDC71234A9CD9")]         // 0000ABCD1234FEDC71234ABCD9 with single char transcription error B -> 9
+   [InlineData("0000ABCD1234FEDC71243ABCD9")]         // 0000ABCD1234FEDC71234ABCD9 with two digit transposition error 34 -> 43
+   [InlineData("0000ABCD1234FEDC71234ACBD9")]         // 0000ABCD1234FEDC71234ABCD9 with two char transposition error BC -> CB
+   [InlineData("0000ABCD1234FEDC71155AABB6")]         // 0000ABCD1234FEDC71122AABB6 with two digit twin error 22 -> 55
+   [InlineData("0000ABCD1234FEDC71122AAEE6")]         // 0000ABCD1234FEDC71122AABB6 with two char twin error BB -> EE
+   [InlineData("0000ABCD1234FEDC72112AABB6")]         // 0000ABCD1234FEDC71122AABB6 with jump transposition error 112 -> 211
+   [InlineData("0000ABCD1234FEDC71122BAAB6")]         // 0000ABCD1234FEDC71122AABB6 with jump transposition error AAB -> BAA
+   public void IsanAlgorithm_Validate_ShouldReturnFalse_WhenInputContainsDetectableSecondCheckDigitError(String value)
+      => _sut.Validate(value).Should().BeFalse();
+
+   [Theory]
+   [InlineData("123456789ABCDEFGN000000005")]         // Valid MOD 37,36 value but not ISAN - G is out of range
+   [InlineData("11112222333344447ABCDEFGHB")]         // Valid MOD 37,36 value but not ISAN - G,H are out of range
+   [InlineData("123456789ABCDEF+N000000005")]
+   [InlineData("123456789ABCDEF:N000000005")]
+   [InlineData("123456789ABCDEF^N000000005")]
+   [InlineData("11112222333344447ABCDEFA+B")]
+   [InlineData("11112222333344447ABCDEFA:B")]
+   [InlineData("11112222333344447ABCDEFA^B")]
+   public void IsanAlgorithm_Validate_ShouldReturnFalse_WhenInputContainsInvalidCharacter(String value)
+      => _sut.Validate(value).Should().BeFalse();
+
+   [Theory]
+   [InlineData("00000000C36D002B+00000000E")]
+   [InlineData("00000000C36D002B:00000000E")]
+   [InlineData("00000000C36D002B^00000000E")]
+   [InlineData("00000000C36D002BK00000000+")]
+   [InlineData("00000000C36D002BK00000000:")]
+   [InlineData("00000000C36D002BK00000000^")]
+   public void IsanAlgorithm_Validate_ShouldReturnFalse_WhenInputContainsInvalidCheckCharacter(String value)
+      => _sut.Validate(value).Should().BeFalse();
+
+   //[Fact]
+   //public void GenerateTestData()
+   //{
+   //   //r value = "0000ABCD1234FEDC";
+   //   var value = "1111222233334444ABCDEFGH";
+   //   Algorithms.Iso7064Mod37_36.TryCalculateCheckDigit(value, out var checkChar);
+
+   //   _outputHelper.WriteLine($"{value}{checkChar}");
+
+   //   //foreach (Char ch in "0123456789ABCDEF")
+   //   //{
+   //   //   //        12341234123412341234123
+   //   //   value = $"00000000000000000000000{ch}";
+   //   //   Algorithms.Iso7064Mod37_36.TryCalculateCheckDigit(value, out var checkChar);
+
+   //   //   _outputHelper.WriteLine($"{value}{checkChar}");
+   //   //}
+   //}
+
+   #endregion
+
+   #region ValidateFormatted Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void IsanAlgorithm_ValidateFormatted_ShouldReturnFalse_WhenInputIsNull()
+      => _sut.ValidateFormatted(null!).Should().BeFalse();
+
+   [Fact]
+   public void IsanAlgorithm_ValidateFormatted_ShouldReturnFalse_WhenInputIsEmpty()
+      => _sut.ValidateFormatted(String.Empty).Should().BeFalse();
+
+   [Theory]
+   [InlineData("ISAN 0000-0000-C36D-002B-")]
+   [InlineData("ISAN 0000-0000-C36D-002B-K-")]
+   [InlineData("ISAN 0000-0000-C36D-002B-K-0000-0000-")]
+   [InlineData("ISAN 0000-0000-C36D-002B-K-0000-0000-E-")]
+   public void IsanAlgorithm_ValidateFormatted_ShouldReturnFalse_WhenValueIsInvalidLength(String value)
+      => _sut.ValidateFormatted(value).Should().BeFalse();
+
+   [Theory]
+   [InlineData("SAN 0000-0000-C36D-002B-K-0000-0000-E-")]
+   [InlineData("AN 0000-0000-C36D-002B-K-0000-0000-E--")]
+   [InlineData("N 0000-0000-C36D-002B-K-0000-0000-E---")]
+   [InlineData(" 0000-0000-C36D-002B-K-0000-0000-E----")]
+   [InlineData("0000-0000-C36D-002B-K-0000-0000-E-----")]
+   [InlineData("I-AN 0000-0000-C36D-002B-K-0000-0000-E")]
+   [InlineData("ISIN 0000-0000-C36D-002B-K-0000-0000-E")]
+   public void IsanAlgorithm_ValidateFormatted_ShouldReturnFalse_WhenInputDoesNotStartWithIsanPrefix(String value)
+      => _sut.ValidateFormatted(value).Should().BeFalse();
+
+   [Theory]
+   [InlineData("ISAN 00000-000-C36D-002B-K-0000-0000-E")]   // Would pass unless formatting explicitly checked
+   [InlineData("ISAN 0000-0000C-36D-002B-K-0000-0000-E")]   // Valid digit in dash location
+   [InlineData("ISAN 0000-0000-C36D0-02B-K-0000-0000-E")]
+   [InlineData("ISAN 0000-0000-C36D-002B-K0-000-0000-E")]
+
+   [InlineData("ISAN 000-00000-C36D-002B-K-0000-0000-E")]   // Dash in digit location
+   [InlineData("ISAN 0000-000-0C36D-002B-K-0000-0000-E")]
+   [InlineData("ISAN 0000-0000-C36-D002B-K-0000-0000-E")]
+   [InlineData("ISAN 0000-0000-C36D-002-BK-0000-0000-E")]
+   [InlineData("ISAN 0000-0000-C36D-002B-K-000-00000-E")]
+   [InlineData("ISAN 0000-0000-C36D-002B-K-0000-000-0E")]
+   public void IsanAlgorithm_ValidateFormatted_ShouldReturnFalse_WhenInputContainsOutOfPlaceGroupSeparator(String value)
+      => _sut.ValidateFormatted(value).Should().BeFalse();
+
+   [Theory]
+   [InlineData("ISAN 0000-0001-8947-0000-8")]               // Example value from Wikipedia
+   [InlineData("ISAN B159-D8FA-0124-0000-K")]               // Example from https://www.isan.org/docs/isan_check_digit_calculation_v2.0.pdf
+   [InlineData("ISAN 0000-0000-C36D-002B-K-0000-0000-E")]   // Full ISAN for Star Trek episode "Amok Time"
+   [InlineData("ISAN 0000-0000-C36D-004B-C-0000-0000-1")]   // Full ISAN for Star Trek episode "The Trouble With Tribbles"
+   [InlineData("ISAN 0000-0000-D2D7-0009-L-0000-0000-B")]   // Full ISAN for Star Trek DS9 episode "Trials And Tribble-ations"
+   public void IsanAlgorithm_ValidateFormatted_ShouldReturnTrue_WhenValueContainsValidCheckDigit(String value)
+      => _sut.ValidateFormatted(value).Should().BeTrue();
+
+   [Theory]
+   [InlineData("ISAN 0000-0000-0000-000G-E")]               // Would pass unless explicitly checked for hexadecimal value
+   [InlineData("ISAN 0000-0000-0000-000F-G-0000-000G-T")]
+   public void IsanAlgorithm_ValidateFormatted_ShouldReturnFalse_WhenValueContainsNonHexadecimalDigit(String value)
+      => _sut.ValidateFormatted(value).Should().BeFalse();
+
+   #endregion
+}

--- a/CheckDigits.Net/Algorithms.cs
+++ b/CheckDigits.Net/Algorithms.cs
@@ -1,4 +1,4 @@
-﻿// Ignore Spelling: Aba Damm Iban Isin Luhn Ncd Nhs Npi Rtn Verhoeff
+﻿// Ignore Spelling: Aba Damm Iban Isan Isin Luhn Ncd Nhs Npi Rtn Verhoeff
 
 namespace CheckDigits.Net;
 
@@ -19,6 +19,9 @@ public static class Algorithms
 
    private static readonly Lazy<IDoubleCheckDigitAlgorithm> _iban =
      new(() => new IbanAlgorithm());
+
+   private static readonly Lazy<ICheckDigitAlgorithm> _isan =
+     new(() => new IsanAlgorithm());
 
    private static readonly Lazy<ISingleCheckDigitAlgorithm> _isin =
      new(() => new IsinAlgorithm());
@@ -98,6 +101,11 @@ public static class Algorithms
    ///   International Bank Account Number algorithm.
    /// </summary>
    public static IDoubleCheckDigitAlgorithm Iban => _iban.Value;
+
+   /// <summary>
+   ///   International Standard Audiovisual Number algorithm.
+   /// </summary>
+   public static ICheckDigitAlgorithm Isan => _isan.Value;
 
    /// <summary>
    ///   International Securities Identification Number algorithm.

--- a/CheckDigits.Net/Resources.Designer.cs
+++ b/CheckDigits.Net/Resources.Designer.cs
@@ -160,6 +160,24 @@ namespace CheckDigits.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Variation of ISO/IEC 7064 MOD 37,36 for ISAN values formatted as human readable strings.
+        /// </summary>
+        internal static string IsanAlgorithmDescription {
+            get {
+                return ResourceManager.GetString("IsanAlgorithmDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ISAN (International Standard Audiovisual Number).
+        /// </summary>
+        internal static string IsanAlgorithmName {
+            get {
+                return ResourceManager.GetString("IsanAlgorithmName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Variation of the Luhn algorithm that supports alphanumeric characters.
         /// </summary>
         internal static string IsinAlgorithmDescription {

--- a/CheckDigits.Net/Resources.resx
+++ b/CheckDigits.Net/Resources.resx
@@ -150,6 +150,12 @@
   <data name="IbanAlgorithmName" xml:space="preserve">
     <value>IBAN (International Bank Account Number)</value>
   </data>
+  <data name="IsanAlgorithmDescription" xml:space="preserve">
+    <value>Variation of ISO/IEC 7064 MOD 37,36 for ISAN values formatted as human readable strings</value>
+  </data>
+  <data name="IsanAlgorithmName" xml:space="preserve">
+    <value>ISAN (International Standard Audiovisual Number)</value>
+  </data>
   <data name="IsinAlgorithmDescription" xml:space="preserve">
     <value>Variation of the Luhn algorithm that supports alphanumeric characters</value>
   </data>

--- a/CheckDigits.Net/Utility/CharConstants.cs
+++ b/CheckDigits.Net/Utility/CharConstants.cs
@@ -5,6 +5,7 @@ public static class CharConstants
    public const Char NUL = '\0';
 
    public const Char Asterisk = '*';
+   public const Char Dash = '-';
 
    public const Char DigitZero = '0';
    public const Char DigitOne = '1';

--- a/CheckDigits.Net/ValueSpecificAlgorithms/IsanAlgorithm.cs
+++ b/CheckDigits.Net/ValueSpecificAlgorithms/IsanAlgorithm.cs
@@ -1,0 +1,214 @@
+﻿// Ignore Spelling: Isan
+
+namespace CheckDigits.Net.ValueSpecificAlgorithms;
+
+/// <summary>
+///   International Standard Audiovisual Number (ISAN) algorithm. Variation of
+///   ISO/IEC 7064 MOD 37,36 algorithm adapted for use with ISAN values formatted
+///   as human readable strings.
+/// </summary>
+/// <remarks>
+///   <para>
+///   Valid characters are hexadecimal characters (0-9, A-F).
+///   </para>
+///   <para>
+///   Check character(s) calculated by the algorithm is an alphanumeric character (0-9, A-Z).
+///   </para>
+///   <para>
+///   Will detect all single character transcription errors, all or nearly all 
+///   two character transposition errors, all or nearly all jump transposition 
+///   errors, all or nearly all circular shift errors and a high proportion of 
+///   double character transcription errors (two separate single character 
+///   transcription errors in the same value).
+///   </para>
+/// </remarks>
+public class IsanAlgorithm : ICheckDigitAlgorithm
+{
+   private readonly Int32 _modulus = 36;
+   private readonly Int32 _modulusPlus1 = 37;
+   private const String _prefix = "ISAN ";
+
+   private const Int32 _validateExpectedLength = 26;
+   private const Int32 _validateFirstCheckCharIndex = 16;
+
+   private const Int32 _validateFormattedExpectedRootLength = 26;
+   private const Int32 _validateFormattedExpectedVersionLength = 38;
+
+   // Mask characters:
+   // a - alphabetic character
+   // b - betanumeric character
+   // d - digit character
+   // h - hexadecimal character
+   // # - check character
+   // _ - wildcard character; ignored
+   // Another character must match exactly
+   private const String _mask = "ISAN hhhh-hhhh-hhhh-hhhh-#-hhhh-hhhh-#";
+
+   private const Int32 _rootOnlyLength = 26;
+   private const Int32 _rootCheckCharacterIndex = _rootOnlyLength - 1;
+   private const Int32 _rootPlusVersionLength = 38;
+
+   /// <inheritdoc/>
+   public String AlgorithmDescription => Resources.IsanAlgorithmDescription;
+
+   /// <inheritdoc/>
+   public String AlgorithmName => Resources.IsanAlgorithmName;
+
+   /// <inheritdoc/>
+   public Boolean Validate(String value)
+   {
+      if (String.IsNullOrEmpty(value) || value.Length != _validateExpectedLength)
+      {
+         return false;
+      }
+
+      Char ch;
+      Int32 num;
+      var product = _modulus;
+      for (var index = 0; index < value.Length - 1; index++)
+      {
+         ch = value[index];
+         if (ch >= CharConstants.DigitZero && ch <= CharConstants.DigitNine)
+         {
+            num = ch.ToIntegerDigit();
+         }
+         else if ((ch >= CharConstants.UpperCaseA && ch <= CharConstants.UpperCaseF)      // Hexadecimal chars only, unless check character position
+                 || (ch >= CharConstants.UpperCaseG && ch <= CharConstants.UpperCaseZ && index == _validateFirstCheckCharIndex))
+         {
+            num = ch - CharConstants.UpperCaseA + 10;
+         }
+         else
+         {
+            return false;
+         }
+
+         // Root segment check character.
+         if (index == _validateFirstCheckCharIndex)
+         {
+            var rootProduct = product + num;
+            if (rootProduct % _modulus != 1)
+            {
+               return false;
+            }
+         }
+         else
+         {
+            product += num;
+            if (product > _modulus)
+            {
+               product -= _modulus;
+            }
+            product *= 2;
+            if (product >= _modulusPlus1)
+            {
+               product -= _modulusPlus1;
+            }
+         }
+      }
+
+      ch = value[^1];
+      if (ch >= CharConstants.DigitZero && ch <= CharConstants.DigitNine)
+      {
+         num = ch.ToIntegerDigit();
+      }
+      else if (ch >= CharConstants.UpperCaseA && ch <= CharConstants.UpperCaseZ)
+      {
+         num = ch - CharConstants.UpperCaseA + 10;
+      }
+      else
+      {
+         return false;
+      }
+      product += num;
+
+      return product % _modulus == 1;
+   }
+
+   /// <inheritdoc/>
+   public Boolean ValidateFormatted(String value)
+   {
+      if (String.IsNullOrEmpty(value)
+         || (value.Length != _rootOnlyLength && value.Length != _rootPlusVersionLength)
+         || !value.StartsWith(_prefix, StringComparison.Ordinal)) 
+      {
+         return false;
+      }
+
+      Char ch;
+      Int32 num;
+      var product = _modulus;
+      for (var index = _prefix.Length; index < value.Length - 1; index++)
+      {
+         ch = value[index];
+         if (index == 9 || index == 14 || index == 19 || index == 24 || index == 26 || index == 31 || index == 36)
+         {
+            // Ignore group separator dash characters. Otherwise it's an invalid character.
+            if (ch == CharConstants.Dash)
+            {
+               continue;
+            }
+
+            return false;
+         }
+
+         if (ch >= CharConstants.DigitZero && ch <= CharConstants.DigitNine)
+         {
+            num = ch.ToIntegerDigit();
+         }
+         else if (ch >= CharConstants.UpperCaseA && ch <= CharConstants.UpperCaseZ)
+         {
+            num = ch - CharConstants.UpperCaseA + 10;
+         }
+         else
+         {
+            return false;
+         }
+
+         // Root segment check character.
+         if (index == _rootCheckCharacterIndex)
+         {
+            var rootProduct = product + num;
+            if (rootProduct % _modulus != 1)
+            {
+               return false;
+            }
+         }
+         else
+         {
+            // Check for non-hexadecimal value.
+            if (num > 15)
+            {
+               return false;
+            }
+
+            product += num;
+            if (product > _modulus)
+            {
+               product -= _modulus;
+            }
+            product *= 2;
+            if (product >= _modulusPlus1)
+            {
+               product -= _modulusPlus1;
+            }
+         }
+      }
+
+      ch = value[^1];
+      if (ch >= CharConstants.DigitZero && ch <= CharConstants.DigitNine)
+      {
+         num = ch.ToIntegerDigit();
+      }
+      else if (ch >= CharConstants.UpperCaseA && ch <= CharConstants.UpperCaseZ)
+      {
+         num = ch - CharConstants.UpperCaseA + 10;
+      }
+      else
+      {
+         return false;
+      }
+      product += num;
+
+      return product % _modulus == 1;
+   }
+}

--- a/README.md
+++ b/README.md
@@ -410,22 +410,29 @@ Wikipedia: https://en.wikipedia.org/wiki/International_Bank_Account_Number
 
 The ISAN (International Standard Audiovisual Number) algorithm uses the ISO/IEC
 7064 MOD 37,36 algorithm internally. The algorithm in CheckDigits.Net is appropriate
-for ISAN values (either root segments or root+version segments) formatted as 
-human readable strings. The leading "ISAN " prefix is ignored as well as the 
-dash ('-') characters used to separate the hexadecimal digits into groups of four
-characters. Values that are 21 characters long are treated as root segments and
-the 21st character is assumed to be the check digit. Values that are 33 characters
-long are treated as root+version segments and **both** the 21st and the 33rd
-characters are assumed to be check digits. Both check digits for root+version 
-segments must be valid for the value to be considered valid.
+for ISAN values formatted as human readable strings. Either ISAN root segments
+(16 hexadecimal digits plus check character and formatting for a total length of 
+26 characters) or root+version segments (24 hexadecimal digits plus two check
+characters and formatting for a total length of 38 characters) can be validated.
+
+For example, the formatted ISAN for the Star Trek episode *Amok Time* is 
+ISAN 0000-0000-C36D-002B-K-0000-0000-E. The 'K' character is the check digit for
+the 16 root characters and the 'E' is the check character for the entire 26
+root+version characters.
+
+When validating an ISAN value, the leading "ISAN " prefix is ignored as well as 
+the dash ('-') characters used to separate the hexadecimal digits into groups of 
+four characters. Per https://www.isan.org/docs/isan_check_digit_calculation_v2.0.pdf,
+both check digits must be correct if the value includes both root and version
+segments.
 
 #### Details
 
 * Valid characters - hexadecimal characters ('0' - '9', 'A' - 'F')
 * Check digit size - one character
 * Check digit value - alphanumeric characters ('0' - '9', 'A' - 'Z')
-* Check digit location - the 21st character (**and** the 33rd character for values longer than 21 characters)
-* Value length - 21 or 33
+* Check digit location - the 26th character (**and** the 38th character for values longer than 26 characters)
+* Value length - 26 or 38
 * Class name - IsanAlgorithm
 
 #### Common Applications

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ are up to 10X-50X faster than those in popular Nuget packages.
     * [Alphanumeric MOD 97-10 Algorithm](#alphanumeric-mod-97-10-algorithm)
     * [Damm Algorithm](#damm-algorithm)
     * [IBAN (International Bank Account Number) Algorithm](#iban-algorithm)
+    * [ISAN (International Standard Audiovisual Number) Algorithm](#isan-algorithm)
     * [ISIN (International Securities Identification Number) Algorithm](#isin-algorithm)
     * [ISO/IEC 7064 MOD 11,10 Algorithm](#isoiec-7064-mod-1110-algorithm)
     * [ISO/IEC 7064 MOD 11-2 Algorithm](#isoiec-7064-mod-11-2-algorithm)
@@ -109,6 +110,7 @@ The ISO/IEC 7064:2003 standard is available at https://www.iso.org/standard/3153
 * [Alphanumeric MOD 97-10 Algorithm](#alphanumeric-mod-97-10-algorithm)
 * [Damm Algorithm](#damm-algorithm)
 * [IBAN (International Bank Account Number) Algorithm](#iban-algorithm)
+* [ISAN (International Standard Audiovisual Number) Algorithm](#isan-algorithm)
 * [ISIN (International Securities Identification Number) Algorithm](#isin-algorithm)
 * [ISO/IEC 7064 MOD 11,10 Algorithm](#isoiec-7064-mod-1110-algorithm)
 * [ISO/IEC 7064 MOD 11-2 Algorithm](#isoiec-7064-mod-11-2-algorithm)
@@ -147,6 +149,7 @@ The ISO/IEC 7064:2003 standard is available at https://www.iso.org/standard/3153
 | IBAN                  | [IBAN Algorithm](#iban-algorithm) |
 | IMEI				    | [Luhn Algorithm](#luhn-algorithm) |
 | IMO Number            | [Modulus10 Algorithm](#modulus10_2-algorithm) |
+| ISAN                  | [ISAN Algorithm](#isan-algorithm) |
 | ISBN-10				| [Modulus11 Algorithm](#modulus11-algorithm) |
 | ISBN-13				| [Modulus10_13 Algorithm](#modulus10_13-algorithm) |
 | ISBT Donation Identification Number |  [ISO/IEC 7064 MOD 37-2 Algorithm](#isoiec-7064-mod-37-2-algorithm) |
@@ -400,6 +403,40 @@ contained in account number, etc.) are left to the application developer.
 #### Links
 
 Wikipedia: https://en.wikipedia.org/wiki/International_Bank_Account_Number
+
+### ISAN Algorithm
+
+#### Description
+
+The ISAN (International Standard Audiovisual Number) algorithm uses the ISO/IEC
+7064 MOD 37,36 algorithm internally. The algorithm in CheckDigits.Net is appropriate
+for ISAN values (either root segments or root+version segments) formatted as 
+human readable strings. The leading "ISAN " prefix is ignored as well as the 
+dash ('-') characters used to separate the hexadecimal digits into groups of four
+characters. Values that are 21 characters long are treated as root segments and
+the 21st character is assumed to be the check digit. Values that are 33 characters
+long are treated as root+version segments and **both** the 21st and the 33rd
+characters are assumed to be check digits. Both check digits for root+version 
+segments must be valid for the value to be considered valid.
+
+#### Details
+
+* Valid characters - hexadecimal characters ('0' - '9', 'A' - 'F')
+* Check digit size - one character
+* Check digit value - alphanumeric characters ('0' - '9', 'A' - 'Z')
+* Check digit location - the 21st character (**and** the 33rd character for values longer than 21 characters)
+* Value length - 21 or 33
+* Class name - IsanAlgorithm
+
+#### Common Applications
+
+* International Standard Audiovisual Number (ISAN)
+
+#### Links
+
+https://en.wikipedia.org/wiki/International_Standard_Audiovisual_Number
+https://www.isan.org/docs/isan_check_digit_calculation_v2.0.pdf
+https://web.isan.org/public/en/search
 
 ### ISIN Algorithm
 

--- a/README.md
+++ b/README.md
@@ -396,10 +396,6 @@ contained in account number, etc.) are left to the application developer.
 * Value minimum length - 5
 * Class name - IbanAlgorithm
 
-#### Common Applications
-
-* International Securities Identification Number (ISIN)
-
 #### Links
 
 Wikipedia: https://en.wikipedia.org/wiki/International_Bank_Account_Number
@@ -408,36 +404,39 @@ Wikipedia: https://en.wikipedia.org/wiki/International_Bank_Account_Number
 
 #### Description
 
-The ISAN (International Standard Audiovisual Number) algorithm uses the ISO/IEC
-7064 MOD 37,36 algorithm internally. The algorithm in CheckDigits.Net is appropriate
-for ISAN values formatted as human readable strings. Either ISAN root segments
-(16 hexadecimal digits plus check character and formatting for a total length of 
-26 characters) or root+version segments (24 hexadecimal digits plus two check
-characters and formatting for a total length of 38 characters) can be validated.
+The ISAN (International Standard Audiovisual Number) algorithm uses a variation 
+of the ISO/IEC 7064 MOD 37,36 algorithm and can have either one or two check
+characters. 16 character ISAN root segment values have a single trailing check 
+character while 24 character ISAN root+version values contain two check characters,
+the root segment check character in the 17th character position for the first 16
+characters and a trailing check character for the entire 24 character value. Per 
+https://www.isan.org/docs/isan_check_digit_calculation_v2.0.pdf, both check 
+characters must be correct if the value includes both root and version segments.
 
-For example, the formatted ISAN for the Star Trek episode *Amok Time* is 
-ISAN 0000-0000-C36D-002B-K-0000-0000-E. The 'K' character is the check digit for
-the 16 root characters and the 'E' is the check character for the entire 26
-root+version characters.
+CheckDigits.Net can validate either unformatted ISAN values consisting only of 
+hexadecimal digits and alphanumeric check characters or ISAN values that have
+been formatted for human readability. 
 
-When validating an ISAN value, the leading "ISAN " prefix is ignored as well as 
-the dash ('-') characters used to separate the hexadecimal digits into groups of 
-four characters. Per https://www.isan.org/docs/isan_check_digit_calculation_v2.0.pdf,
-both check digits must be correct if the value includes both root and version
-segments.
+To validate unformatted root+version ISAN values, use the Validate method. The
+Validate method only checks 26 character unformatted ISAN root+version values.
+(To check 17 character root segment only ISAN values, use the ISO/IEC 7064 MOD 37,36
+algorithm directly.)
+
+To validate formatted ISAN values, either root segment only or root+version values,
+use the ValidateFormatted method. The ValidateFormatted method will check both
+the format of the value ("ISAN " prefix plus dash characters that separate the
+value into 4 character groups) and the check character(s) in the value.
+
+An example formatted root segment ISAN value is ISAN 0000-0000-C36D-002B-K. And
+example formatted root+version ISAN value is ISAN 0000-0000-C36D-002B-K-0000-0000-E.
 
 #### Details
 
 * Valid characters - hexadecimal characters ('0' - '9', 'A' - 'F')
 * Check digit size - one character
 * Check digit value - alphanumeric characters ('0' - '9', 'A' - 'Z')
-* Check digit location - the 26th character (**and** the 38th character for values longer than 26 characters)
-* Value length - 26 or 38
+* Check digit location - the 17th non-format character (**and** the 26th non-format character for root+version values)
 * Class name - IsanAlgorithm
-
-#### Common Applications
-
-* International Standard Audiovisual Number (ISAN)
 
 #### Links
 
@@ -469,10 +468,6 @@ algorithm cannot detect).
 * Check digit location - assumed to be the trailing (right-most) character when validating
 * Value length - 12
 * Class name - IsinAlgorithm
-
-#### Common Applications
-
-* International Securities Identification Number (ISIN)
 
 #### Links
 

--- a/README.md
+++ b/README.md
@@ -406,12 +406,13 @@ Wikipedia: https://en.wikipedia.org/wiki/International_Bank_Account_Number
 
 The ISAN (International Standard Audiovisual Number) algorithm uses a variation 
 of the ISO/IEC 7064 MOD 37,36 algorithm and can have either one or two check
-characters. 16 character ISAN root segment values have a single trailing check 
-character while 24 character ISAN root+version values contain two check characters,
-the root segment check character in the 17th character position for the first 16
-characters and a trailing check character for the entire 24 character value. Per 
-https://www.isan.org/docs/isan_check_digit_calculation_v2.0.pdf, both check 
-characters must be correct if the value includes both root and version segments.
+characters. A full ISAN value consists of 12 hexadecimal digits for the "root" 
+segment, 4 hexadecimal digits for the "episode" segment, an alphanumeric check
+character calculated for the 16 characters of the root/episode segments and 
+optionally, 8 hexadecimal digits for the version segment and an alphanumeric check 
+character calculated for the 24 characters of the root/episode/version segments. 
+Per https://www.isan.org/docs/isan_check_digit_calculation_v2.0.pdf, both check 
+characters must be correct if the value includes a version segment.
 
 CheckDigits.Net can validate either unformatted ISAN values consisting only of 
 hexadecimal digits and alphanumeric check characters or ISAN values that have
@@ -419,16 +420,16 @@ been formatted for human readability.
 
 To validate unformatted root+version ISAN values, use the Validate method. The
 Validate method only checks 26 character unformatted ISAN root+version values.
-(To check 17 character root segment only ISAN values, use the ISO/IEC 7064 MOD 37,36
+(To check 17 character root/episode only ISAN values, use the ISO/IEC 7064 MOD 37,36
 algorithm directly.)
 
-To validate formatted ISAN values, either root segment only or root+version values,
+To validate formatted ISAN values, either root/episode values or root/episode/version values,
 use the ValidateFormatted method. The ValidateFormatted method will check both
 the format of the value ("ISAN " prefix plus dash characters that separate the
 value into 4 character groups) and the check character(s) in the value.
 
-An example formatted root segment ISAN value is ISAN 0000-0000-C36D-002B-K. And
-example formatted root+version ISAN value is ISAN 0000-0000-C36D-002B-K-0000-0000-E.
+An example formatted root/episode ISAN value is ISAN 0000-0000-C36D-002B-K. An
+example formatted root/episode/version ISAN value is ISAN 0000-0000-C36D-002B-K-0000-0000-E.
 
 #### Details
 
@@ -1216,31 +1217,42 @@ Note also that the values used for the NOID Check Digit algorithm do not include
 
 #### Value Specific Algorithms
 
-| Algorithm Name | Value                           | Mean      | Error     | StdDev    | Allocated |
-|--------------- |-------------------------------- |----------:|----------:|----------:|----------:|
-| ABA RTN        | 111000025                       |  8.862 ns | 0.1623 ns | 0.1518 ns |         - |
-| ABA RTN        | 122235821                       |  8.692 ns | 0.1737 ns | 0.1624 ns |         - |
-| ABA RTN        | 325081403                       |  8.684 ns | 0.1237 ns | 0.1157 ns |         - |
+| Algorithm Name   | Value                                  | Mean      | Error     | StdDev    | Allocated |
+|----------------- |--------------------------------------- |----------:|----------:|----------:|----------:|
+| ABA RTN          | 111000025                              |  8.862 ns | 0.1623 ns | 0.1518 ns |         - |
+| ABA RTN          | 122235821                              |  8.692 ns | 0.1737 ns | 0.1624 ns |         - |
+| ABA RTN          | 325081403                              |  8.684 ns | 0.1237 ns | 0.1157 ns |         - |
+|                                                           
+| IBAN             | BE71096123456769                       | 22.310 ns | 0.2240 ns | 0.1980 ns |         - |
+| IBAN             | GB82WEST12345698765432                 | 34.930 ns | 0.3060 ns | 0.2870 ns |         - |
+| IBAN             | SC74MCBL01031234567890123456USD        | 51.930 ns | 0.8720 ns | 0.7730 ns |         - |
+|                                                           
+| ISAN             | C594660A8B2E5D22X6DDA3272E             | 57.740 ns | 0.7840 ns | 0.6950 ns |         - |
+| ISAN             | D02C42E954183EE2Q1291C8AEO             | 54.680 ns | 0.7400 ns | 0.6560 ns |         - |
+| ISAN             | E9530C32BC0EE83B269867B20F             | 54.830 ns | 0.6520 ns | 0.5780 ns |         - |
+|                                                           
+| ISAN (Formatted) | ISAN C594-660A-8B2E-5D22-X             | 49.680 ns | 0.5080 ns | 0.4750 ns |         - |
+| ISAN (Formatted) | ISAN D02C-42E9-5418-3EE2-Q             | 49.640 ns | 0.3700 ns | 0.3460 ns |         - |
+| ISAN (Formatted) | ISAN E953-0C32-BC0E-E83B-2             | 47.750 ns | 0.4370 ns | 0.4090 ns |         - |
+| ISAN (Formatted) | ISAN C594-660A-8B2E-5D22-X-6DDA-3272-E | 71.010 ns | 0.9400 ns | 0.8790 ns |         - |
+| ISAN (Formatted) | ISAN D02C-42E9-5418-3EE2-Q-1291-C8AE-O | 69.900 ns | 0.9790 ns | 0.8680 ns |         - |
+| ISAN (Formatted) | ISAN E953-0C32-BC0E-E83B-2-6986-7B20-F | 71.490 ns | 0.9130 ns | 0.8540 ns |         - |
 |
-| IBAN           | BE71096123456769                | 22.310 ns | 0.2240 ns | 0.1980 ns |         - |
-| IBAN           | GB82WEST12345698765432          | 34.930 ns | 0.3060 ns | 0.2870 ns |         - |
-| IBAN           | SC74MCBL01031234567890123456USD | 51.930 ns | 0.8720 ns | 0.7730 ns |         - |
-|
-| ISIN           | AU0000XVGZA3                    | 25.624 ns | 0.2618 ns | 0.2449 ns |         - |
-| ISIN           | GB0002634946                    | 21.148 ns | 0.2497 ns | 0.2335 ns |         - |
-| ISIN           | US0378331005                    | 21.139 ns | 0.3062 ns | 0.2865 ns |         - |
-|                                                  
-| NHS            | 4505577104                      | 11.933 ns | 0.1477 ns | 0.1309 ns |         - |
-| NHS            | 5301194917                      | 11.898 ns | 0.1416 ns | 0.1324 ns |         - |
-| NHS            | 9434765919                      | 11.917 ns | 0.1627 ns | 0.1522 ns |         - |
-|                                                  
-| NPI            | 1122337797                      | 15.106 ns | 0.2468 ns | 0.2309 ns |         - |
-| NPI            | 1234567893                      | 14.986 ns | 0.0968 ns | 0.0808 ns |         - |
-| NPI            | 1245319599                      | 15.067 ns | 0.2008 ns | 0.1878 ns |         - |
-|                                                  
-| VIN            | 1G8ZG127XWZ157259               | 40.107 ns | 0.3094 ns | 0.2743 ns |         - |
-| VIN            | 1HGEM21292L047875               | 40.206 ns | 0.2919 ns | 0.2438 ns |         - |
-| VIN            | 1M8GDM9AXKP042788               | 40.266 ns | 0.5329 ns | 0.4985 ns |         - |
+| ISIN             | AU0000XVGZA3                           | 25.624 ns | 0.2618 ns | 0.2449 ns |         - |
+| ISIN             | GB0002634946                           | 21.148 ns | 0.2497 ns | 0.2335 ns |         - |
+| ISIN             | US0378331005                           | 21.139 ns | 0.3062 ns | 0.2865 ns |         - |
+|                                                           
+| NHS              | 4505577104                             | 11.933 ns | 0.1477 ns | 0.1309 ns |         - |
+| NHS              | 5301194917                             | 11.898 ns | 0.1416 ns | 0.1324 ns |         - |
+| NHS              | 9434765919                             | 11.917 ns | 0.1627 ns | 0.1522 ns |         - |
+|                                                           
+| NPI              | 1122337797                             | 15.106 ns | 0.2468 ns | 0.2309 ns |         - |
+| NPI              | 1234567893                             | 14.986 ns | 0.0968 ns | 0.0808 ns |         - |
+| NPI              | 1245319599                             | 15.067 ns | 0.2008 ns | 0.1878 ns |         - |
+|                                                           
+| VIN              | 1G8ZG127XWZ157259                      | 40.107 ns | 0.3094 ns | 0.2743 ns |         - |
+| VIN              | 1HGEM21292L047875                      | 40.206 ns | 0.2919 ns | 0.2438 ns |         - |
+| VIN              | 1M8GDM9AXKP042788                      | 40.266 ns | 0.5329 ns | 0.4985 ns |         - |
 
 # Release History/Release Notes
 
@@ -1276,6 +1288,7 @@ Initial release. Additional included algorithms
 Additional included algorithms
 * AlphanumericMod97_10Algorithm
 * IbanAlgorithm
+* IsanAlgorithm (including ValidateFormatted method)
  
 Performance increases for:
 * ISO/IEC 7064 MOD 1271-36, Validate method ~18% improvement


### PR DESCRIPTION
# S0022-ISANlgorithm

As a developer of CheckDigits.Net, I want CheckDigits.Net to include the ISAN (International Standard Audiovisual Number) check digit algorithm in the list of supported algorithms.

https://www.isan.org/docs/isan_check_digit_calculation_v2.0.pdf

Note that the ISAN specification includes two check digits, one for the root segment that appears in the 17th character position and a second check digit for the root + version segment that appears in the 26th character position.

## Requirements

* IsanAlgorithm class that implements the following interfaces:
	- ICheckDigitAlgorithm
	- IDoubleCheckDigitAlgorithm
* Resiliency. Invalid input should not throw an exception and instead should simply return Boolean false to indicate failure. Invalid input will include:
	- null
	- String.Empty

## Definition of DONE

1. IsanAlgorithm class
1. Full unit tests
1. README updates
1. Performance benchmarks