### PR TITLE
Optimize Luhn algorithm for .Net 8

### DIFF
--- a/CheckDigits.Net.Tests.Benchmarks/NumericAlgorithmBenchmarks.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/NumericAlgorithmBenchmarks.cs
@@ -7,29 +7,29 @@ public class NumericAlgorithmBenchmarks
 {
    public IEnumerable<Object[]> TryCalculateCheckDigitArguments()
    {
-      yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140" };
-      yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662" };
-      yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538" };
-      yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538042" };
-      yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538042551" };
-      yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538042551028" };
-      yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538042551028265" };
+      //yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140" };
+      //yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662" };
+      //yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538" };
+      //yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538042" };
+      //yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538042551" };
+      //yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538042551028" };
+      //yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538042551028265" };
 
-      yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140" };
-      yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662" };
-      yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538" };
-      yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538042" };
-      yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538042551" };
-      yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538042551028" };
-      yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538042551028265" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538042" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538042551" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538042551028" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538042551028265" };
 
-      yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140" };
-      yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662" };
-      yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538" };
-      yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042" };
-      yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042551" };
-      yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042551028" };
-      yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042551028265" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042551" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042551028" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042551028265" };
 
       yield return new Object[] { Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140" };
       yield return new Object[] { Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662" };
@@ -39,33 +39,33 @@ public class NumericAlgorithmBenchmarks
       yield return new Object[] { Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662538042551028" };
       yield return new Object[] { Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662538042551028265" };
 
-      yield return new Object[] { Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "140" };
-      yield return new Object[] { Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "140662" };
-      yield return new Object[] { Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "140662538" };
+      //yield return new Object[] { Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "140" };
+      //yield return new Object[] { Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "140662" };
+      //yield return new Object[] { Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "140662538" };
 
-      yield return new Object[] { Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "140" };
-      yield return new Object[] { Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "140662" };
-      yield return new Object[] { Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "140662538" };
+      //yield return new Object[] { Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "140" };
+      //yield return new Object[] { Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "140662" };
+      //yield return new Object[] { Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "140662538" };
 
-      yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140" };
-      yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662" };
-      yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538" };
-      yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538042" };
-      yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538042551" };
-      yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538042551028" };
-      yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538042551028265" };
+      //yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140" };
+      //yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662" };
+      //yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538" };
+      //yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538042" };
+      //yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538042551" };
+      //yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538042551028" };
+      //yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538042551028265" };
 
-      yield return new Object[] { Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "140" };
-      yield return new Object[] { Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "140662" };
-      yield return new Object[] { Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "140662538" };
+      //yield return new Object[] { Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "140" };
+      //yield return new Object[] { Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "140662" };
+      //yield return new Object[] { Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "140662538" };
 
-      yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140" };
-      yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662" };
-      yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538" };
-      yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538042" };
-      yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538042551" };
-      yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538042551028" };
-      yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538042551028265" };
+      //yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140" };
+      //yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662" };
+      //yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538" };
+      //yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538042" };
+      //yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538042551" };
+      //yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538042551028" };
+      //yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538042551028265" };
    }
 
    public IEnumerable<Object[]> TryCalculateCheckDigitsArguments()
@@ -81,37 +81,37 @@ public class NumericAlgorithmBenchmarks
 
    public IEnumerable<Object[]> ValidateArguments()
    {
-      yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1402" };
-      yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406622" };
-      yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625388" };
-      yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625380422" };
-      yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625380425518" };
-      yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625380425510280" };
-      yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625380425510282654" };
+      //yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1402" };
+      //yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406622" };
+      //yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625388" };
+      //yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625380422" };
+      //yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625380425518" };
+      //yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625380425510280" };
+      //yield return new Object[] { Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625380425510282654" };
 
-      yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1409" };
-      yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406623" };
-      yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625381" };
-      yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625380426" };
-      yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625380425514" };
-      yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625380425510286" };
-      yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625380425510282657" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1409" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406623" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625381" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625380426" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625380425514" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625380425510286" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625380425510282657" };
 
-      yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140X" };
-      yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406628" };
-      yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406625380" };
-      yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406625380426" };
-      yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406625380425511" };
-      yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042551028X" };
-      yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406625380425510282651" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140X" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406628" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406625380" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406625380426" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406625380425511" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042551028X" };
+      //yield return new Object[] { Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406625380425510282651" };
 
-      yield return new Object[] { Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066" };
-      yield return new Object[] { Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066262" };
-      yield return new Object[] { Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253823" };
-      yield return new Object[] { Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253804250" };
-      yield return new Object[] { Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253804255112" };
-      yield return new Object[] { Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253804255102853" };
-      yield return new Object[] { Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253804255102826587" };
+      //yield return new Object[] { Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066" };
+      //yield return new Object[] { Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066262" };
+      //yield return new Object[] { Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253823" };
+      //yield return new Object[] { Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253804250" };
+      //yield return new Object[] { Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253804255112" };
+      //yield return new Object[] { Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253804255102853" };
+      //yield return new Object[] { Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253804255102826587" };
 
       yield return new Object[] { Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1404" };
       yield return new Object[] { Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406628" };
@@ -121,33 +121,33 @@ public class NumericAlgorithmBenchmarks
       yield return new Object[] { Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406625380425510285" };
       yield return new Object[] { Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406625380425510282651" };
 
-      yield return new Object[] { Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "1401" };
-      yield return new Object[] { Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "1406628" };
-      yield return new Object[] { Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "1406625384" };
+      //yield return new Object[] { Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "1401" };
+      //yield return new Object[] { Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "1406628" };
+      //yield return new Object[] { Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "1406625384" };
 
-      yield return new Object[] { Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "1406" };
-      yield return new Object[] { Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "1406627" };
-      yield return new Object[] { Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "1406625389" };
+      //yield return new Object[] { Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "1406" };
+      //yield return new Object[] { Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "1406627" };
+      //yield return new Object[] { Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "1406625389" };
 
-      yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1403" };
-      yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406627" };
-      yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625385" };
-      yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625380425" };
-      yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625380425518" };
-      yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625380425510288" };
-      yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625380425510282657" };
+      //yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1403" };
+      //yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406627" };
+      //yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625385" };
+      //yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625380425" };
+      //yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625380425518" };
+      //yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625380425510288" };
+      //yield return new Object[] { Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625380425510282657" };
 
-      yield return new Object[] { Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "1406" };
-      yield return new Object[] { Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "1406625" };
-      yield return new Object[] { Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "1406625388" };
+      //yield return new Object[] { Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "1406" };
+      //yield return new Object[] { Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "1406625" };
+      //yield return new Object[] { Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "1406625388" };
 
-      yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1401" };
-      yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625" };
-      yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625388" };
-      yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380426" };
-      yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380425512" };
-      yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380425510285" };
-      yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380425510282655" };
+      //yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1401" };
+      //yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625" };
+      //yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625388" };
+      //yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380426" };
+      //yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380425512" };
+      //yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380425510285" };
+      //yield return new Object[] { Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380425510282655" };
    }
 
    [Benchmark]
@@ -157,12 +157,12 @@ public class NumericAlgorithmBenchmarks
       algorithm.TryCalculateCheckDigit(value, out var checkDigit);
    }
 
-   [Benchmark]
-   [ArgumentsSource(nameof(TryCalculateCheckDigitsArguments))]
-   public void TryCalculateCheckDigits(IDoubleCheckDigitAlgorithm algorithm, String name, String value)
-   {
-      algorithm.TryCalculateCheckDigits(value, out var first, out var second);
-   }
+   //[Benchmark]
+   //[ArgumentsSource(nameof(TryCalculateCheckDigitsArguments))]
+   //public void TryCalculateCheckDigits(IDoubleCheckDigitAlgorithm algorithm, String name, String value)
+   //{
+   //   algorithm.TryCalculateCheckDigits(value, out var first, out var second);
+   //}
 
    [Benchmark]
    [ArgumentsSource(nameof(ValidateArguments))]

--- a/CheckDigits.Net.Tests.Benchmarks/Program.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/Program.cs
@@ -1,8 +1,8 @@
 ﻿
-//BenchmarkRunner.Run<NumericAlgorithmBenchmarks>();
+BenchmarkRunner.Run<NumericAlgorithmBenchmarks>();
 
 //BenchmarkRunner.Run<AlphabeticAlgorithmsBenchmarks>();
 
 //BenchmarkRunner.Run<AlphanumericAlgorithmBenchmarks>();
 
-BenchmarkRunner.Run<ValueSpecificAlgorithmBenchmarks>();
+//BenchmarkRunner.Run<ValueSpecificAlgorithmBenchmarks>();

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/LuhnAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/LuhnAlgorithmTests.cs
@@ -136,13 +136,13 @@ public class LuhnAlgorithmTests
         checkDigit.Should().Be('\0');
     }
 
-    #endregion
+   #endregion
 
-    #region Validate Tests
-    // ==========================================================================
-    // ==========================================================================
+   #region Validate Tests
+   // ==========================================================================
+   // ==========================================================================
 
-    [Fact]
+   [Fact]
     public void LuhnAlgorithm_Validate_ShouldReturnFalse_WhenInputIsNull()
        => _sut.Validate(null!).Should().BeFalse();
 
@@ -234,5 +234,5 @@ public class LuhnAlgorithmTests
     public void LuhnAlgorithm_Validate_ShouldReturnFalse_WhenInputContainsNonDigitCharacter(string value)
        => _sut.Validate(value).Should().BeFalse();
 
-    #endregion
+   #endregion
 }

--- a/CheckDigits.Net/GeneralAlgorithms/LuhnAlgorithm.cs
+++ b/CheckDigits.Net/GeneralAlgorithms/LuhnAlgorithm.cs
@@ -25,63 +25,65 @@ namespace CheckDigits.Net.GeneralAlgorithms;
 /// </remarks>
 public sealed class LuhnAlgorithm : ISingleCheckDigitAlgorithm
 {
-    private static readonly int[] _doubledValues = new int[] { 0, 2, 4, 6, 8, 1, 3, 5, 7, 9 };
-
     /// <inheritdoc/>
     public string AlgorithmDescription => Resources.LuhnAlgorithmDescription;
 
     /// <inheritdoc/>
     public string AlgorithmName => Resources.LuhnAlgorithmName;
 
-    /// <inheritdoc/>
-    public bool TryCalculateCheckDigit(string value, out char checkDigit)
-    {
-        checkDigit = CharConstants.NUL;
-        if (string.IsNullOrEmpty(value))
-        {
+   /// <inheritdoc/>
+   public bool TryCalculateCheckDigit(string value, out char checkDigit)
+   {
+      checkDigit = CharConstants.NUL;
+      if (string.IsNullOrEmpty(value))
+      {
+         return false;
+      }
+
+      var sum = 0;
+      var oddPosition = true;
+      for (var index = value.Length - 1; index >= 0; index--)
+      {
+         var digit = value[index].ToIntegerDigit();
+         if (digit < 0 || digit > 9)
+         {
             return false;
-        }
+         }
+         sum += oddPosition
+            ? digit > 4 ? digit * 2 - 9 : digit * 2
+            : digit;
+         oddPosition = !oddPosition;
+      }
+      var mod = 10 - sum % 10;
+      checkDigit = mod == 10 ? CharConstants.DigitZero : mod.ToDigitChar();
 
-        var sum = 0;
-        var oddPosition = true;
-        for (var index = value.Length - 1; index >= 0; index--)
-        {
-            var digit = value[index].ToIntegerDigit();
-            if (digit < 0 || digit > 9)
-            {
-                return false;
-            }
-            sum += oddPosition ? _doubledValues[digit] : digit;
-            oddPosition = !oddPosition;
-        }
-        var mod = 10 - sum % 10;
-        checkDigit = mod == 10 ? CharConstants.DigitZero : mod.ToDigitChar();
+      return true;
+   }
 
-        return true;
-    }
+   /// <inheritdoc/>
+   public bool Validate(string value)
+   {
+      if (string.IsNullOrEmpty(value) || value.Length < 2)
+      {
+         return false;
+      }
 
-    /// <inheritdoc/>
-    public bool Validate(string value)
-    {
-        if (string.IsNullOrEmpty(value) || value.Length < 2)
-        {
+      var sum = 0;
+      var oddPosition = true;
+      for (var index = value.Length - 2; index >= 0; index--)
+      {
+         var digit = value[index].ToIntegerDigit();
+         if (digit < 0 || digit > 9)
+         {
             return false;
-        }
+         }
+         sum += oddPosition 
+            ? digit > 4 ? digit * 2 - 9 : digit * 2
+            : digit;
+         oddPosition = !oddPosition;
+      }
+      var checkDigit = (10 - sum % 10) % 10;
 
-        var sum = 0;
-        var oddPosition = true;
-        for (var index = value.Length - 2; index >= 0; index--)
-        {
-            var digit = value[index].ToIntegerDigit();
-            if (digit < 0 || digit > 9)
-            {
-                return false;
-            }
-            sum += oddPosition ? _doubledValues[digit] : digit;
-            oddPosition = !oddPosition;
-        }
-        var checkDigit = (10 - sum % 10) % 10;
-
-        return value[^1].ToIntegerDigit() == checkDigit;
-    }
+      return value[^1].ToIntegerDigit() == checkDigit;
+   }
 }

--- a/Documentation/Stories/Backlog/S0025-DotNet8LuhnOptimization.md
+++ b/Documentation/Stories/Backlog/S0025-DotNet8LuhnOptimization.md
@@ -1,0 +1,14 @@
+# S0025-DotNet8LuhnOptimization
+
+As a developer who uses CheckDigits.Net, I want the highest performance available for the Luhn algorithm in CheckDigits.Net. Updating to .Net 8 slightly lowered the performance of the Luhn algorithm.
+
+
+## Requirements
+
+* Re-optimize Luhn algorithm
+* Re-run benchmarks
+
+## Definition of DONE
+
+1. Increased performance for Luhn algorithm
+1. Updated benchmarks/readme

--- a/Documentation/Stories/Backlog/S0026-CusipAlgorithm.md
+++ b/Documentation/Stories/Backlog/S0026-CusipAlgorithm.md
@@ -1,0 +1,20 @@
+# S0026-CusipAlgorithm
+
+As a developer of CheckDigits.Net, I want CheckDigits.Net to include the CUSIP check digit algorithm in the list of supported algorithms.
+
+https://en.wikipedia.org/wiki/CUSIP
+
+## Requirements
+
+* CusipAlgorithm class that implements the following interfaces:
+	- ICheckDigitAlgorithm
+* Resiliency. Invalid input should not throw an exception and instead should simply return Boolean false to indicate failure. Invalid input will include:
+	- null
+	- String.Empty
+
+## Definition of DONE
+
+1. CusipAlgorithm class
+1. Full unit tests
+1. README updates
+1. Performance benchmarks

--- a/Documentation/Stories/Backlog/S0027-SedolAlgorithm.md
+++ b/Documentation/Stories/Backlog/S0027-SedolAlgorithm.md
@@ -1,0 +1,20 @@
+# S0027-SedolAlgorithm
+
+As a developer of CheckDigits.Net, I want CheckDigits.Net to include the SEDOL check digit algorithm in the list of supported algorithms.
+
+https://en.wikipedia.org/wiki/SEDOL
+
+## Requirements
+
+* SedolAlgorithm class that implements the following interfaces:
+	- ICheckDigitAlgorithm
+* Resiliency. Invalid input should not throw an exception and instead should simply return Boolean false to indicate failure. Invalid input will include:
+	- null
+	- String.Empty
+
+## Definition of DONE
+
+1. SedolAlgorithm class
+1. Full unit tests
+1. README updates
+1. Performance benchmarks

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ let us know. Or contribute to the CheckDigits.Net repository: https://github.com
     - [v1.0.0](#v1.0.0)
     - [v1.1.0](#v1.1.0)
     - [v2.0.0](#v2.0.0)
+    - [v2.1.0](#v2.1.0)
 
 ## Check Digit Overview
 
@@ -957,13 +958,13 @@ benchmarks do not cover lengths greater than 10.
 | ISO/IEC 706 97-10 | 140662538042551028    | 22.542 ns | 0.2155 ns | 0.2016 ns |         - |
 | ISO/IEC 706 97-10 | 140662538042551028265 | 25.380 ns | 0.2038 ns | 0.1906 ns |         - |
 |                   |                       |           |           |           |           |                                           
-| Luhn              | 140                   |  5.678 ns | 0.0561 ns | 0.0497 ns |         - |
-| Luhn              | 140662                | 10.488 ns | 0.0978 ns | 0.0915 ns |         - |
-| Luhn              | 140662538             | 14.572 ns | 0.1481 ns | 0.1237 ns |         - |
-| Luhn              | 140662538042          | 18.432 ns | 0.1437 ns | 0.1122 ns |         - |
-| Luhn              | 140662538042551       | 22.530 ns | 0.2081 ns | 0.1947 ns |         - |
-| Luhn              | 140662538042551028    | 19.954 ns | 0.2879 ns | 0.2693 ns |         - |
-| Luhn              | 140662538042551028265 | 30.808 ns | 0.5542 ns | 0.5184 ns |         - |
+| Luhn              | 140                   |  6.674 ns | 0.1106 ns | 0.1035 ns |         - |
+| Luhn              | 140662                |  9.396 ns | 0.0575 ns | 0.0538 ns |         - |
+| Luhn              | 140662538             | 14.913 ns | 0.0464 ns | 0.0434 ns |         - |
+| Luhn              | 140662538042          | 14.981 ns | 0.0720 ns | 0.0638 ns |         - |
+| Luhn              | 140662538042551       | 20.813 ns | 0.1534 ns | 0.1435 ns |         - |
+| Luhn              | 140662538042551028    | 22.434 ns | 0.1459 ns | 0.1365 ns |         - |
+| Luhn              | 140662538042551028265 | 27.432 ns | 0.1217 ns | 0.1138 ns |         - |
 |                   |                       |           |           |           |           |                                           
 | Modulus10_13      | 140                   |  4.845 ns | 0.0532 ns | 0.0498 ns |         - |
 | Modulus10_13      | 140662                |  8.806 ns | 0.1316 ns | 0.1167 ns |         - |
@@ -1122,13 +1123,13 @@ benchmarks do not cover lengths greater than 10.
 | ISO/IEC 7064 MOD 97-10 | 14066253804255102853    | 22.186 ns | 0.2068 ns | 0.1935 ns |         - |
 | ISO/IEC 7064 MOD 97-10 | 14066253804255102826587 | 24.965 ns | 0.5259 ns | 0.4919 ns |         - |
 |                        |                         |           |           |           |           |                                           
-| Luhn                   | 1404                    |  7.787 ns | 0.0630 ns | 0.0589 ns |         - |
-| Luhn                   | 1406628                 | 11.274 ns | 0.0995 ns | 0.0931 ns |         - |
-| Luhn                   | 1406625382              | 16.513 ns | 0.2051 ns | 0.1818 ns |         - |
-| Luhn                   | 1406625380421           | 19.712 ns | 0.1856 ns | 0.1736 ns |         - |
-| Luhn                   | 1406625380425514        | 23.241 ns | 0.1690 ns | 0.1581 ns |         - |
-| Luhn                   | 1406625380425510285     | 27.301 ns | 0.2171 ns | 0.1813 ns |         - |
-| Luhn                   | 1406625380425510282651  | 32.255 ns | 0.2482 ns | 0.2321 ns |         - |
+| Luhn                   | 1404                    |  6.671 ns | 0.0366 ns | 0.0305 ns |         - |
+| Luhn                   | 1406628                 |  8.910 ns | 0.0483 ns | 0.0377 ns |         - |
+| Luhn                   | 1406625382              | 12.273 ns | 0.0815 ns | 0.0763 ns |         - |
+| Luhn                   | 1406625380421           | 14.002 ns | 0.0486 ns | 0.0431 ns |         - |
+| Luhn                   | 1406625380425514        | 18.127 ns | 0.2873 ns | 0.2687 ns |         - |
+| Luhn                   | 1406625380425510285     | 19.739 ns | 0.1725 ns | 0.1613 ns |         - |
+| Luhn                   | 1406625380425510282651  | 23.388 ns | 0.1535 ns | 0.1435 ns |         - |
 |                        |                         |           |           |           |           |                                           
 | Modulus10_13           | 1403                    |  5.844 ns | 0.0538 ns | 0.0503 ns |         - |
 | Modulus10_13           | 1406627                 |  9.622 ns | 0.1128 ns | 0.1055 ns |         - |
@@ -1320,4 +1321,8 @@ Average performance improvement for .Net 8.0 across all algorithms:
 
 Detailed benchmark results for .Net 7 vs .Net 8 located at https://github.com/KnowledgeForwardSolutions/CheckDigits.Net/blob/main/Documentation/DotNet7_DotNet8_PerformanceComparision.md
 
+## v2.1.0
 
+Performance increases for:
+* Luhn Algorithm, Validate method ~15% improvement over .Net 7, TryCalculateCheckDigit method ~27% improvement over .Net 7
+  (Luhn algorithm originally saw a slight performance decrease when switching from .Net 7 to .Net 8. This release addresses that performance decrease.) 


### PR DESCRIPTION
# S0025-DotNet8LuhnOptimization

As a developer who uses CheckDigits.Net, I want the highest performance available for the Luhn algorithm in CheckDigits.Net. Updating to .Net 8 slightly lowered the performance of the Luhn algorithm.

## Requirements

* Re-optimize Luhn algorithm
* Re-run benchmarks

## Definition of DONE

1. Increased performance for Luhn algorithm
1. Updated benchmarks/readme