### PR TITLE
S0035 icao9303 machine readable visa algorithm

### DIFF
--- a/CheckDigits.Net.Tests.Benchmarks/ValueSpecificAlgorithmBenchmarks.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/ValueSpecificAlgorithmBenchmarks.cs
@@ -53,13 +53,17 @@ public class ValueSpecificAlgorithmBenchmarks
       //yield return new Object[] { Algorithms.Icao9303, Algorithms.Icao9303.AlgorithmName, "U7Y8SXRC0O3SC4IHYQ9" };
       //yield return new Object[] { Algorithms.Icao9303, Algorithms.Icao9303.AlgorithmName, "U7Y8SXRC0O3SC4IHYQF4M8" };
 
+      yield return new Object[] { Algorithms.Icao9303MachineReadableVisa, Algorithms.Icao9303MachineReadableVisa.AlgorithmName, "I<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<D231458907UTO7408122F1204159<<<<<<A<" };
+      yield return new Object[] { Algorithms.Icao9303MachineReadableVisa, Algorithms.Icao9303MachineReadableVisa.AlgorithmName, "V<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<L898902C<3UTO6908061F9406236ZE184226B<<<<<<<" };
+      yield return new Object[] { Algorithms.Icao9303MachineReadableVisa, Algorithms.Icao9303MachineReadableVisa.AlgorithmName, "I<UTOSKYWALKER<<LUKE<<<<<<<<<<<<<<<<STARWARS45UTO7705256M2405252<<<<<<B<" };
+
       //yield return new Object[] { Algorithms.Icao9303SizeTD1, Algorithms.Icao9303SizeTD1.AlgorithmName, "I<UTOD231458907<<<<<<<<<<<<<<<7408122F1204159UTO<<<<<<<<<<<6ERIKSSON<<ANNA<MARIA<<<<<<<<A<" };
       //yield return new Object[] { Algorithms.Icao9303SizeTD1, Algorithms.Icao9303SizeTD1.AlgorithmName, "I<UTOD23145890<AB112234566<<<<7408122F1204159UTO<<<<<<<<<<<4ERIKSSON<<ANNA<MARIA<<<<<<<<B<" };
       //yield return new Object[] { Algorithms.Icao9303SizeTD1, Algorithms.Icao9303SizeTD1.AlgorithmName, "I<UTOSTARWARS45<<<<<<<<<<<<<<<7705256M2405252UTO<<<<<<<<<<<4SKYWALKER<<LUKE<<<<<<<<<<<<<C<" };
 
-      yield return new Object[] { Algorithms.Icao9303SizeTD2, Algorithms.Icao9303SizeTD2.AlgorithmName, "I<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<D231458907UTO7408122F1204159<<<<<<<6" };
-      yield return new Object[] { Algorithms.Icao9303SizeTD2, Algorithms.Icao9303SizeTD2.AlgorithmName, "I<UTOQWERTY<<ASDF<<<<<<<<<<<<<<<<<<<D23145890<UTO7408122F1204159AB1124<4" };
-      yield return new Object[] { Algorithms.Icao9303SizeTD2, Algorithms.Icao9303SizeTD2.AlgorithmName, "I<UTOSKYWALKER<<LUKE<<<<<<<<<<<<<<<<STARWARS45UTO7705256M2405252<<<<<<<8" };
+      //yield return new Object[] { Algorithms.Icao9303SizeTD2, Algorithms.Icao9303SizeTD2.AlgorithmName, "I<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<D231458907UTO7408122F1204159<<<<<<<6" };
+      //yield return new Object[] { Algorithms.Icao9303SizeTD2, Algorithms.Icao9303SizeTD2.AlgorithmName, "I<UTOQWERTY<<ASDF<<<<<<<<<<<<<<<<<<<D23145890<UTO7408122F1204159AB1124<4" };
+      //yield return new Object[] { Algorithms.Icao9303SizeTD2, Algorithms.Icao9303SizeTD2.AlgorithmName, "I<UTOSKYWALKER<<LUKE<<<<<<<<<<<<<<<<STARWARS45UTO7705256M2405252<<<<<<<8" };
 
       //yield return new Object[] { Algorithms.Icao9303SizeTD3, Algorithms.Icao9303SizeTD3.AlgorithmName, "P<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<L898902C36UTO7408122F1204159ZE184226B<<<<<10" };
       //yield return new Object[] { Algorithms.Icao9303SizeTD3, Algorithms.Icao9303SizeTD3.AlgorithmName, "P<UTOQWERTY<<ASDF<<<<<<<<<<<<<<<<<<<<<<<<<<<Q123987655UTO3311226F2010201<<<<<<<<<<<<<<06" };

--- a/CheckDigits.Net.Tests.Unit/AlgorithmsTests.cs
+++ b/CheckDigits.Net.Tests.Unit/AlgorithmsTests.cs
@@ -88,6 +88,20 @@ public class AlgorithmsTests
 
    #endregion
 
+   #region Icao9303MachineReadableVisa Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void Algorithms_Icao9303MachineReadableVisa_ShouldNotBeNull()
+      => Algorithms.Icao9303MachineReadableVisa.Should().NotBeNull();
+
+   [Fact]
+   public void Algorithms_Icao9303MachineReadableVisa_ShouldBeExpectedType()
+      => Algorithms.Icao9303MachineReadableVisa.Should().BeOfType<Icao9303MachineReadableVisaAlgorithm>();
+
+   #endregion
+
    #region Icao9303SizeTD1 Property Tests
    // ==========================================================================
    // ==========================================================================

--- a/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303MachineReadableVisaAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303MachineReadableVisaAlgorithmTests.cs
@@ -1,0 +1,431 @@
+﻿// Ignore Spelling: Icao Mrz
+
+namespace CheckDigits.Net.Tests.Unit.ValueSpecificAlgorithms;
+
+public class Icao9303MachineReadableVisaAlgorithmTests
+{
+   private readonly Icao9303MachineReadableVisaAlgorithm _sut = new();
+
+   // Example MRZ from https://www.icao.int/publications/Documents/9303_p7_cons_en.pdf
+   private const String _fmtAMrzFirstLine = "V<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<";
+   private const String _fmtAMrzSecondLine = "L898902C<3UTO6908061F9406236ZE184226B<<<<<<<";
+   private const String _fmtBMrzFirstLine = "V<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<";
+   private const String _fmtBMrzSecondLine = "L898902C<3UTO6908061F9406236ZE184226";
+
+   public enum MrzFormat { A, B }
+
+   private static String GetTestValue(
+      MrzFormat format = MrzFormat.A,
+      LineSeparator lineSeparator = LineSeparator.None,
+#if !NET48
+      String? firstLine = null,
+      String? secondLine = null)
+#else
+      String firstLine = null,
+      String secondLine = null)
+#endif
+   {
+      var separatorChars = lineSeparator switch
+      {
+         LineSeparator.Crlf => "\r\n",
+         LineSeparator.Lf => "\n",
+         _ => String.Empty,
+      };
+
+      return (firstLine ?? MrzFirstLine(format))
+         + separatorChars + (secondLine ?? MrzSecondLine(format));
+   }
+
+   private static String MrzFirstLine(MrzFormat format)
+      => format switch
+      {
+         MrzFormat.A => _fmtAMrzFirstLine,
+         MrzFormat.B => _fmtBMrzFirstLine,
+         _ => throw new ArgumentOutOfRangeException(),
+      };
+
+   private static String MrzSecondLine(MrzFormat format)
+      => format switch
+      {
+         MrzFormat.A => _fmtAMrzSecondLine,
+         MrzFormat.B => _fmtBMrzSecondLine,
+         _ => throw new ArgumentOutOfRangeException(),
+      };
+
+   #region AlgorithmDescription Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void Icao9303MachineReadableVisaAlgorithm_AlgorithmDescription_ShouldReturnExpectedValue()
+      => _sut.AlgorithmDescription.Should().Be(Resources.Icao9303MachineReadableVisaAlgorithmDescription);
+
+   #endregion
+
+   #region AlgorithmName Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void Icao9303MachineReadableVisaAlgorithm_AlgorithmName_ShouldReturnExpectedValue()
+      => _sut.AlgorithmName.Should().Be(Resources.Icao9303MachineReadableVisaAlgorithmName);
+
+   #endregion
+
+   #region LineSeparator Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   public static TheoryData<LineSeparator> LineSeparatorValues
+   {
+      get
+      {
+         var data = new TheoryData<LineSeparator>();
+         foreach (var value in Enum.GetValues(typeof(LineSeparator)))
+         {
+            data.Add((LineSeparator)value);
+         }
+
+         return data;
+      }
+   }
+
+   [Theory]
+   [MemberData(nameof(LineSeparatorValues))]
+   public void Icao9302MachineReadableVisaAlgorithm_LineSeparator_ShouldNotThrow_ValueIsValid(LineSeparator lineSeparator)
+   {
+      // Arrange.
+      var act = () => _sut.LineSeparator = lineSeparator;
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [MemberData(nameof(LineSeparatorValues))]
+   public void Icao9303MachineReadableVisaAlgorithm_LineSeparator_ShouldReturnExpectedValueAfterSetting(LineSeparator lineSeparator)
+   {
+      // Arrange.
+      var sut = new Icao9303MachineReadableVisaAlgorithm() { LineSeparator = lineSeparator };
+
+      // Act/assert.
+      sut.LineSeparator.Should().Be(lineSeparator);
+   }
+
+   [Fact]
+   public void Icao9302MachineReadableVisaAlgorithm_LineSeparator_ShouldThrowArgumentOutOfRangeException_ValueIsInvalid()
+   {
+      // Arrange.
+      var value = (LineSeparator)(-1);
+      var act = () => _sut.LineSeparator = value;
+      var expectedMessage = Resources.LineSeparatorInvalidValueMessage;
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>()
+         .WithParameterName(nameof(value))
+         .WithMessage(expectedMessage + "*")
+         .And.ActualValue.Should().Be(value);
+   }
+
+   #endregion
+
+   #region Validate Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnFalse_WhenInputIsNull()
+      => _sut.Validate(null!).Should().BeFalse();
+
+   [Fact]
+   public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnFalse_WhenInputIsEmpty()
+      => _sut.Validate(String.Empty).Should().BeFalse();
+
+   public static TheoryData<MrzFormat, LineSeparator, String, String> InvalidLengthData => new()
+   {
+      { MrzFormat.A, LineSeparator.None, _fmtAMrzFirstLine[..35], _fmtBMrzSecondLine },
+      { MrzFormat.A, LineSeparator.Crlf, _fmtAMrzFirstLine[..35], _fmtBMrzSecondLine },
+      { MrzFormat.A, LineSeparator.Lf,   _fmtAMrzFirstLine[..35], _fmtBMrzSecondLine },
+      { MrzFormat.A, LineSeparator.None, _fmtAMrzFirstLine[..35], _fmtBMrzSecondLine },
+      { MrzFormat.A, LineSeparator.Crlf, _fmtAMrzFirstLine[..35], _fmtBMrzSecondLine },
+      { MrzFormat.A, LineSeparator.Lf,   _fmtAMrzFirstLine[..35], _fmtBMrzSecondLine },
+      { MrzFormat.B, LineSeparator.None, _fmtBMrzFirstLine + "<<", _fmtBMrzSecondLine },
+      { MrzFormat.B, LineSeparator.Crlf, _fmtBMrzFirstLine + "<<", _fmtBMrzSecondLine },
+      { MrzFormat.B, LineSeparator.Lf,   _fmtBMrzFirstLine + "<<", _fmtBMrzSecondLine },
+      { MrzFormat.B, LineSeparator.None, _fmtBMrzFirstLine + "<<", _fmtBMrzSecondLine },
+      { MrzFormat.B, LineSeparator.Crlf, _fmtBMrzFirstLine + "<<", _fmtBMrzSecondLine },
+      { MrzFormat.B, LineSeparator.Lf,   _fmtBMrzFirstLine + "<<", _fmtBMrzSecondLine },
+   };
+
+   [Theory]
+   [MemberData(nameof(InvalidLengthData))]
+   public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnFalse_WhenValueIsInvalidLength(
+      MrzFormat format,
+      LineSeparator lineSeparator,
+      String firstLine,
+      String secondLine)
+   {
+      // Arrange.
+      var sut = new Icao9303MachineReadableVisaAlgorithm()
+      {
+         LineSeparator = lineSeparator,
+      };
+      var value = GetTestValue(format, lineSeparator, firstLine, secondLine);
+
+      // Act/assert.
+      sut.Validate(value).Should().BeFalse();
+   }
+
+   [Theory]
+   [InlineData(MrzFormat.B, LineSeparator.None, "0000000000UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.None, "0010000001UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.None, "0020000002UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.None, "0030000003UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.None, "0040000004UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.None, "0050000005UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.None, "0060000006UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.None, "0070000007UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.None, "0080000008UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.None, "0090000009UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Crlf, "00A0000000UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Crlf, "00B0000001UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Crlf, "00C0000002UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Crlf, "00D0000003UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Crlf, "00E0000004UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Crlf, "00F0000005UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Crlf, "00G0000006UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Crlf, "00H0000007UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Crlf, "00I0000008UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Crlf, "00J0000009UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Lf, "00K0000000UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Lf, "00L0000001UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Lf, "00M0000002UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Lf, "00N0000003UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Lf, "00O0000004UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Lf, "00P0000005UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Lf, "00Q0000006UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Lf, "00R0000007UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Lf, "00S0000008UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Lf, "00T0000009UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.A, LineSeparator.None, "00U0000000UTO0000000F0000000<<<<<<<<<<<<<<<<")]
+   [InlineData(MrzFormat.A, LineSeparator.None, "00V0000001UTO0000000F0000000<<<<<<<<<<<<<<<<")]
+   [InlineData(MrzFormat.A, LineSeparator.None, "00W0000002UTO0000000F0000000<<<<<<<<<<<<<<<<")]
+   [InlineData(MrzFormat.A, LineSeparator.None, "00X0000003UTO0000000F0000000<<<<<<<<<<<<<<<<")]
+   [InlineData(MrzFormat.A, LineSeparator.None, "00Y0000004UTO0000000F0000000<<<<<<<<<<<<<<<<")]
+   [InlineData(MrzFormat.A, LineSeparator.None, "00Z0000005UTO0000000F0000000<<<<<<<<<<<<<<<<")]
+   [InlineData(MrzFormat.A, LineSeparator.None, "00<0000000UTO0000000F0000000<<<<<<<<<<<<<<<<")]
+   public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldCorrectlyMapFieldCharacterValues(
+      MrzFormat format,
+      LineSeparator lineSeparator,
+      String mrzSecondLine)
+   {
+      // Arrange.
+      var sut = new Icao9303MachineReadableVisaAlgorithm()
+      {
+         LineSeparator = lineSeparator,
+      };
+      var value = GetTestValue(format, lineSeparator, null, mrzSecondLine);
+
+      // Act/assert.
+      sut.Validate(value).Should().BeTrue();
+   }
+
+   [Theory]
+   // Document number field
+   [InlineData(MrzFormat.A, LineSeparator.None, "1000000007UTO0000000F0000000<<<<<<<<<<<<<<<<")]
+   [InlineData(MrzFormat.A, LineSeparator.None, "0100000003UTO0000000F0000000<<<<<<<<<<<<<<<<")]
+   [InlineData(MrzFormat.A, LineSeparator.None, "0010000001UTO0000000F0000000<<<<<<<<<<<<<<<<")]
+   [InlineData(MrzFormat.A, LineSeparator.None, "0001000007UTO0000000F0000000<<<<<<<<<<<<<<<<")]
+   [InlineData(MrzFormat.A, LineSeparator.None, "0000100003UTO0000000F0000000<<<<<<<<<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.None, "0000010001UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.None, "0000001007UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.None, "0000000103UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.None, "0000000011UTO0000000F0000000<<<<<<<<")]
+   // Date of birth field
+   [InlineData(MrzFormat.A, LineSeparator.Crlf, "0000000000UTO1000007F0000000<<<<<<<<<<<<<<<<")]
+   [InlineData(MrzFormat.A, LineSeparator.Crlf, "0000000000UTO0100003F0000000<<<<<<<<<<<<<<<<")]
+   [InlineData(MrzFormat.A, LineSeparator.Crlf, "0000000000UTO0010001F0000000<<<<<<<<<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Crlf, "0000000000UTO0001007F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Crlf, "0000000000UTO0000103F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Crlf, "0000000000UTO0000011F0000000<<<<<<<<")]
+   // Date of expiry field
+   [InlineData(MrzFormat.A, LineSeparator.Lf, "0000000000UTO0000000F1000007<<<<<<<<<<<<<<<<")]
+   [InlineData(MrzFormat.A, LineSeparator.Lf, "0000000000UTO0000000F0100003<<<<<<<<<<<<<<<<")]
+   [InlineData(MrzFormat.A, LineSeparator.Lf, "0000000000UTO0000000F0010001<<<<<<<<<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Lf, "0000000000UTO0000000F0001007<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Lf, "0000000000UTO0000000F0000103<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Lf, "0000000000UTO0000000F0000011<<<<<<<<")]
+   public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldCorrectlyWeightByCharacterPosition(
+      MrzFormat format,
+      LineSeparator lineSeparator,
+      String mrzSecondLine)
+   {
+      // Arrange.
+      var sut = new Icao9303MachineReadableVisaAlgorithm()
+      {
+         LineSeparator = lineSeparator,
+      };
+      var value = GetTestValue(format, lineSeparator, null, mrzSecondLine);
+
+      // Act/assert.
+      sut.Validate(value).Should().BeTrue();
+   }
+
+   [Theory]
+   [InlineData(MrzFormat.A, LineSeparator.None)]
+   [InlineData(MrzFormat.A, LineSeparator.Crlf)]
+   [InlineData(MrzFormat.A, LineSeparator.Lf)]
+   [InlineData(MrzFormat.B, LineSeparator.None)]
+   [InlineData(MrzFormat.B, LineSeparator.Crlf)]
+   [InlineData(MrzFormat.B, LineSeparator.Lf)]
+   public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnTrue_WhenValueContainsValidCheckDigits(
+      MrzFormat format,
+      LineSeparator lineSeparator)
+   {
+      // Arrange.
+      var sut = new Icao9303MachineReadableVisaAlgorithm()
+      {
+         LineSeparator = lineSeparator,
+      };
+      var value = GetTestValue(format, lineSeparator);
+
+      // Act/assert.
+      sut.Validate(value).Should().BeTrue();
+   }
+
+   [Theory]
+   [InlineData(MrzFormat.A, LineSeparator.None, "D2314589A7UTO7408122F1204159<<<<<<<<<<<<<<<<")]   // D231458907 with single char transcription error (0 -> A) with delta 10   
+   [InlineData(MrzFormat.B, LineSeparator.Crlf, "N231458907UTO7408122F1204159<<<<<<<<")]           // D231458907 with single char transcription error (D -> N) with delta 10
+   [InlineData(MrzFormat.B, LineSeparator.Lf,   "L89890C236UTO7408122F1204159<<<<<<<<")]           // L898902C36 with two char transposition error (2C -> C2) with delta 10
+   [InlineData(MrzFormat.B, LineSeparator.None, "0000000000UTO8812728F0000000<<<<<<<<")]           // 8812278 with two char transposition error (27 -> 72) with delta 5
+   [InlineData(MrzFormat.A, LineSeparator.Crlf, "0000000000UTO0000000F8812728<<<<<<<<<<<<<<<<")]   // 8812278 with two char transposition error (27 -> 72) with delta 5
+   public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnTrue_WhenValueContainsUndetectableError(
+      MrzFormat format,
+      LineSeparator lineSeparator,
+      String mrzSecondLine)
+   {
+      // Arrange.
+      var sut = new Icao9303MachineReadableVisaAlgorithm()
+      {
+         LineSeparator = lineSeparator,
+      };
+      var value = GetTestValue(format, lineSeparator, null, mrzSecondLine);
+
+      // Act/assert.
+      sut.Validate(value).Should().BeTrue();
+   }
+
+   [Theory]
+   [InlineData(MrzFormat.A, LineSeparator.None, "E231458907UTO7408122F1204159<<<<<<<<<<<<<<<<")]   // D231458907 with single character transcription error (D -> E)
+   [InlineData(MrzFormat.A, LineSeparator.Crlf, "D241458907UTO7408122F1204159<<<<<<<<<<<<<<<<")]   // D231458907 with single digit transcription error (3 -> 4)
+   [InlineData(MrzFormat.A, LineSeparator.Lf,   "D231458907UTO7409122F1204159<<<<<<<<<<<<<<<<")]   // 7408122 with single digit transcription error (8 -> 9)
+   [InlineData(MrzFormat.A, LineSeparator.None, "D231458907UTO7408122F1203159<<<<<<<<<<<<<<<<")]   // 1204159 with single digit transcription error (4 -> 3)
+   [InlineData(MrzFormat.B, LineSeparator.Crlf, "2D31458907UTO7408122F1204159<<<<<<<<")]           // D231458907 with two character transposition error (D2 -> 2D)
+   [InlineData(MrzFormat.B, LineSeparator.Lf,   "D231548907UTO7408122F1204159<<<<<<<<")]           // D231458907 with two digit transposition error (45 -> 54)
+   [InlineData(MrzFormat.B, LineSeparator.None, "D231458907UTO7408212F1204159<<<<<<<<")]           // 7408122 with two digit transposition error (12 -> 21)
+   [InlineData(MrzFormat.B, LineSeparator.Crlf, "D231458907UTO7409122F1201459<<<<<<<<")]           // 1204159 with two digit transposition error (41 -> 14)
+   public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnFalse_WhenValueContainsDetectableError(
+      MrzFormat format,
+      LineSeparator lineSeparator,
+      String mrzSecondLine)
+   {
+      // Arrange.
+      var sut = new Icao9303MachineReadableVisaAlgorithm()
+      {
+         LineSeparator = lineSeparator,
+      };
+      var value = GetTestValue(format, lineSeparator, null, mrzSecondLine);
+
+      // Act/assert.
+      sut.Validate(value).Should().BeFalse();
+   }
+
+   [Theory]
+   [InlineData(MrzFormat.A, LineSeparator.None, "0000000000UTO0000000F0000000<<<<<<<<<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Crlf, "0000000000UTO0000000F0000000<<<<<<<<")]
+   public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnTrue_WhenFieldsAreAllZeros(
+      MrzFormat format,
+      LineSeparator lineSeparator,
+      String mrzSecondLine)
+   {
+      // Arrange.
+      var sut = new Icao9303MachineReadableVisaAlgorithm()
+      {
+         LineSeparator = lineSeparator,
+      };
+      var value = GetTestValue(format, lineSeparator, null, mrzSecondLine);
+
+      // Act/assert.
+      sut.Validate(value).Should().BeTrue();
+   }
+
+   [Theory]
+   [InlineData(MrzFormat.A, LineSeparator.None, "<<<<<<<<<0UTO<<<<<<0F<<<<<<0<<<<<<<<<<<<<<<<")]
+   [InlineData(MrzFormat.B, LineSeparator.Crlf, "<<<<<<<<<0UTO<<<<<<0F<<<<<<0<<<<<<<<")]
+   public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnTrue_WhenFieldsAreAllFillerCharacters(
+      MrzFormat format,
+      LineSeparator lineSeparator,
+      String mrzSecondLine)
+   {
+      // Arrange.
+      var sut = new Icao9303MachineReadableVisaAlgorithm()
+      {
+         LineSeparator = lineSeparator,
+      };
+      var value = GetTestValue(format, lineSeparator, null, mrzSecondLine);
+
+      // Act/assert.
+      sut.Validate(value).Should().BeTrue();
+   }
+
+   [Theory]
+   [InlineData(MrzFormat.A, LineSeparator.None, "b231458907UTO7408122F1204159<<<<<<<<<<<<<<<<")]   // D231458907 with D replaced with character 30 positions later in ASCII table
+   [InlineData(MrzFormat.A, LineSeparator.Crlf, "D2314589&7UTO7408122F1204159<<<<<<<<<<<<<<<<")]   // D231458907 with 0 replaced with character 10 positions before in ASCII table
+   [InlineData(MrzFormat.B, LineSeparator.Lf,   "D2314589:7UTO7408122F1204159<<<<<<<<")]           // D231458907 with 0 replaced with character 10 positions later in ASCII table
+   [InlineData(MrzFormat.B, LineSeparator.None, "D231458907UTO7>08122F1204159<<<<<<<<")]           // 7408122 with 4 replaced with character 10 positions later in ASCII table
+   public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnFalse_WhenFieldContainsInvalidCharacter(
+      MrzFormat format,
+      LineSeparator lineSeparator,
+      String mrzSecondLine)
+   {
+      // Arrange.
+      var sut = new Icao9303MachineReadableVisaAlgorithm()
+      {
+         LineSeparator = lineSeparator,
+      };
+      var value = GetTestValue(format, lineSeparator, null, mrzSecondLine);
+
+      // Act/assert.
+      sut.Validate(value).Should().BeFalse();
+   }
+
+   [Theory]
+   [InlineData(MrzFormat.A, LineSeparator.None, "D23145890AUTO7408122F1204159<<<<<<<<<<<<<<<<")]   // Document number check digit is invalid character
+   [InlineData(MrzFormat.A, LineSeparator.None, "D23145890&UTO7408122F1204159<<<<<<<<<<<<<<<<")]   // Document number check digit is invalid character
+   [InlineData(MrzFormat.A, LineSeparator.None, "D23145890:UTO7408122F1204159<<<<<<<<<<<<<<<<")]   // Document number check digit is invalid character
+   [InlineData(MrzFormat.A, LineSeparator.Crlf, "D231458907UTO740812AF1204159<<<<<<<<<<<<<<<<")]   // Date of birth check digit is invalid character
+   [InlineData(MrzFormat.A, LineSeparator.Crlf, "D231458907UTO740812&F1204159<<<<<<<<<<<<<<<<")]   // Date of birth check digit is invalid character
+   [InlineData(MrzFormat.A, LineSeparator.Crlf, "D231458907UTO740812<F1204159<<<<<<<<<<<<<<<<")]   // Date of birth check digit is invalid character
+   [InlineData(MrzFormat.A, LineSeparator.Crlf, "D231458907UTO740812[F1204159<<<<<<<<<<<<<<<<")]   // Date of birth check digit is invalid character
+   [InlineData(MrzFormat.B, LineSeparator.Lf,   "D231458907UTO7408122F120415A<<<<<<<<")]           // Date of expiry check digit is invalid character
+   [InlineData(MrzFormat.B, LineSeparator.Lf,   "D231458907UTO7408122F120415&<<<<<<<<")]           // Date of expiry check digit is invalid character
+   [InlineData(MrzFormat.B, LineSeparator.Lf,   "D231458907UTO7408122F120415<<<<<<<<<")]           // Date of expiry check digit is invalid character
+   [InlineData(MrzFormat.B, LineSeparator.Lf,   "D231458907UTO7408122F120415[<<<<<<<<")]           // Date of expiry check digit is invalid character
+   public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnFalse_WhenRequiredFieldCheckDigitContainsNonDigitCharacter(
+      MrzFormat format,
+      LineSeparator lineSeparator,
+      String mrzSecondLine)
+   {
+      // Arrange.
+      var sut = new Icao9303MachineReadableVisaAlgorithm()
+      {
+         LineSeparator = lineSeparator,
+      };
+      var value = GetTestValue(format, lineSeparator, null, mrzSecondLine);
+
+      // Act/assert.
+      sut.Validate(value).Should().BeFalse();
+   }
+
+   #endregion
+}

--- a/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303SizeTD1AlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303SizeTD1AlgorithmTests.cs
@@ -6,7 +6,7 @@ public class Icao9303SizeTD1AlgorithmTests
 {
    private readonly Icao9303SizeTD1Algorithm _sut = new();
 
-   // Example MRZ from Example from https://www.icao.int/publications/Documents/9303_p5_cons_en.pdf
+   // Example MRZ from https://www.icao.int/publications/Documents/9303_p5_cons_en.pdf
    private const String _mrzFirstLine = "I<UTOD231458907<<<<<<<<<<<<<<<";
    private const String _mrzSecondLine = "7408122F1204159UTO<<<<<<<<<<<6";
    private const String _mrzThirdLine = "ERIKSSON<<ANNA<MARIA<<<<<<<<<<";
@@ -75,7 +75,7 @@ public class Icao9303SizeTD1AlgorithmTests
 
    [Theory]
    [MemberData(nameof(LineSeparatorValues))]
-   public void Icao9302TD1Algorithm_LineSeparator_ShouldNotThrow_ValueIsValid(LineSeparator lineSeparator)
+   public void Icao9302SizeTD1Algorithm_LineSeparator_ShouldNotThrow_ValueIsValid(LineSeparator lineSeparator)
    {
       // Arrange.
       var act = () => _sut.LineSeparator = lineSeparator;
@@ -86,7 +86,7 @@ public class Icao9303SizeTD1AlgorithmTests
 
    [Theory]
    [MemberData(nameof(LineSeparatorValues))]
-   public void Icao9303TD1Algorithm_LineSeparator_ShouldReturnExpectedValueAfterSetting(LineSeparator lineSeparator)
+   public void Icao9303SizeTD1Algorithm_LineSeparator_ShouldReturnExpectedValueAfterSetting(LineSeparator lineSeparator)
    {
       // Arrange.
       var sut = new Icao9303SizeTD1Algorithm() { LineSeparator = lineSeparator };
@@ -96,7 +96,7 @@ public class Icao9303SizeTD1AlgorithmTests
    }
 
    [Fact]
-   public void Icao9302TD1Algorithm_LineSeparator_ShouldThrowArgumentOutOfRangeException_ValueIsInvalid()
+   public void Icao9302SizeTD1Algorithm_LineSeparator_ShouldThrowArgumentOutOfRangeException_ValueIsInvalid()
    {
       // Arrange.
       var value = (LineSeparator)(-1);

--- a/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303SizeTD2AlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303SizeTD2AlgorithmTests.cs
@@ -6,7 +6,7 @@ public class Icao9303SizeTD2AlgorithmTests
 {
    private readonly Icao9303SizeTD2Algorithm _sut = new();
 
-   // Example MRZ from Example from https://www.icao.int/publications/Documents/9303_p6_cons_en.pdf
+   // Example MRZ from https://www.icao.int/publications/Documents/9303_p6_cons_en.pdf
    private const String _mrzFirstLine = "I<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<";
    private const String _mrzSecondLine = "D231458907UTO7408122F1204159<<<<<<<6";
 
@@ -71,7 +71,7 @@ public class Icao9303SizeTD2AlgorithmTests
 
    [Theory]
    [MemberData(nameof(LineSeparatorValues))]
-   public void Icao9302TD2Algorithm_LineSeparator_ShouldNotThrow_ValueIsValid(LineSeparator lineSeparator)
+   public void Icao9302SizeTD2Algorithm_LineSeparator_ShouldNotThrow_ValueIsValid(LineSeparator lineSeparator)
    {
       // Arrange.
       var act = () => _sut.LineSeparator = lineSeparator;
@@ -82,7 +82,7 @@ public class Icao9303SizeTD2AlgorithmTests
 
    [Theory]
    [MemberData(nameof(LineSeparatorValues))]
-   public void Icao9303TD2Algorithm_LineSeparator_ShouldReturnExpectedValueAfterSetting(LineSeparator lineSeparator)
+   public void Icao9303SizeTD2Algorithm_LineSeparator_ShouldReturnExpectedValueAfterSetting(LineSeparator lineSeparator)
    {
       // Arrange.
       var sut = new Icao9303SizeTD2Algorithm() { LineSeparator = lineSeparator };
@@ -92,7 +92,7 @@ public class Icao9303SizeTD2AlgorithmTests
    }
 
    [Fact]
-   public void Icao9302TD2Algorithm_LineSeparator_ShouldThrowArgumentOutOfRangeException_ValueIsInvalid()
+   public void Icao9302SizeTD2Algorithm_LineSeparator_ShouldThrowArgumentOutOfRangeException_ValueIsInvalid()
    {
       // Arrange.
       var value = (LineSeparator)(-1);

--- a/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303SizeTD3AlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303SizeTD3AlgorithmTests.cs
@@ -6,7 +6,7 @@ public class Icao9303SizeTD3AlgorithmTests
 {
    private readonly Icao9303SizeTD3Algorithm _sut = new();
 
-   // Example MRZ from Example from https://www.icao.int/publications/Documents/9303_p4_cons_en.pdf
+   // Example MRZ from https://www.icao.int/publications/Documents/9303_p4_cons_en.pdf
    private const String _mrzFirstLine = "P<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<";
    private const String _mrzSecondLine = "L898902C36UTO7408122F1204159ZE184226B<<<<<10";
    private const String _mrzLineSeparatorNone = "P<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<L898902C36UTO7408122F1204159ZE184226B<<<<<10";
@@ -71,7 +71,7 @@ public class Icao9303SizeTD3AlgorithmTests
 
    [Theory]
    [MemberData(nameof(LineSeparatorValues))]
-   public void Icao9302TD3Algorithm_LineSeparator_ShouldNotThrow_ValueIsValid(LineSeparator lineSeparator)
+   public void Icao9302SizeTD3Algorithm_LineSeparator_ShouldNotThrow_ValueIsValid(LineSeparator lineSeparator)
    {
       // Arrange.
       var act = () => _sut.LineSeparator = lineSeparator;
@@ -82,7 +82,7 @@ public class Icao9303SizeTD3AlgorithmTests
 
    [Theory]
    [MemberData(nameof(LineSeparatorValues))]
-   public void Icao9303TD3Algorithm_LineSeparator_ShouldReturnExpectedValueAfterSetting(LineSeparator lineSeparator)
+   public void Icao9303SizeTD3Algorithm_LineSeparator_ShouldReturnExpectedValueAfterSetting(LineSeparator lineSeparator)
    {
       // Arrange.
       var sut = new Icao9303SizeTD1Algorithm() { LineSeparator = lineSeparator };
@@ -92,7 +92,7 @@ public class Icao9303SizeTD3AlgorithmTests
    }
 
    [Fact]
-   public void Icao9302TD3Algorithm_LineSeparator_ShouldThrowArgumentOutOfRangeException_ValueIsInvalid()
+   public void Icao9302SizeTD3Algorithm_LineSeparator_ShouldThrowArgumentOutOfRangeException_ValueIsInvalid()
    {
       // Arrange.
       var value = (LineSeparator)(-1);

--- a/CheckDigits.Net/Algorithms.cs
+++ b/CheckDigits.Net/Algorithms.cs
@@ -26,6 +26,9 @@ public static class Algorithms
    private static readonly Lazy<ICheckDigitAlgorithm> _icao9303 =
      new(() => new Icao9303Algorithm());
 
+   private static readonly Lazy<ICheckDigitAlgorithm> _icao9303MachineReadableVisa =
+     new(() => new Icao9303MachineReadableVisaAlgorithm());
+
    private static readonly Lazy<ICheckDigitAlgorithm> _icao9303SizeTD1 =
      new(() => new Icao9303SizeTD1Algorithm());
 
@@ -132,6 +135,12 @@ public static class Algorithms
    ///   International Civil Aviation Organization 9303 algorithm.
    /// </summary>
    public static ICheckDigitAlgorithm Icao9303 => _icao9303.Value;
+
+   /// <summary>
+   ///   International Civil Aviation Organization 9303 algorithm for Machine
+   ///   Readable Visas, both format MRV-A and MRV-B.
+   /// </summary>
+   public static ICheckDigitAlgorithm Icao9303MachineReadableVisa => _icao9303MachineReadableVisa.Value;
 
    /// <summary>
    ///   International Civil Aviation Organization 9303 algorithm for Machine

--- a/CheckDigits.Net/Resources.Designer.cs
+++ b/CheckDigits.Net/Resources.Designer.cs
@@ -196,6 +196,24 @@ namespace CheckDigits.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to IACO 9303 Algorithm for Machine Readable Visas.
+        /// </summary>
+        internal static string Icao9303MachineReadableVisaAlgorithmDescription {
+            get {
+                return ResourceManager.GetString("Icao9303MachineReadableVisaAlgorithmDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to IACO 9303 Machine Readable Visa.
+        /// </summary>
+        internal static string Icao9303MachineReadableVisaAlgorithmName {
+            get {
+                return ResourceManager.GetString("Icao9303MachineReadableVisaAlgorithmName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to IACO 9303 Algorithm for Machine Readable Documents Size TD1.
         /// </summary>
         internal static string Icao9303SizeTD1AlgorithmDescription {

--- a/CheckDigits.Net/Resources.resx
+++ b/CheckDigits.Net/Resources.resx
@@ -162,6 +162,12 @@
   <data name="Icao9303AlgorithmName" xml:space="preserve">
     <value>Icao9303</value>
   </data>
+  <data name="Icao9303MachineReadableVisaAlgorithmDescription" xml:space="preserve">
+    <value>IACO 9303 Algorithm for Machine Readable Visas</value>
+  </data>
+  <data name="Icao9303MachineReadableVisaAlgorithmName" xml:space="preserve">
+    <value>IACO 9303 Machine Readable Visa</value>
+  </data>
   <data name="Icao9303SizeTD1AlgorithmDescription" xml:space="preserve">
     <value>IACO 9303 Algorithm for Machine Readable Documents Size TD1</value>
   </data>

--- a/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303MachineReadableVisaAlgorithm.cs
+++ b/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303MachineReadableVisaAlgorithm.cs
@@ -1,0 +1,134 @@
+﻿// Ignore Spelling: Icao
+
+namespace CheckDigits.Net.ValueSpecificAlgorithms;
+
+/// <summary>
+///   Algorithm used to validate the check digits contained in the machine readable
+///   zone of ICAO (International Civil Aviation Organization) Machine Readable 
+///   Travel Visas (both format MRV-A and format MRV-B).
+/// </summary>
+/// <remarks>
+///   <para>
+///   Validates the following fields in the machine readable zone:
+///   <list type="bullet">
+///      <item>Document number, line 2, characters 1-9, check digit in character 10</item>
+///      <item>Date of birth, line 2, characters 14-19, check digit in character 20</item>
+///      <item>Date of expiry, line 2, characters 22-27, check digit in character 28</item>
+///   </list>
+///   </para>
+///   <para>
+///   Valid characters are decimal digits (0-9), uppercase alphabetic characters 
+///   (A-Z) and a filler character ('<').
+///   </para>
+///   <para>
+///   Check digit calculated by the algorithm is a decimal digit (0-9).
+///   </para>
+///   <para>
+///   Uses the same Modulus 10 algorithm as the <see cref="Icao9303Algorithm"/>
+///   and has the same weaknesses as that algorithm.
+///   </para>
+public sealed class Icao9303MachineReadableVisaAlgorithm : ICheckDigitAlgorithm
+{
+   private static readonly Int32[] _weights = [7, 3, 1];
+   private static readonly Int32[] _fieldStartPositions = [0, 13, 21];
+   private static readonly Int32[] _fieldSLengths = [9, 6, 6];
+   private static readonly Int32[] _charMap = Icao9303CharacterMap.GetCharacterMap();
+
+   private const Int32 _numFields = 3;
+   private const Int32 _formatALineLength = 44;
+   private const Int32 _formatBLineLength = 36;
+   private LineSeparator _lineSeparator = LineSeparator.None;
+   private Int32 _lineSeparatorLength = 0;
+
+   /// <inheritdoc/>
+   public String AlgorithmDescription => Resources.Icao9303MachineReadableVisaAlgorithmDescription;
+
+   /// <inheritdoc/>
+   public String AlgorithmName => Resources.Icao9303MachineReadableVisaAlgorithmName;
+
+   /// <summary>
+   ///   Specifies the character(s) used to separate lines in the value being
+   ///   validated.
+   /// </summary>
+   /// <exception cref="ArgumentOutOfRangeException">
+   ///   The value used to set the <see cref="LineSeparator"/> property is not
+   ///   a defined member of the <see cref="LineSeparator"/> enumeration.
+   /// </exception>
+   public LineSeparator LineSeparator
+   {
+      get => _lineSeparator;
+      set
+      {
+         if (!value.IsDefined())
+         {
+            throw new ArgumentOutOfRangeException(nameof(value), value, Resources.LineSeparatorInvalidValueMessage);
+         }
+
+         _lineSeparator = value;
+         _lineSeparatorLength = value.CharacterLength();
+      }
+   }
+
+   /// <inheritdoc/>
+   public Boolean Validate(String value)
+   {
+      if (String.IsNullOrEmpty(value))
+      {
+         return false;
+      }
+      Int32 lineLength;
+      if (value.Length == (_formatALineLength * 2) + _lineSeparatorLength)
+      {
+         lineLength = _formatALineLength;
+      }
+      else if (value.Length == (_formatBLineLength * 2) + _lineSeparatorLength)
+      {
+         lineLength = _formatBLineLength;
+      }
+      else
+      {
+         return false;
+      }
+
+      Char ch;
+      Int32 num;
+      for (var fieldIndex = 0; fieldIndex < _numFields; fieldIndex++)
+      {
+         var fieldSum = 0;
+         var fieldWeightIndex = new ModulusInt32(3);
+         var start = _fieldStartPositions[fieldIndex] + lineLength + _lineSeparatorLength;
+         var end = start + _fieldSLengths[fieldIndex];
+         for (var charIndex = start; charIndex < end; charIndex++)
+         {
+            ch = value[charIndex];
+            num = (ch >= CharConstants.DigitZero && ch <= CharConstants.UpperCaseZ)
+               ? _charMap[ch - CharConstants.DigitZero]
+               : -1;
+            if (num == -1)
+            {
+               return false;
+            }
+
+            fieldSum += num * _weights[fieldWeightIndex];
+            fieldWeightIndex++;
+         }
+
+         // Field check digit.
+         ch = value[end];
+         if (ch >= CharConstants.DigitZero && ch <= CharConstants.DigitNine)
+         {
+            num = ch.ToIntegerDigit();
+         }
+         else
+         {
+            return false;
+         }
+         if (num != fieldSum % 10)
+         {
+            return false;
+         }
+      }
+
+      return true;
+   }
+}

--- a/README.md
+++ b/README.md
@@ -1538,82 +1538,86 @@ Note also that the values used for the NOID Check Digit algorithm do not include
 
 #### Value Specific Algorithms
 
-| Algorithm Name       | Value                                  | Mean      | Error     | StdDev    | Allocated |
-|--------------------- |--------------------------------------- |----------:|----------:|----------:|----------:|
-| ABA RTN              | 111000025                              | 10.830 ns | 0.0650 ns | 0.0580 ns |         - |
-| ABA RTN              | 122235821                              | 10.400 ns | 0.1880 ns | 0.1570 ns |         - |
-| ABA RTN              | 325081403                              | 10.310 ns | 0.0610 ns | 0.0570 ns |         - |
-|                      |                                        |           |           |           |           |                                           
-| CUSIP                | 037833100                              | 16.500 ns | 0.1990 ns | 0.1760 ns |         - |
-| CUSIP                | 38143VAA7                              | 13.020 ns | 0.0830 ns | 0.0770 ns |         - |
-| CUSIP                | 91282CJL6                              | 12.850 ns | 0.0630 ns | 0.0530 ns |         - |
-|                      |                                        |           |           |           |           |                                           
-| IBAN                 | BE71096123456769                       | 20.090 ns | 0.1710 ns | 0.1600 ns |         - |
-| IBAN                 | GB82WEST12345698765432                 | 34.960 ns | 0.2120 ns | 0.1880 ns |         - |
-| IBAN                 | SC74MCBL01031234567890123456USD        | 51.580 ns | 0.2410 ns | 0.2130 ns |         - |
-|                      |                                        |           |           |           |           |
-| ICAO 9303            | U7Y5                                   |  7.376 ns | 0.0654 ns | 0.0580 ns |         - |
-| ICAO 9303            | U7Y8SX8                                | 13.371 ns | 0.2098 ns | 0.1752 ns |         - |
-| ICAO 9303            | U7Y8SXRC03                             | 17.766 ns | 0.3089 ns | 0.2890 ns |         - |
-| ICAO 9303            | U7Y8SXRC0O3S8                          | 22.630 ns | 0.4513 ns | 0.4221 ns |         - |
-| ICAO 9303            | U7Y8SXRC0O3SC4I2                       | 28.543 ns | 0.3081 ns | 0.2731 ns |         - |
-| ICAO 9303            | U7Y8SXRC0O3SC4IHYQ9                    | 32.207 ns | 0.3189 ns | 0.2490 ns |         - |
-| ICAO 9303            | U7Y8SXRC0O3SC4IHYQF4M8                 | 39.060 ns | 0.4010 ns | 0.3555 ns |         - |
-|                      |                                        |           |           |           |           |
-| ICAO 9303 (Embedded) | +U7Y5+                                 |  9.022 ns | 0.2106 ns | 0.3278 ns |         - |
-| ICAO 9303 (Embedded) | +U7Y8SX8+                              | 11.690 ns | 0.2177 ns | 0.2036 ns |         - |
-| ICAO 9303 (Embedded) | +U7Y8SXRC03+                           | 15.562 ns | 0.2131 ns | 0.1993 ns |         - |
-| ICAO 9303 (Embedded) | +U7Y8SXRC0O3S8+                        | 19.363 ns | 0.3438 ns | 0.3216 ns |         - |
-| ICAO 9303 (Embedded) | +U7Y8SXRC0O3SC4I2+                     | 22.433 ns | 0.2453 ns | 0.2174 ns |         - |
-| ICAO 9303 (Embedded) | +U7Y8SXRC0O3SC4IHYQ9+                  | 26.724 ns | 0.2726 ns | 0.2416 ns |         - |
-| ICAO 9303 (Embedded) | +U7Y8SXRC0O3SC4IHYQF4M8+               | 29.762 ns | 0.5975 ns | 0.6394 ns |         - |
-|                      |                                        |           |           |           |           |
-| ICAO 9303 Size TD1   | I<UTOD231458907<<<<<<<<<<<<<<<<br>7408122F1204159UTO<<<<<<<<<<<6<br>ERIKSSON<<ANNA<MARIA<<<<<<<<<< | 84.945 ns | 1.6663 ns | 1.5586 ns |         - |
-| ICAO 9303 Size TD1   | I<UTOSTARWARS45<<<<<<<<<<<<<<<<br>7705256M2405252UTO<<<<<<<<<<<4<br>SKYWALKER<<LUKE<<<<<<<<<<<<<<< | 97.953 ns | 1.0370 ns | 0.9700 ns |         - |
-| ICAO 9303 Size TD1   | I<UTOD23145890<AB112234566<<<<<br>7408122F1204159UTO<<<<<<<<<<<4<br>ERIKSSON<<ANNA<MARIA<<<<<<<<<< | 97.953 ns | 1.0370 ns | 0.9700 ns |         - |
-|                      |                                        |           |           |           |           |
-| ICAO 9303 Size TD2   | I<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<br>D231458907UTO7408122F1204159<<<<<<<6 | 86.78 ns | 0.816 ns | 0.763 ns |         - |
-| ICAO 9303 Size TD2   | I<UTOQWERTY<<ASDF<<<<<<<<<<<<<<<<<<<<br>D23145890<UTO7408122F1204159AB1124<4 | 95.22 ns | 0.852 ns | 0.797 ns |         - |
-| ICAO 9303 Size TD2   | I<UTOSKYWALKER<<LUKE<<<<<<<<<<<<<<<<<br>STARWARS45UTO7705256M2405252<<<<<<<8 | 87.34 ns | 0.704 ns | 0.658 ns |         - |
-|                      |                                        |           |           |           |           |
-| ICAO 9303 Size TD3   | P<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<<br>L898902C36UTO7408122F1204159ZE184226B<<<<<10 | 85.675 ns | 0.5136 ns | 0.4804 ns |         - |
-| ICAO 9303 Size TD3   | P<UTOQWERTY<<ASDF<<<<<<<<<<<<<<<<<<<<<<<<<<<<br>Q123987655UTO3311226F2010201<<<<<<<<<<<<<<06 | 85.188 ns | 0.2958 ns | 0.2310 ns |         - |
-| ICAO 9303 Size TD3   | P<UTOSKYWALKER<<LUKE<<<<<<<<<<<<<<<<<<<<<<<<<br>STARWARS45UTO7705256M2405252HAN<SHOT<FIRST78 | 85.401 ns | 0.5888 ns | 0.5507 ns |         - |
-|                      |                                        |           |           |           |           |                                           
-| ISAN                 | C594660A8B2E5D22X6DDA3272E             | 54.400 ns | 0.1940 ns | 0.1810 ns |         - |
-| ISAN                 | D02C42E954183EE2Q1291C8AEO             | 51.210 ns | 0.2820 ns | 0.2640 ns |         - |
-| ISAN                 | E9530C32BC0EE83B269867B20F             | 46.700 ns | 0.1390 ns | 0.1300 ns |         - |
-|                      |                                        |           |           |           |           |                                           
-| ISAN (Formatted)     | ISAN C594-660A-8B2E-5D22-X             | 45.420 ns | 0.1530 ns | 0.1360 ns |         - |
-| ISAN (Formatted)     | ISAN D02C-42E9-5418-3EE2-Q             | 44.310 ns | 0.2520 ns | 0.2360 ns |         - |
-| ISAN (Formatted)     | ISAN E953-0C32-BC0E-E83B-2             | 50.080 ns | 0.2070 ns | 0.1840 ns |         - |
-| ISAN (Formatted)     | ISAN C594-660A-8B2E-5D22-X-6DDA-3272-E | 64.650 ns | 0.3200 ns | 0.3000 ns |         - |
-| ISAN (Formatted)     | ISAN D02C-42E9-5418-3EE2-Q-1291-C8AE-O | 65.820 ns | 0.3030 ns | 0.2840 ns |         - |
-| ISAN (Formatted)     | ISAN E953-0C32-BC0E-E83B-2-6986-7B20-F | 64.220 ns | 0.3640 ns | 0.3400 ns |         - |
-|                      |                                        |           |           |           |           |                                           
-| ISIN                 | AU0000XVGZA3                           | 25.520 ns | 0.1260 ns | 0.1170 ns |         - |
-| ISIN                 | GB0002634946                           | 19.150 ns | 0.1290 ns | 0.1140 ns |         - |
-| ISIN                 | US0378331005                           | 19.110 ns | 0.1400 ns | 0.1310 ns |         - |
-|                      |                                        |           |           |           |           |                                           
-| ISO 6346             | CSQU3054383                            | 14.970 ns | 0.0350 ns | 0.0280 ns |         - |
-| ISO 6346             | MSKU9070323                            | 14.890 ns | 0.0930 ns | 0.0870 ns |         - |
-| ISO 6346             | TOLU4734787                            | 14.840 ns | 0.0980 ns | 0.0870 ns |         - |
-|                      |                                        |           |           |           |           |                                           
-| NHS                  | 4505577104                             | 11.280 ns | 0.0360 ns | 0.0340 ns |         - |
-| NHS                  | 5301194917                             | 11.270 ns | 0.0400 ns | 0.0360 ns |         - |
-| NHS                  | 9434765919                             | 11.270 ns | 0.0450 ns | 0.0430 ns |         - |
-|                      |                                        |           |           |           |           |                                           
-| NPI                  | 1122337797                             | 14.490 ns | 0.0490 ns | 0.0440 ns |         - |
-| NPI                  | 1234567893                             | 14.530 ns | 0.0800 ns | 0.0710 ns |         - |
-| NPI                  | 1245319599                             | 14.520 ns | 0.0890 ns | 0.0830 ns |         - |
-|                      |                                        |           |           |           |           |                                           
-| SEDOL                | 3134865                                | 12.290 ns | 0.1440 ns | 0.1200 ns |         - |
-| SEDOL                | B0YQ5W0                                | 12.180 ns | 0.0630 ns | 0.0560 ns |         - |
-| SEDOL                | BRDVMH9                                | 12.220 ns | 0.0800 ns | 0.0710 ns |         - |
-|                      |                                        |           |           |           |           |                                           
-| VIN                  | 1G8ZG127XWZ157259                      | 21.120 ns | 0.1160 ns | 0.1080 ns |         - |
-| VIN                  | 1HGEM21292L047875                      | 20.920 ns | 0.0770 ns | 0.0690 ns |         - |
-| VIN                  | 1M8GDM9AXKP042788                      | 21.050 ns | 0.0940 ns | 0.0830 ns |         - |
+| Algorithm Name                  | Value                                  | Mean      | Error     | StdDev    | Allocated |
+|-------------------------------- |--------------------------------------- |----------:|----------:|----------:|----------:|
+| ABA RTN                         | 111000025                              | 10.830 ns | 0.0650 ns | 0.0580 ns |         - |
+| ABA RTN                         | 122235821                              | 10.400 ns | 0.1880 ns | 0.1570 ns |         - |
+| ABA RTN                         | 325081403                              | 10.310 ns | 0.0610 ns | 0.0570 ns |         - |
+|                                 |                                        |           |           |           |           |                                           
+| CUSIP                           | 037833100                              | 16.500 ns | 0.1990 ns | 0.1760 ns |         - |
+| CUSIP                           | 38143VAA7                              | 13.020 ns | 0.0830 ns | 0.0770 ns |         - |
+| CUSIP                           | 91282CJL6                              | 12.850 ns | 0.0630 ns | 0.0530 ns |         - |
+|                                 |                                        |           |           |           |           |                                           
+| IBAN                            | BE71096123456769                       | 20.090 ns | 0.1710 ns | 0.1600 ns |         - |
+| IBAN                            | GB82WEST12345698765432                 | 34.960 ns | 0.2120 ns | 0.1880 ns |         - |
+| IBAN                            | SC74MCBL01031234567890123456USD        | 51.580 ns | 0.2410 ns | 0.2130 ns |         - |
+|                                 |                                        |           |           |           |           |
+| ICAO 9303                       | U7Y5                                   |  7.376 ns | 0.0654 ns | 0.0580 ns |         - |
+| ICAO 9303                       | U7Y8SX8                                | 13.371 ns | 0.2098 ns | 0.1752 ns |         - |
+| ICAO 9303                       | U7Y8SXRC03                             | 17.766 ns | 0.3089 ns | 0.2890 ns |         - |
+| ICAO 9303                       | U7Y8SXRC0O3S8                          | 22.630 ns | 0.4513 ns | 0.4221 ns |         - |
+| ICAO 9303                       | U7Y8SXRC0O3SC4I2                       | 28.543 ns | 0.3081 ns | 0.2731 ns |         - |
+| ICAO 9303                       | U7Y8SXRC0O3SC4IHYQ9                    | 32.207 ns | 0.3189 ns | 0.2490 ns |         - |
+| ICAO 9303                       | U7Y8SXRC0O3SC4IHYQF4M8                 | 39.060 ns | 0.4010 ns | 0.3555 ns |         - |
+|                                 |                                        |           |           |           |           |
+| ICAO 9303 (Embedded)            | +U7Y5+                                 |  9.022 ns | 0.2106 ns | 0.3278 ns |         - |
+| ICAO 9303 (Embedded)            | +U7Y8SX8+                              | 11.690 ns | 0.2177 ns | 0.2036 ns |         - |
+| ICAO 9303 (Embedded)            | +U7Y8SXRC03+                           | 15.562 ns | 0.2131 ns | 0.1993 ns |         - |
+| ICAO 9303 (Embedded)            | +U7Y8SXRC0O3S8+                        | 19.363 ns | 0.3438 ns | 0.3216 ns |         - |
+| ICAO 9303 (Embedded)            | +U7Y8SXRC0O3SC4I2+                     | 22.433 ns | 0.2453 ns | 0.2174 ns |         - |
+| ICAO 9303 (Embedded)            | +U7Y8SXRC0O3SC4IHYQ9+                  | 26.724 ns | 0.2726 ns | 0.2416 ns |         - |
+| ICAO 9303 (Embedded)            | +U7Y8SXRC0O3SC4IHYQF4M8+               | 29.762 ns | 0.5975 ns | 0.6394 ns |         - |
+|                                 |                                        |           |           |           |           |
+| ICAO 9303 Machine Readable Visa | I<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<br>D231458907UTO7408122F1204159<<<<<<<< | 59.49 ns | 1.208 ns | 1.770 ns |         - |
+| ICAO 9303 Machine Readable Visa | I<UTOSKYWALKER<<LUKE<<<<<<<<<<<<<<<<<br>STARWARS45UTO7705256M2405252<<<<<<<< | 53.47 ns | 0.739 ns | 0.655 ns |         - |
+| ICAO 9303 Machine Readable Visa | V<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<<br>L898902C<3UTO6908061F9406236ZE184226B<<<<<<< | 52.94 ns | 0.527 ns | 0.493 ns |         - |
+|                                 |                                        |           |           |           |           |
+| ICAO 9303 Size TD1              | I<UTOD231458907<<<<<<<<<<<<<<<<br>7408122F1204159UTO<<<<<<<<<<<6<br>ERIKSSON<<ANNA<MARIA<<<<<<<<<< | 84.945 ns | 1.6663 ns | 1.5586 ns |         - |
+| ICAO 9303 Size TD1              | I<UTOSTARWARS45<<<<<<<<<<<<<<<<br>7705256M2405252UTO<<<<<<<<<<<4<br>SKYWALKER<<LUKE<<<<<<<<<<<<<<< | 97.953 ns | 1.0370 ns | 0.9700 ns |         - |
+| ICAO 9303 Size TD1              | I<UTOD23145890<AB112234566<<<<<br>7408122F1204159UTO<<<<<<<<<<<4<br>ERIKSSON<<ANNA<MARIA<<<<<<<<<< | 97.953 ns | 1.0370 ns | 0.9700 ns |         - |
+|                                 |                                        |           |           |           |           |
+| ICAO 9303 Size TD2              | I<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<br>D231458907UTO7408122F1204159<<<<<<<6 | 86.78 ns | 0.816 ns | 0.763 ns |         - |
+| ICAO 9303 Size TD2              | I<UTOQWERTY<<ASDF<<<<<<<<<<<<<<<<<<<<br>D23145890<UTO7408122F1204159AB1124<4 | 95.22 ns | 0.852 ns | 0.797 ns |         - |
+| ICAO 9303 Size TD2              | I<UTOSKYWALKER<<LUKE<<<<<<<<<<<<<<<<<br>STARWARS45UTO7705256M2405252<<<<<<<8 | 87.34 ns | 0.704 ns | 0.658 ns |         - |
+|                                 |                                        |           |           |           |           |
+| ICAO 9303 Size TD3              | P<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<<br>L898902C36UTO7408122F1204159ZE184226B<<<<<10 | 85.675 ns | 0.5136 ns | 0.4804 ns |         - |
+| ICAO 9303 Size TD3              | P<UTOQWERTY<<ASDF<<<<<<<<<<<<<<<<<<<<<<<<<<<<br>Q123987655UTO3311226F2010201<<<<<<<<<<<<<<06 | 85.188 ns | 0.2958 ns | 0.2310 ns |         - |
+| ICAO 9303 Size TD3              | P<UTOSKYWALKER<<LUKE<<<<<<<<<<<<<<<<<<<<<<<<<br>STARWARS45UTO7705256M2405252HAN<SHOT<FIRST78 | 85.401 ns | 0.5888 ns | 0.5507 ns |         - |
+|                                 |                                        |           |           |           |           |                                           
+| ISAN                            | C594660A8B2E5D22X6DDA3272E             | 54.400 ns | 0.1940 ns | 0.1810 ns |         - |
+| ISAN                            | D02C42E954183EE2Q1291C8AEO             | 51.210 ns | 0.2820 ns | 0.2640 ns |         - |
+| ISAN                            | E9530C32BC0EE83B269867B20F             | 46.700 ns | 0.1390 ns | 0.1300 ns |         - |
+|                                 |                                        |           |           |           |           |                                           
+| ISAN (Formatted)                | ISAN C594-660A-8B2E-5D22-X             | 45.420 ns | 0.1530 ns | 0.1360 ns |         - |
+| ISAN (Formatted)                | ISAN D02C-42E9-5418-3EE2-Q             | 44.310 ns | 0.2520 ns | 0.2360 ns |         - |
+| ISAN (Formatted)                | ISAN E953-0C32-BC0E-E83B-2             | 50.080 ns | 0.2070 ns | 0.1840 ns |         - |
+| ISAN (Formatted)                | ISAN C594-660A-8B2E-5D22-X-6DDA-3272-E | 64.650 ns | 0.3200 ns | 0.3000 ns |         - |
+| ISAN (Formatted)                | ISAN D02C-42E9-5418-3EE2-Q-1291-C8AE-O | 65.820 ns | 0.3030 ns | 0.2840 ns |         - |
+| ISAN (Formatted)                | ISAN E953-0C32-BC0E-E83B-2-6986-7B20-F | 64.220 ns | 0.3640 ns | 0.3400 ns |         - |
+|                                 |                                        |           |           |           |           |                                           
+| ISIN                            | AU0000XVGZA3                           | 25.520 ns | 0.1260 ns | 0.1170 ns |         - |
+| ISIN                            | GB0002634946                           | 19.150 ns | 0.1290 ns | 0.1140 ns |         - |
+| ISIN                            | US0378331005                           | 19.110 ns | 0.1400 ns | 0.1310 ns |         - |
+|                                 |                                        |           |           |           |           |                                           
+| ISO 6346                        | CSQU3054383                            | 14.970 ns | 0.0350 ns | 0.0280 ns |         - |
+| ISO 6346                        | MSKU9070323                            | 14.890 ns | 0.0930 ns | 0.0870 ns |         - |
+| ISO 6346                        | TOLU4734787                            | 14.840 ns | 0.0980 ns | 0.0870 ns |         - |
+|                                 |                                        |           |           |           |           |                                           
+| NHS                             | 4505577104                             | 11.280 ns | 0.0360 ns | 0.0340 ns |         - |
+| NHS                             | 5301194917                             | 11.270 ns | 0.0400 ns | 0.0360 ns |         - |
+| NHS                             | 9434765919                             | 11.270 ns | 0.0450 ns | 0.0430 ns |         - |
+|                                 |                                        |           |           |           |           |                                           
+| NPI                             | 1122337797                             | 14.490 ns | 0.0490 ns | 0.0440 ns |         - |
+| NPI                             | 1234567893                             | 14.530 ns | 0.0800 ns | 0.0710 ns |         - |
+| NPI                             | 1245319599                             | 14.520 ns | 0.0890 ns | 0.0830 ns |         - |
+|                                 |                                        |           |           |           |           |                                           
+| SEDOL                           | 3134865                                | 12.290 ns | 0.1440 ns | 0.1200 ns |         - |
+| SEDOL                           | B0YQ5W0                                | 12.180 ns | 0.0630 ns | 0.0560 ns |         - |
+| SEDOL                           | BRDVMH9                                | 12.220 ns | 0.0800 ns | 0.0710 ns |         - |
+|                                 |                                        |           |           |           |           |                                           
+| VIN                             | 1G8ZG127XWZ157259                      | 21.120 ns | 0.1160 ns | 0.1080 ns |         - |
+| VIN                             | 1HGEM21292L047875                      | 20.920 ns | 0.0770 ns | 0.0690 ns |         - |
+| VIN                             | 1M8GDM9AXKP042788                      | 21.050 ns | 0.0940 ns | 0.0830 ns |         - |
                         
 
 # Release History/Release Notes

--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Validate method will return ```false```.
 * Check digit size - one character
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - trailing (right-most) character of individual fields, trailing character of second line for composite check digit
+* Value length - three lines of 30 characters plus additional line separator characters as specified by the LineSeparator property
 * Class name - Icao9303SizeTD1Algorithm
 
 #### Links
@@ -569,6 +570,7 @@ Validate method will return ```false```.
 * Check digit size - one character
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - trailing (right-most) character of individual fields, trailing character of second line for composite check digit
+* Value length - two lines of 36 characters plus additional line separator characters as specified by the LineSeparator property
 * Class name - Icao9303SizeTD2Algorithm
 
 #### Links
@@ -610,6 +612,7 @@ validation then the Validate method will return ```false```.
 * Check digit size - one character
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - trailing (right-most) character of individual fields, trailing character of entire string for composite check digit
+* Value length - two lines of 44 characters plus additional line separator characters as specified by the LineSeparator property
 * Class name - Icao9303SizeTD3Algorithm
 
 #### Links
@@ -624,8 +627,15 @@ The ICAO 9303 (International Civil Aviation Organization) specification for
 Machine Readable Visas uses multiple check digits in the machine readable zone 
 of the document. The second line of the machine readable zone contains fields 
 for document number, date of birth and date of expiry and associated check 
-digits for each field. The individual field check digits are all calculated 
-using the[ICAO 9303 Algorithm](#icao-9303-algorithm).
+digits for each field. (Unlike other ICAO 9303 TD1, TD2 or TD3 documents, no 
+composite check digit is used.) The individual field check digits are all 
+calculated using the[ICAO 9303 Algorithm](#icao-9303-algorithm).
+
+Machine Readable Visas have two formats: MRV-A and MRV-B. The MRV-A format uses
+two lines of 44 characters while the MRV-B format uses two lines of 36 characters.
+The individual fields in the second line of the machine readable zone are located
+in the same character positions regardless of the format. The Validate method
+can validate either format
 
 The machine readable zone of a Machine Readable Visa consists of two lines of 36
 characters. The value passed to the Validate method should contain all lines of
@@ -640,6 +650,9 @@ LineSeparator is None.
 The ICAO 9303 Machine Readable Visa Algorithm will validate the check digits of 
 the three fields (document number, date of birth and date of expiry). If any of 
 the check digits fail validation then the Validate method will return ```false```.
+In addition, if the value is not the correct length (two lines of either 44 or 
+36 characters, plus line separator characters matching the LineSeparator 
+property) then the method will return false.
 
 #### Details
 
@@ -647,6 +660,7 @@ the check digits fail validation then the Validate method will return ```false``
 * Check digit size - one character
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - trailing (right-most) character of individual fields
+* Value length - two lines of either 44 characters (MRV-A) or 36 characters (MRV-B), plus additional line separator characters as specified by the LineSeparator property
 * Class name - Icao9303MachineReadableVisaAlgorithm
 
 #### Links

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ let us know. Or contribute to the CheckDigits.Net repository: https://github.com
     * [ICAO 9303 Document Size TD1 Algorithm](#icao-9303-document-size-td1-algorithm)
     * [ICAO 9303 Document Size TD2 Algorithm](#icao-9303-document-size-td2-algorithm)
     * [ICAO 9303 Document Size TD3 Algorithm](#icao-9303-document-size-td3-algorithm)
+    * [ICAO 9303 Machine Readable Visa Algorithm](#icao-9303-machine-readable-visa-algorithm)
     * [ISAN (International Standard Audiovisual Number) Algorithm](#isan-algorithm)
     * [ISIN (International Securities Identification Number) Algorithm](#isin-algorithm)
     * [ISO 6346 Algorithm](#iso-6346-algorithm)
@@ -132,6 +133,7 @@ The ISO/IEC 7064:2003 standard is available at https://www.iso.org/standard/3153
 * [ICAO 9303 Document Size TD1 Algorithm](#icao-9303-document-size-td1-algorithm)
 * [ICAO 9303 Document Size TD2 Algorithm](#icao-9303-document-size-td2-algorithm)
 * [ICAO 9303 Document Size TD3 Algorithm](#icao-9303-document-size-td3-algorithm)
+* [ICAO 9303 Machine Readable Visa Algorithm](#icao-9303-machine-readable-visa-algorithm)
 * [ISAN (International Standard Audiovisual Number) Algorithm](#isan-algorithm)
 * [ISIN (International Securities Identification Number) Algorithm](#isin-algorithm)
 * [ISO 6346 Algorithm](#iso-6346-algorithm)
@@ -173,9 +175,10 @@ The ISO/IEC 7064:2003 standard is available at https://www.iso.org/standard/3153
 | GTIN-14				| [Modulus10_13 Algorithm](#modulus10_13-algorithm) |
 | IBAN                  | [IBAN Algorithm](#iban-algorithm) |
 | ICAO Machine Readable Travel Document Field | [ICAO 9303 Algorithm](#icao-9303-algorithm) |
-| ICAO Machine Readable Travel Documents Size TD1 Documents | [ICAO 9303 Document Size TD1 Algorithm](#icao-9303-document-size-td1-algorithm) |
-| ICAO Machine Readable Travel Documents Size TD2 Documents | [ICAO 9303 Document Size TD2 Algorithm](#icao-9303-document-size-td2-algorithm) |
+| ICAO Machine Readable Travel Documents Size TD1 | [ICAO 9303 Document Size TD1 Algorithm](#icao-9303-document-size-td1-algorithm) |
+| ICAO Machine Readable Travel Documents Size TD2 | [ICAO 9303 Document Size TD2 Algorithm](#icao-9303-document-size-td2-algorithm) |
 | ICAO Machine Readable Passports and Size TD3 Documents | [ICAO 9303 Document Size TD3 Algorithm](#icao-9303-document-size-td3-algorithm) |
+| ICAO Machine Readable Visas | [ICAO 9303 Machine Readable Visa Algorithm](#icao-9303-machine-readable-visa-algorithm) |
 | IMEI				    | [Luhn Algorithm](#luhn-algorithm) |
 | IMO Number            | [Modulus10_2 Algorithm](#modulus10_2-algorithm) |
 | ISAN                  | [ISAN Algorithm](#isan-algorithm) |
@@ -518,7 +521,7 @@ LineSeparator is None.
 
 The ICAO 9303 Document Size TD1 Algorithm will validate the check digits of the
 three fields (document number, date of birth and date of expiry) as well as the 
-composite check digit. If any of the check digits fail  validation then the 
+composite check digit. If any of the check digits fail validation then the 
 Validate method will return ```false```.
 
 #### Details
@@ -535,6 +538,8 @@ https://www.icao.int/publications/Documents/9303_p5_cons_en.pdf
 
 ### ICAO 9303 Document Size TD2 Algorithm
 
+#### Description
+
 The ICAO 9303 (International Civil Aviation Organization) specification for 
 Machine Readable Travel Documents Size TD2 uses multiple check digits in the 
 machine readable zone of the document. The second line of the machine readable 
@@ -547,7 +552,7 @@ The machine readable zone of a Size TD2 document consists of two lines of 36
 characters. The value passed to the Validate method should contain all lines of
 data concatenated together. You can specify how the lines are separated in the
 concatenated value by setting the LineSeparator property of the algorithm class.
-The three values are None (no line separator is used and the 31st character of the
+The three values are None (no line separator is used and the 37th character of the
 value is the first character of the second line), Crlf (the Windows line separator,
 i.e. a carriage return character followed by a line feed character - '\r\n') and 
 Lf (the Unix line separator, i.e a line feed character - '\n').The default 
@@ -555,7 +560,7 @@ LineSeparator is None.
 
 The ICAO 9303 Document Size TD2 Algorithm will validate the check digits of the
 three fields (document number, date of birth and date of expiry) as well as the 
-composite check digit. If any of the check digits fail  validation then the 
+composite check digit. If any of the check digits fail validation then the 
 Validate method will return ```false```.
 
 #### Details
@@ -564,7 +569,7 @@ Validate method will return ```false```.
 * Check digit size - one character
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - trailing (right-most) character of individual fields, trailing character of second line for composite check digit
-* Class name - Icao9303SizeTD1Algorithm
+* Class name - Icao9303SizeTD2Algorithm
 
 #### Links
 
@@ -610,6 +615,43 @@ validation then the Validate method will return ```false```.
 #### Links
 
 https://www.icao.int/publications/Documents/9303_p4_cons_en.pdf
+
+### ICAO 9303 Machine Readable Visa Algorithm
+
+#### Description
+
+The ICAO 9303 (International Civil Aviation Organization) specification for 
+Machine Readable Visas uses multiple check digits in the machine readable zone 
+of the document. The second line of the machine readable zone contains fields 
+for document number, date of birth and date of expiry and associated check 
+digits for each field. The individual field check digits are all calculated 
+using the[ICAO 9303 Algorithm](#icao-9303-algorithm).
+
+The machine readable zone of a Machine Readable Visa consists of two lines of 36
+characters. The value passed to the Validate method should contain all lines of
+data concatenated together. You can specify how the lines are separated in the
+concatenated value by setting the LineSeparator property of the algorithm class.
+The three values are None (no line separator is used and the 37th character of the
+value is the first character of the second line), Crlf (the Windows line separator,
+i.e. a carriage return character followed by a line feed character - '\r\n') and 
+Lf (the Unix line separator, i.e a line feed character - '\n').The default 
+LineSeparator is None.
+
+The ICAO 9303 Machine Readable Visa Algorithm will validate the check digits of 
+the three fields (document number, date of birth and date of expiry). If any of 
+the check digits fail validation then the Validate method will return ```false```.
+
+#### Details
+
+* Valid characters - decimal digits ('0' - '9'), upper case letters ('A' - 'Z') and a filler character ('<').
+* Check digit size - one character
+* Check digit value - decimal digit ('0' - '9')
+* Check digit location - trailing (right-most) character of individual fields
+* Class name - Icao9303MachineReadableVisaAlgorithm
+
+#### Links
+
+https://www.icao.int/publications/Documents/9303_p7_cons_en.pdf
 
 ### ISAN Algorithm
 
@@ -1513,7 +1555,7 @@ Note also that the values used for the NOID Check Digit algorithm do not include
 | ICAO 9303 (Embedded) | +U7Y8SXRC0O3SC4IHYQF4M8+               | 29.762 ns | 0.5975 ns | 0.6394 ns |         - |
 |                      |                                        |           |           |           |           |
 | ICAO 9303 Size TD1   | I<UTOD231458907<<<<<<<<<<<<<<<<br>7408122F1204159UTO<<<<<<<<<<<6<br>ERIKSSON<<ANNA<MARIA<<<<<<<<<< | 84.945 ns | 1.6663 ns | 1.5586 ns |         - |
-| ICAO 9303 Size TD1   | I<UTOSTARWARS45<<<<<<<<<<<<<<<<br>7705256F2405252UTO<<<<<<<<<<<4<br>SKYWALKER<<LUKE<<<<<<<<<<<<<<< | 97.953 ns | 1.0370 ns | 0.9700 ns |         - |
+| ICAO 9303 Size TD1   | I<UTOSTARWARS45<<<<<<<<<<<<<<<<br>7705256M2405252UTO<<<<<<<<<<<4<br>SKYWALKER<<LUKE<<<<<<<<<<<<<<< | 97.953 ns | 1.0370 ns | 0.9700 ns |         - |
 | ICAO 9303 Size TD1   | I<UTOD23145890<AB112234566<<<<<br>7408122F1204159UTO<<<<<<<<<<<4<br>ERIKSSON<<ANNA<MARIA<<<<<<<<<< | 97.953 ns | 1.0370 ns | 0.9700 ns |         - |
 |                      |                                        |           |           |           |           |
 | ICAO 9303 Size TD2   | I<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<br>D231458907UTO7408122F1204159<<<<<<<6 | 86.78 ns | 0.816 ns | 0.763 ns |         - |
@@ -1638,3 +1680,4 @@ Additional included algorithms
 * ICAO 9303 Document Size TD1 Algorithm
 * ICAO 9303 Document Size TD2 Algorithm
 * ICAO 9303 Document Size TD3 Algorithm
+* ICAO 9303 Machine Readable Visa Algorithm


### PR DESCRIPTION
# Icao9303MachineReadableVisaAlgorithm

As a developer of CheckDigits.Net, I want CheckDigits.Net to include the algorithm for validating ICAO 9303 Machine Readable Visas. Machine Readable Visas include check digits for individual fields.

A Machine Readable Visa contains two lines of machine readable data of 36 characters. The second line contains fields for the document number, date of birth and valid until date. All of the fields have associated check digits.

https://en.wikipedia.org/wiki/Machine-readable_passport#Official_travel_documents
https://www.icao.int/publications/Documents/9303_p7_cons_en.pdf

## Requirements

* Icao9303MachineReadableVisaAlgorithm class that implements the following interfaces:
	- ICheckDigitAlgorithm
* Resiliency. Invalid input should not throw an exception and instead should simply return Boolean false to indicate failure. Invalid input will include:
	- null
	- String.Empty

## Definition of DONE

1. Icao9303MachineReadableVisaAlgorithm class
1. Full unit tests
1. README updates
1. Performance benchmarks