### PR TITLE
S0039 luhn validate masked

### DIFF
--- a/CheckDigits.Net.Tests.Benchmarks/CheckDigitMasks.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/CheckDigitMasks.cs
@@ -1,0 +1,8 @@
+﻿namespace CheckDigits.Net.Tests.Benchmarks;
+
+public class GroupsOfThreeCheckDigitMask : ICheckDigitMask
+{
+   public Boolean ExcludeCharacter(Int32 index) => (index + 1) % 4 == 0;
+
+   public Boolean IncludeCharacter(Int32 index) => (index + 1) % 4 != 0;
+}

--- a/CheckDigits.Net.Tests.Benchmarks/NumericAlgorithmBenchmarks.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/NumericAlgorithmBenchmarks.cs
@@ -10,6 +10,8 @@ namespace CheckDigits.Net.Tests.Benchmarks;
 [MemoryDiagnoser]
 public class NumericAlgorithmBenchmarks
 {
+   private static readonly ICheckDigitMask _groupsOfThreeMask = new GroupsOfThreeCheckDigitMask();
+
    public IEnumerable<Object[]> TryCalculateCheckDigitArguments()
    {
       yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140" ];
@@ -155,24 +157,42 @@ public class NumericAlgorithmBenchmarks
       yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380425510282655" ];
    }
 
-   [Benchmark]
-   [ArgumentsSource(nameof(TryCalculateCheckDigitArguments))]
-   public void TryCalculateCheckDigit(ISingleCheckDigitAlgorithm algorithm, String name, String value)
+   public IEnumerable<Object[]> ValidateMaskedArguments()
    {
-      algorithm.TryCalculateCheckDigit(value, out var checkDigit);
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 4"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 8"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 2"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 1"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 551 4"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 551 028 5"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 551 028 265 1"];
    }
 
-   [Benchmark]
-   [ArgumentsSource(nameof(TryCalculateCheckDigitsArguments))]
-   public void TryCalculateCheckDigits(IDoubleCheckDigitAlgorithm algorithm, String name, String value)
-   {
-      algorithm.TryCalculateCheckDigits(value, out var first, out var second);
-   }
+   //[Benchmark]
+   //[ArgumentsSource(nameof(TryCalculateCheckDigitArguments))]
+   //public void TryCalculateCheckDigit(ISingleCheckDigitAlgorithm algorithm, String name, String value)
+   //{
+   //   algorithm.TryCalculateCheckDigit(value, out var checkDigit);
+   //}
+
+   //[Benchmark]
+   //[ArgumentsSource(nameof(TryCalculateCheckDigitsArguments))]
+   //public void TryCalculateCheckDigits(IDoubleCheckDigitAlgorithm algorithm, String name, String value)
+   //{
+   //   algorithm.TryCalculateCheckDigits(value, out var first, out var second);
+   //}
+
+   //[Benchmark]
+   //[ArgumentsSource(nameof(ValidateArguments))]
+   //public void Validate(ICheckDigitAlgorithm algorithm, String name, String value)
+   //{
+   //   algorithm.Validate(value);
+   //}
 
    [Benchmark]
-   [ArgumentsSource(nameof(ValidateArguments))]
-   public void Validate(ICheckDigitAlgorithm algorithm, String name, String value)
+   [ArgumentsSource(nameof(ValidateMaskedArguments))]
+   public void ValidateMasked(IMaskedCheckDigitAlgorithm algorithm, String name, String value)
    {
-      algorithm.Validate(value);
+      algorithm.Validate(value, _groupsOfThreeMask);
    }
 }

--- a/CheckDigits.Net.Tests.Benchmarks/Program.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/Program.cs
@@ -1,10 +1,10 @@
 ﻿
-//BenchmarkRunner.Run<NumericAlgorithmBenchmarks>();
+BenchmarkRunner.Run<NumericAlgorithmBenchmarks>();
 
 //BenchmarkRunner.Run<AlphabeticAlgorithmsBenchmarks>();
 
 //BenchmarkRunner.Run<AlphanumericAlgorithmBenchmarks>();
 
-BenchmarkRunner.Run<ValueSpecificAlgorithmBenchmarks>();
+//BenchmarkRunner.Run<ValueSpecificAlgorithmBenchmarks>();
 
 //BenchmarkRunner.Run<OptimizeBenchmarks>();

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/LuhnAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/LuhnAlgorithmTests.cs
@@ -4,137 +4,140 @@ namespace CheckDigits.Net.Tests.Unit.GeneralAlgorithms;
 
 public class LuhnAlgorithmTests
 {
-    private readonly LuhnAlgorithm _sut = new();
+   private readonly LuhnAlgorithm _sut = new();
+   private readonly ICheckDigitMask _acceptAllMask = new AcceptAllMask();
+   private readonly ICheckDigitMask _creditCardMask = new CreditCardMask();
+   private readonly ICheckDigitMask _rejectAllMask = new RejectAllMask();
 
-    #region AlgorithmDescription Property Tests
-    // ==========================================================================
-    // ==========================================================================
+   #region AlgorithmDescription Property Tests
+   // ==========================================================================
+   // ==========================================================================
 
-    [Fact]
-    public void LuhnAlgorithm_AlgorithmDescription_ShouldReturnExpectedValue()
-       => _sut.AlgorithmDescription.Should().Be(Resources.LuhnAlgorithmDescription);
+   [Fact]
+   public void LuhnAlgorithm_AlgorithmDescription_ShouldReturnExpectedValue()
+      => _sut.AlgorithmDescription.Should().Be(Resources.LuhnAlgorithmDescription);
 
-    #endregion
+   #endregion
 
-    #region AlgorithmName Property Tests
-    // ==========================================================================
-    // ==========================================================================
+   #region AlgorithmName Property Tests
+   // ==========================================================================
+   // ==========================================================================
 
-    [Fact]
-    public void LuhnAlgorithm_AlgorithmName_ShouldReturnExpectedValue()
-       => _sut.AlgorithmName.Should().Be(Resources.LuhnAlgorithmName);
+   [Fact]
+   public void LuhnAlgorithm_AlgorithmName_ShouldReturnExpectedValue()
+      => _sut.AlgorithmName.Should().Be(Resources.LuhnAlgorithmName);
 
-    #endregion
+   #endregion
 
-    #region TryCalculateCheckDigit Tests
-    // ==========================================================================
-    // ==========================================================================
+   #region TryCalculateCheckDigit Tests
+   // ==========================================================================
+   // ==========================================================================
 
-    [Fact]
-    public void LuhnAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenInputIsNull()
-    {
-        // Act/assert.
-        _sut.TryCalculateCheckDigit(null!, out var checkDigit).Should().BeFalse();
-        checkDigit.Should().Be('\0');
-    }
+   [Fact]
+   public void LuhnAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenInputIsNull()
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(null!, out var checkDigit).Should().BeFalse();
+      checkDigit.Should().Be('\0');
+   }
 
-    [Fact]
-    public void LuhnAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenInputIsEmpty()
-    {
-        // Act/assert.
-        _sut.TryCalculateCheckDigit(String.Empty, out var checkDigit).Should().BeFalse();
-        checkDigit.Should().Be('\0');
-    }
+   [Fact]
+   public void LuhnAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenInputIsEmpty()
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(String.Empty, out var checkDigit).Should().BeFalse();
+      checkDigit.Should().Be('\0');
+   }
 
-    [Theory]
-    [InlineData("000000001", '8')]
-    [InlineData("000000100", '8')]
-    [InlineData("000010000", '8')]
-    [InlineData("001000000", '8')]
-    [InlineData("100000000", '8')]
-    public void LuhnAlgorithm_TryCalculateCheckDigit_ShouldCorrectlyWeightOddPositionCharacters(
-       String value,
-       Char expectedCheckDigit)
-    {
-        // Act/assert.
-        _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
-        checkDigit.Should().Be(expectedCheckDigit);
-    }
+   [Theory]
+   [InlineData("000000001", '8')]
+   [InlineData("000000100", '8')]
+   [InlineData("000010000", '8')]
+   [InlineData("001000000", '8')]
+   [InlineData("100000000", '8')]
+   public void LuhnAlgorithm_TryCalculateCheckDigit_ShouldCorrectlyWeightOddPositionCharacters(
+      String value,
+      Char expectedCheckDigit)
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
+      checkDigit.Should().Be(expectedCheckDigit);
+   }
 
-    [Theory]
-    [InlineData("000000010", '9')]
-    [InlineData("000001000", '9')]
-    [InlineData("000100000", '9')]
-    [InlineData("010000000", '9')]
-    public void LuhnAlgorithm_TryCalculateCheckDigit_ShouldCorrectlyWeightEvenPositionCharacters(
-       String value,
-       Char expectedCheckDigit)
-    {
-        // Act/assert.
-        _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
-        checkDigit.Should().Be(expectedCheckDigit);
-    }
+   [Theory]
+   [InlineData("000000010", '9')]
+   [InlineData("000001000", '9')]
+   [InlineData("000100000", '9')]
+   [InlineData("010000000", '9')]
+   public void LuhnAlgorithm_TryCalculateCheckDigit_ShouldCorrectlyWeightEvenPositionCharacters(
+      String value,
+      Char expectedCheckDigit)
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
+      checkDigit.Should().Be(expectedCheckDigit);
+   }
 
-    [Theory]
-    [InlineData("0", '0')]
-    [InlineData("1", '8')]
-    [InlineData("2", '6')]
-    [InlineData("3", '4')]
-    [InlineData("4", '2')]
-    [InlineData("5", '9')]
-    [InlineData("6", '7')]
-    [InlineData("7", '5')]
-    [InlineData("8", '3')]
-    [InlineData("9", '1')]
-    public void LuhnAlgorithm_TryCalculateCheckDigit_ShouldCalculateCorrectDoubleForOddPositionCharacters(
-       String value,
-       Char expectedCheckDigit)
-    {
-        // Act/assert.
-        _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
-        checkDigit.Should().Be(expectedCheckDigit);
-    }
+   [Theory]
+   [InlineData("0", '0')]
+   [InlineData("1", '8')]
+   [InlineData("2", '6')]
+   [InlineData("3", '4')]
+   [InlineData("4", '2')]
+   [InlineData("5", '9')]
+   [InlineData("6", '7')]
+   [InlineData("7", '5')]
+   [InlineData("8", '3')]
+   [InlineData("9", '1')]
+   public void LuhnAlgorithm_TryCalculateCheckDigit_ShouldCalculateCorrectDoubleForOddPositionCharacters(
+      String value,
+      Char expectedCheckDigit)
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
+      checkDigit.Should().Be(expectedCheckDigit);
+   }
 
-    [Theory]
-    [InlineData("37828224631000", '5')]     // American Express test credit card number
-    [InlineData("601111111111111", '7')]    // Discover test credit card number
-    [InlineData("555555555555444", '4')]    // MasterCard test credit card number
-    [InlineData("401288888888188", '1')]    // Visa test credit card number
-    [InlineData("305693000902000", '4')]    // Diners Club test credit card number
-    [InlineData("356611111111111", '3')]    // JCB test credit card number
-    [InlineData("80840123456789", '3')]     // NPI (National Provider Identifier), including 80840 prefix
-    [InlineData("49015420323751", '8')]     // IMEI (International Mobile Equipment Identity)
-    [InlineData("29344343", '8')]           // Canadian Social Insurance Number from https://www.ibm.com/docs/en/sga?topic=patterns-canada-social-insurance-number
-    [InlineData("51170095", '7')]           // "
-    public void LuhnAlgorithm_TryCalculateCheckDigit_ShouldCalculateExpectedCheckDigit(
-       String value,
-       Char expectedCheckDigit)
-    {
-        // Act/assert.
-        _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
-        checkDigit.Should().Be(expectedCheckDigit);
-    }
+   [Theory]
+   [InlineData("37828224631000", '5')]     // American Express test credit card number
+   [InlineData("601111111111111", '7')]    // Discover test credit card number
+   [InlineData("555555555555444", '4')]    // MasterCard test credit card number
+   [InlineData("401288888888188", '1')]    // Visa test credit card number
+   [InlineData("305693000902000", '4')]    // Diners Club test credit card number
+   [InlineData("356611111111111", '3')]    // JCB test credit card number
+   [InlineData("80840123456789", '3')]     // NPI (National Provider Identifier), including 80840 prefix
+   [InlineData("49015420323751", '8')]     // IMEI (International Mobile Equipment Identity)
+   [InlineData("29344343", '8')]           // Canadian Social Insurance Number from https://www.ibm.com/docs/en/sga?topic=patterns-canada-social-insurance-number
+   [InlineData("51170095", '7')]           // "
+   public void LuhnAlgorithm_TryCalculateCheckDigit_ShouldCalculateExpectedCheckDigit(
+      String value,
+      Char expectedCheckDigit)
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
+      checkDigit.Should().Be(expectedCheckDigit);
+   }
 
-    [Fact]
-    public void LuhnAlgorithm_TryCalculateCheckDigit_ShouldCalculateExpectedCheckDigit_WhenInputIsAllZeros()
-    {
-        // Arrange.
-        var value = "00000";
-        var expectedCheckDigit = Chars.DigitZero;
+   [Fact]
+   public void LuhnAlgorithm_TryCalculateCheckDigit_ShouldCalculateExpectedCheckDigit_WhenInputIsAllZeros()
+   {
+      // Arrange.
+      var value = "00000";
+      var expectedCheckDigit = Chars.DigitZero;
 
-        // Act/assert.
-        _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
-        checkDigit.Should().Be(expectedCheckDigit);
-    }
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
+      checkDigit.Should().Be(expectedCheckDigit);
+   }
 
-    [Theory]
-    [InlineData("12G45")]      // Value 12345 would have check digit = 5. G is 20 positions later in ASCII table than 3 so test will fail unless code explicitly checks for non-digit
-    [InlineData("12)45")]      // ) is 10 positions earlier in ASCII table than 3 so test will fail unless code explicitly checks for non-digit
-    public void LuhnAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenInputContainsNonDigitCharacter(String value)
-    {
-        _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeFalse();
-        checkDigit.Should().Be('\0');
-    }
+   [Theory]
+   [InlineData("12G45")]      // Value 12345 would have check digit = 5. G is 20 positions later in ASCII table than 3 so test will fail unless code explicitly checks for non-digit
+   [InlineData("12)45")]      // ) is 10 positions earlier in ASCII table than 3 so test will fail unless code explicitly checks for non-digit
+   public void LuhnAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenInputContainsNonDigitCharacter(String value)
+   {
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeFalse();
+      checkDigit.Should().Be('\0');
+   }
 
    #endregion
 
@@ -143,96 +146,200 @@ public class LuhnAlgorithmTests
    // ==========================================================================
 
    [Fact]
-    public void LuhnAlgorithm_Validate_ShouldReturnFalse_WhenInputIsNull()
-       => _sut.Validate(null!).Should().BeFalse();
+   public void LuhnAlgorithm_Validate_ShouldReturnFalse_WhenInputIsNull()
+      => _sut.Validate(null!).Should().BeFalse();
 
-    [Fact]
-    public void LuhnAlgorithm_Validate_ShouldReturnFalse_WhenInputIsEmpty()
-       => _sut.Validate(String.Empty).Should().BeFalse();
+   [Fact]
+   public void LuhnAlgorithm_Validate_ShouldReturnFalse_WhenInputIsEmpty()
+      => _sut.Validate(String.Empty).Should().BeFalse();
 
-    [Theory]
-    [InlineData("0")]
-    [InlineData("1")]
-    public void LuhnAlgorithm_Validate_ShouldReturnFalse_WhenInputIsOneCharacterInLength(String value)
-       => _sut.Validate(value).Should().BeFalse();
+   [Theory]
+   [InlineData("0")]
+   [InlineData("1")]
+   public void LuhnAlgorithm_Validate_ShouldReturnFalse_WhenInputIsOneCharacterInLength(String value)
+      => _sut.Validate(value).Should().BeFalse();
 
-    [Theory]
-    [InlineData("0000000018")]
-    [InlineData("0000001008")]
-    [InlineData("0000100008")]
-    [InlineData("0010000008")]
-    [InlineData("1000000008")]
-    public void LuhnAlgorithm_Validate_ShouldCorrectlyWeightOddPositionCharacters(String value)
-       => _sut.Validate(value).Should().BeTrue();
+   [Theory]
+   [InlineData("0000000018")]
+   [InlineData("0000001008")]
+   [InlineData("0000100008")]
+   [InlineData("0010000008")]
+   [InlineData("1000000008")]
+   public void LuhnAlgorithm_Validate_ShouldCorrectlyWeightOddPositionCharacters(String value)
+      => _sut.Validate(value).Should().BeTrue();
 
-    [Theory]
-    [InlineData("0000000109")]
-    [InlineData("0000010009")]
-    [InlineData("0001000009")]
-    [InlineData("0100000009")]
-    public void LuhnAlgorithm_Validate_ShouldCorrectlyWeightEvenPositionCharacters(String value)
-       => _sut.Validate(value).Should().BeTrue();
+   [Theory]
+   [InlineData("0000000109")]
+   [InlineData("0000010009")]
+   [InlineData("0001000009")]
+   [InlineData("0100000009")]
+   public void LuhnAlgorithm_Validate_ShouldCorrectlyWeightEvenPositionCharacters(String value)
+      => _sut.Validate(value).Should().BeTrue();
 
-    [Theory]
-    [InlineData("00")]
-    [InlineData("18")]
-    [InlineData("26")]
-    [InlineData("34")]
-    [InlineData("42")]
-    [InlineData("59")]
-    [InlineData("67")]
-    [InlineData("75")]
-    [InlineData("83")]
-    [InlineData("91")]
-    public void LuhnAlgorithm_Validate_ShouldCalculateCorrectDoubleForOddPositionCharacters(String value)
-       => _sut.Validate(value).Should().BeTrue();
+   [Theory]
+   [InlineData("00")]
+   [InlineData("18")]
+   [InlineData("26")]
+   [InlineData("34")]
+   [InlineData("42")]
+   [InlineData("59")]
+   [InlineData("67")]
+   [InlineData("75")]
+   [InlineData("83")]
+   [InlineData("91")]
+   public void LuhnAlgorithm_Validate_ShouldCalculateCorrectDoubleForOddPositionCharacters(String value)
+      => _sut.Validate(value).Should().BeTrue();
 
-    [Theory]
-    [InlineData("378282246310005")]     // American Express test credit card number
-    [InlineData("6011111111111117")]    // Discover test credit card number
-    [InlineData("5555555555554444")]    // MasterCard test credit card number
-    [InlineData("4012888888881881")]    // Visa test credit card number
-    [InlineData("3056930009020004")]    // Diners Club test credit card number
-    [InlineData("3566111111111113")]    // JCB test credit card number
-    [InlineData("808401234567893")]     // NPI (National Provider Identifier), including 80840 prefix
-    [InlineData("490154203237518")]     // IMEI (International Mobile Equipment Identity)
-    [InlineData("293443438")]           // Canadian Social Insurance Number from https://www.ibm.com/docs/en/sga?topic=patterns-canada-social-insurance-number
-    [InlineData("511700957")]           // "
-    public void LuhnAlgorithm_Validate_ShouldReturnTrue_WhenValueContainsValidCheckDigit(String value)
-       => _sut.Validate(value).Should().BeTrue();
+   [Theory]
+   [InlineData("378282246310005")]     // American Express test credit card number
+   [InlineData("6011111111111117")]    // Discover test credit card number
+   [InlineData("5555555555554444")]    // MasterCard test credit card number
+   [InlineData("4012888888881881")]    // Visa test credit card number
+   [InlineData("3056930009020004")]    // Diners Club test credit card number
+   [InlineData("3566111111111113")]    // JCB test credit card number
+   [InlineData("808401234567893")]     // NPI (National Provider Identifier), including 80840 prefix
+   [InlineData("490154203237518")]     // IMEI (International Mobile Equipment Identity)
+   [InlineData("293443438")]           // Canadian Social Insurance Number from https://www.ibm.com/docs/en/sga?topic=patterns-canada-social-insurance-number
+   [InlineData("511700957")]           // "
+   public void LuhnAlgorithm_Validate_ShouldReturnTrue_WhenValueContainsValidCheckDigit(String value)
+      => _sut.Validate(value).Should().BeTrue();
 
-    [Theory]
-    [InlineData("3056930090020004")]    // Diners Club test card number with two digit transposition 09 -> 90
-    [InlineData("3056930000920004")]    // Diners Club test card number with two digit transposition 90 -> 09
-    [InlineData("5555555225554444")]    // MasterCard test card number with two digit twin error 55 -> 22
-    [InlineData("5555555225554774")]    // MasterCard test card number with two digit twin error 44 -> 77
-    [InlineData("3533111111111113")]    // JCB test card number with two digit twin error 66 -> 33
-    public void LuhnAlgorithm_Validate_ShouldReturnTrue_WhenValueContainsUndetectableError(String value)
-       => _sut.Validate(value).Should().BeTrue();
+   [Theory]
+   [InlineData("3056930090020004")]    // Diners Club test card number with two digit transposition 09 -> 90
+   [InlineData("3056930000920004")]    // Diners Club test card number with two digit transposition 90 -> 09
+   [InlineData("5555555225554444")]    // MasterCard test card number with two digit twin error 55 -> 22
+   [InlineData("5555555225554774")]    // MasterCard test card number with two digit twin error 44 -> 77
+   [InlineData("3533111111111113")]    // JCB test card number with two digit twin error 66 -> 33
+   public void LuhnAlgorithm_Validate_ShouldReturnTrue_WhenValueContainsUndetectableError(String value)
+      => _sut.Validate(value).Should().BeTrue();
 
-    [Theory]
-    [InlineData("5558555555554444")]    // MasterCard test card number with single digit transcription error 5 -> 8
-    [InlineData("5558555555554434")]    // MasterCard test card number with single digit transcription error 4 -> 3
-    [InlineData("3059630009020004")]    // Diners Club test card number with two digit transposition error 69 -> 96 
-    [InlineData("3056930009002004")]    // Diners Club test card number with two digit transposition error 20 -> 02
-    [InlineData("5559955555554444")]    // MasterCard test card number with two digit twin error 55 -> 99
-    [InlineData("3566111144111113")]    // JCB test card number with two digit twin error 11 -> 44
-    public void LuhnAlgorithm_Validate_ShouldReturnFalse_WhenInputContainsDetectableError(String value)
-       => _sut.Validate(value).Should().BeFalse();
+   [Theory]
+   [InlineData("5558555555554444")]    // MasterCard test card number with single digit transcription error 5 -> 8
+   [InlineData("5558555555554434")]    // MasterCard test card number with single digit transcription error 4 -> 3
+   [InlineData("3059630009020004")]    // Diners Club test card number with two digit transposition error 69 -> 96 
+   [InlineData("3056930009002004")]    // Diners Club test card number with two digit transposition error 20 -> 02
+   [InlineData("5559955555554444")]    // MasterCard test card number with two digit twin error 55 -> 99
+   [InlineData("3566111144111113")]    // JCB test card number with two digit twin error 11 -> 44
+   public void LuhnAlgorithm_Validate_ShouldReturnFalse_WhenInputContainsDetectableError(String value)
+      => _sut.Validate(value).Should().BeFalse();
 
-    [Fact]
-    public void LuhnAlgorithm_Validate_ShouldReturnTrue_WhenInputIsAllZeros()
-       => _sut.Validate("0000000000000000").Should().BeTrue();
+   [Fact]
+   public void LuhnAlgorithm_Validate_ShouldReturnTrue_WhenInputIsAllZeros()
+      => _sut.Validate("0000000000000000").Should().BeTrue();
 
-    [Fact]
-    public void LuhnAlgorithm_Validate_ShouldReturnTrue_WhenCheckDigitIsCalculatesAsZero()
-       => _sut.Validate("7624810").Should().BeTrue();
+   [Fact]
+   public void LuhnAlgorithm_Validate_ShouldReturnTrue_WhenCheckDigitIsCalculatesAsZero()
+      => _sut.Validate("7624810").Should().BeTrue();
 
-    [Theory]
-    [InlineData("12G455")]     // Value 12345 would have check digit = 5. G is 20 positions later in ASCII table than 3 and would also calculate check digit 5 unless code explicitly checks for non-digit
-    [InlineData("12)455")]     // ) is 10 positions earlier in ASCII table than 3 and would also calculate check digit 5 unless code explicitly checks for non-digit
-    public void LuhnAlgorithm_Validate_ShouldReturnFalse_WhenInputContainsNonDigitCharacter(String value)
-       => _sut.Validate(value).Should().BeFalse();
+   [Theory]
+   [InlineData("12G455")]     // Value 12345 would have check digit = 5. G is 20 positions later in ASCII table than 3 and would also calculate check digit 5 unless code explicitly checks for non-digit
+   [InlineData("12)455")]     // ) is 10 positions earlier in ASCII table than 3 and would also calculate check digit 5 unless code explicitly checks for non-digit
+   public void LuhnAlgorithm_Validate_ShouldReturnFalse_WhenInputContainsNonDigitCharacter(String value)
+      => _sut.Validate(value).Should().BeFalse();
+
+   [Fact]
+   public void LuhnAlgorithm_Validate_ShouldReturnFalse_WhenCheckDigitCharacterIsNonDigit()
+      => _sut.Validate("12345A").Should().BeFalse();
+
+   #endregion
+
+   #region Validate (ICheckDigitMask Overload) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void LuhnAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputIsNull()
+      => _sut.Validate(null!, _acceptAllMask).Should().BeFalse();
+
+   [Fact]
+   public void LuhnAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputIsEmpty()
+      => _sut.Validate(String.Empty, _acceptAllMask).Should().BeFalse();
+
+   [Fact]
+   public void LuhnAlgorithm_ValidateMasked_ShouldReturnFalse_WhenAllNonCheckDigitCharactersAreMaskedOut()
+      => _sut.Validate("0000 0000 0000 0000", _rejectAllMask).Should().BeFalse();
+
+   [Theory]
+   [InlineData("0000 0000 18")]
+   [InlineData("0000 0010 08")]
+   [InlineData("0000 1000 08")]
+   [InlineData("0010 0000 08")]
+   [InlineData("1000 0000 08")]
+   public void LuhnAlgorithm_ValidateMasked_ShouldCorrectlyWeightOddPositionCharacters(String value)
+      => _sut.Validate(value, _creditCardMask).Should().BeTrue();
+
+   [Theory]
+   [InlineData("0000 0001 09")]
+   [InlineData("0000 0100 09")]
+   [InlineData("0001 0000 09")]
+   [InlineData("0100 0000 09")]
+   public void LuhnAlgorithm_ValidateMasked_ShouldCorrectlyWeightEvenPositionCharacters(String value)
+      => _sut.Validate(value, _creditCardMask).Should().BeTrue();
+
+   [Theory]
+   [InlineData("00")]
+   [InlineData("18")]
+   [InlineData("26")]
+   [InlineData("34")]
+   [InlineData("42")]
+   [InlineData("59")]
+   [InlineData("67")]
+   [InlineData("75")]
+   [InlineData("83")]
+   [InlineData("91")]
+   public void LuhnAlgorithm_ValidateMasked_ShouldCalculateCorrectDoubleForOddPositionCharacters(String value)
+      => _sut.Validate(value, _acceptAllMask).Should().BeTrue();
+
+   [Theory]
+   [InlineData("3782 8224 6310 005")]     // American Express test credit card number
+   [InlineData("6011 1111 1111 1117")]    // Discover test credit card number
+   [InlineData("5555 5555 5555 4444")]    // MasterCard test credit card number
+   [InlineData("4012 8888 8888 1881")]    // Visa test credit card number
+   [InlineData("3056 9300 0902 0004")]    // Diners Club test credit card number
+   [InlineData("3566 1111 1111 1113")]    // JCB test credit card number
+   [InlineData("8084 0123 4567 893")]     // NPI (National Provider Identifier), including 80840 prefix
+   [InlineData("4901 5420 3237 518")]     // IMEI (International Mobile Equipment Identity)
+   [InlineData("2934 4343 8")]            // Canadian Social Insurance Number from https://www.ibm.com/docs/en/sga?topic=patterns-canada-social-insurance-number
+   [InlineData("5117 0095 7")]            // "
+   public void LuhnAlgorithm_ValidateMasked_ShouldReturnTrue_WhenValueContainsValidCheckDigit(String value)
+      => _sut.Validate(value, _creditCardMask).Should().BeTrue();
+
+   [Theory]
+   [InlineData("3056 9300 9002 0004")]    // Diners Club test card number with two digit transposition 09 -> 90
+   [InlineData("3056 9300 0092 0004")]    // Diners Club test card number with two digit transposition 90 -> 09
+   [InlineData("5555 5552 2555 4444")]    // MasterCard test card number with two digit twin error 55 -> 22
+   [InlineData("5555 5552 2555 4774")]    // MasterCard test card number with two digit twin error 44 -> 77
+   [InlineData("3533 1111 1111 1113")]    // JCB test card number with two digit twin error 66 -> 33
+   public void LuhnAlgorithm_ValidateMasked_ShouldReturnTrue_WhenValueContainsUndetectableError(String value)
+      => _sut.Validate(value, _creditCardMask).Should().BeTrue();
+
+   [Theory]
+   [InlineData("5558 5555 5555 4444")]    // MasterCard test card number with single digit transcription error 5 -> 8
+   [InlineData("5558 5555 5555 4434")]    // MasterCard test card number with single digit transcription error 4 -> 3
+   [InlineData("3059 6300 0902 0004")]    // Diners Club test card number with two digit transposition error 69 -> 96 
+   [InlineData("3056 9300 0900 2004")]    // Diners Club test card number with two digit transposition error 20 -> 02
+   [InlineData("5559 9555 5555 4444")]    // MasterCard test card number with two digit twin error 55 -> 99
+   [InlineData("3566 1111 4411 1113")]    // JCB test card number with two digit twin error 11 -> 44
+   public void LuhnAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputContainsDetectableError(String value)
+      => _sut.Validate(value, _creditCardMask).Should().BeFalse();
+
+   [Fact]
+   public void LuhnAlgorithm_ValidateMasked_ShouldReturnTrue_WhenInputIsAllZeros()
+      => _sut.Validate("0000 0000 0000 0000", _creditCardMask).Should().BeTrue();
+
+   [Fact]
+   public void LuhnAlgorithm_ValidateMasked_ShouldReturnTrue_WhenCheckDigitIsCalculatesAsZero()
+      => _sut.Validate("7624 810", _creditCardMask).Should().BeTrue();
+
+   [Theory]
+   [InlineData("12G4 55")]     // Value 12345 would have check digit = 5. G is 20 positions later in ASCII table than 3 and would also calculate check digit 5 unless code explicitly checks for non-digit
+   [InlineData("12)4 55")]     // ) is 10 positions earlier in ASCII table than 3 and would also calculate check digit 5 unless code explicitly checks for non-digit
+   public void LuhnAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputContainsNonDigitCharacter(String value)
+      => _sut.Validate(value, _creditCardMask).Should().BeFalse();
+
+   [Fact]
+   public void LuhnAlgorithm_ValidateMasked_ShouldReturnFalse_WhenCheckDigitCharacterIsNonDigit()
+      => _sut.Validate("1234 5A", _creditCardMask).Should().BeFalse();
 
    #endregion
 }

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/LuhnAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/LuhnAlgorithmTests.cs
@@ -7,6 +7,7 @@ public class LuhnAlgorithmTests
    private readonly LuhnAlgorithm _sut = new();
    private readonly ICheckDigitMask _acceptAllMask = new AcceptAllMask();
    private readonly ICheckDigitMask _creditCardMask = new CreditCardMask();
+   private readonly ICheckDigitMask _groupsOfThreeMask = new GroupsOfThreeCheckDigitMask();
    private readonly ICheckDigitMask _rejectAllMask = new RejectAllMask();
 
    #region AlgorithmDescription Property Tests
@@ -205,6 +206,17 @@ public class LuhnAlgorithmTests
       => _sut.Validate(value).Should().BeTrue();
 
    [Theory]
+   [InlineData("1404")]
+   [InlineData("1406628")]
+   [InlineData("1406625382")]
+   [InlineData("1406625380421")]
+   [InlineData("1406625380425514")]
+   [InlineData("1406625380425510285")]
+   [InlineData("1406625380425510282651")]
+   public void LuhnAlgorithm_Validate_ShouldReturnTrue_ForBenchmarkValues(String value)
+      => _sut.Validate(value).Should().BeTrue();
+
+   [Theory]
    [InlineData("3056930090020004")]    // Diners Club test card number with two digit transposition 09 -> 90
    [InlineData("3056930000920004")]    // Diners Club test card number with two digit transposition 90 -> 09
    [InlineData("5555555225554444")]    // MasterCard test card number with two digit twin error 55 -> 22
@@ -300,9 +312,20 @@ public class LuhnAlgorithmTests
    [InlineData("8084 0123 4567 893")]     // NPI (National Provider Identifier), including 80840 prefix
    [InlineData("4901 5420 3237 518")]     // IMEI (International Mobile Equipment Identity)
    [InlineData("2934 4343 8")]            // Canadian Social Insurance Number from https://www.ibm.com/docs/en/sga?topic=patterns-canada-social-insurance-number
-   [InlineData("5117 0095 7")]            // "
+   [InlineData("5117 0095 7")]            // "   Note CSIN is normally formatted as XXX XXX XXX and the groups of four used here is to allow the same mask for all test cases 
    public void LuhnAlgorithm_ValidateMasked_ShouldReturnTrue_WhenValueContainsValidCheckDigit(String value)
       => _sut.Validate(value, _creditCardMask).Should().BeTrue();
+
+   [Theory]
+   [InlineData("140 4")]
+   [InlineData("140 662 8")]
+   [InlineData("140 662 538 2")]
+   [InlineData("140 662 538 042 1")]
+   [InlineData("140 662 538 042 551 4")]
+   [InlineData("140 662 538 042 551 028 5")]
+   [InlineData("140 662 538 042 551 028 265 1")]
+   public void LuhnAlgorithm_ValidateMasked_ShouldReturnTrue_ForBenchmarkValues(String value)
+      => _sut.Validate(value, _groupsOfThreeMask).Should().BeTrue();
 
    [Theory]
    [InlineData("3056 9300 9002 0004")]    // Diners Club test card number with two digit transposition 09 -> 90

--- a/CheckDigits.Net.Tests.Unit/TestData/CheckDigitMasks.cs
+++ b/CheckDigits.Net.Tests.Unit/TestData/CheckDigitMasks.cs
@@ -1,0 +1,29 @@
+﻿namespace CheckDigits.Net.Tests.Unit.TestData;
+
+internal class AcceptAllMask : ICheckDigitMask
+{
+   public Boolean ExcludeCharacter(Int32 index) => false;
+
+   public Boolean IncludeCharacter(Int32 index) => true;
+}
+
+internal class CaSocialInsuranceNumberMask : ICheckDigitMask
+{
+   public Boolean ExcludeCharacter(Int32 index) => index == 3 || index == 7;
+
+   public Boolean IncludeCharacter(Int32 index) => index != 3 && index != 7;
+}
+
+internal class CreditCardMask : ICheckDigitMask
+{
+   public Boolean ExcludeCharacter(Int32 index) => (index + 1) % 5 == 0;
+
+   public Boolean IncludeCharacter(Int32 index) => (index + 1) % 5 != 0;
+}
+
+internal class RejectAllMask : ICheckDigitMask
+{
+   public Boolean ExcludeCharacter(Int32 index) => true;
+
+   public Boolean IncludeCharacter(Int32 index) => false;
+}

--- a/CheckDigits.Net.Tests.Unit/TestData/CheckDigitMasks.cs
+++ b/CheckDigits.Net.Tests.Unit/TestData/CheckDigitMasks.cs
@@ -20,6 +20,12 @@ internal class CreditCardMask : ICheckDigitMask
 
    public Boolean IncludeCharacter(Int32 index) => (index + 1) % 5 != 0;
 }
+public class GroupsOfThreeCheckDigitMask : ICheckDigitMask
+{
+   public Boolean ExcludeCharacter(Int32 index) => (index + 1) % 4 == 0;
+
+   public Boolean IncludeCharacter(Int32 index) => (index + 1) % 4 != 0;
+}
 
 internal class RejectAllMask : ICheckDigitMask
 {

--- a/CheckDigits.Net/GeneralAlgorithms/LuhnAlgorithm.cs
+++ b/CheckDigits.Net/GeneralAlgorithms/LuhnAlgorithm.cs
@@ -23,7 +23,7 @@ namespace CheckDigits.Net.GeneralAlgorithms;
 ///   twin errors (i.e. 11 <-> 44) except 22 <-> 55,  33 <-> 66 and 44 <-> 77.
 ///   </para>
 /// </remarks>
-public sealed class LuhnAlgorithm : ISingleCheckDigitAlgorithm
+public sealed class LuhnAlgorithm : ISingleCheckDigitAlgorithm, IMaskedCheckDigitAlgorithm
 {
    private const Int32 _validateMinLength = 2;
 
@@ -83,6 +83,43 @@ public sealed class LuhnAlgorithm : ISingleCheckDigitAlgorithm
             ? digit > 4 ? (digit * 2) - 9 : digit * 2
             : digit;
          oddPosition = !oddPosition;
+      }
+      var checkDigit = (10 - (sum % 10)) % 10;
+
+      return value[^1].ToIntegerDigit() == checkDigit;
+   }
+
+   /// <inheritdoc/>
+   public Boolean Validate(String value, ICheckDigitMask mask)
+   {
+      if (String.IsNullOrEmpty(value))
+      {
+         return false;
+      }
+
+      var sum = 0;
+      var oddPosition = true;
+      var processedDigits = 0;
+      for (var index = value.Length - 2; index >= 0; index--)
+      {
+         if (mask.ExcludeCharacter(index))
+         {
+            continue;
+         }
+         var digit = value[index].ToIntegerDigit();
+         if (digit < 0 || digit > 9)
+         {
+            return false;
+         }
+         sum += oddPosition
+            ? digit > 4 ? (digit * 2) - 9 : digit * 2
+            : digit;
+         oddPosition = !oddPosition;
+         processedDigits++;
+      }
+      if (processedDigits == 0)
+      {
+         return false;
       }
       var checkDigit = (10 - (sum % 10)) % 10;
 

--- a/CheckDigits.Net/ICheckDigitMask.cs
+++ b/CheckDigits.Net/ICheckDigitMask.cs
@@ -1,0 +1,36 @@
+﻿namespace CheckDigits.Net;
+
+/// <summary>
+///   Public contract for a mask that identifies characters in a string value 
+///   that should be included or excluded from check digit calculations.
+/// </summary>
+public interface ICheckDigitMask
+{
+   /// <summary>
+   ///   Determines whether the character at the specified index should be 
+   ///   included in check digit calculations.
+   /// </summary>
+   /// <param name="index">
+   ///   The zero-based index of the character to evaluate.
+   ///   </param>
+   /// <returns>
+   ///   <see langword="true"/> if the character at the specified index should
+   ///   be excluded from check digit calculations; otherwise, 
+   ///   <see langword="false"/>.
+   /// </returns>
+   Boolean ExcludeCharacter(Int32 index);
+
+   /// <summary>
+   ///   Determines whether the character at the specified index should be 
+   ///   included in check digit calculations.
+   /// </summary>
+   /// <param name="index">
+   ///   The zero-based index of the character to evaluate.
+   ///   </param>
+   /// <returns>
+   ///   <see langword="true"/> if the character at the specified index should
+   ///   be included in check digit calculations; otherwise, 
+   ///   <see langword="false"/>.
+   /// </returns>
+   Boolean IncludeCharacter(Int32 index);
+}

--- a/CheckDigits.Net/IMaskedCheckDigitAlgorithm.cs
+++ b/CheckDigits.Net/IMaskedCheckDigitAlgorithm.cs
@@ -1,0 +1,35 @@
+﻿namespace CheckDigits.Net;
+
+/// <summary>
+///   Public contract for validating a string that contains a check digit or
+///   check digits. Supports masking to include or exclude characters from the
+///   check digit calculation.
+/// </summary>
+public interface IMaskedCheckDigitAlgorithm : ICheckDigitAlgorithm
+{
+   /// <summary>
+   ///   Determine if the <paramref name="value"/> contains a valid check digit
+   ///   (or check digits).
+   /// </summary>
+   /// <param name="value">
+   ///   The value to validate. 
+   /// </param>
+   /// <param name="mask">
+   ///   Mask used to include or exclude characters from the check digit
+   ///   calculation. Note that check digit characters are generally located at
+   ///   fixed locations (e.g., last character) and the mask is not consulted
+   ///   when considering the check digit character(s).
+   /// </param>
+   /// <returns>
+   ///   <see langword="true"/> if the check digit(s) contained in
+   ///   <paramref name="value"/> matches the check digit(s) calculated by this
+   ///   algorithm; otherwise <see langword="false"/>.
+   /// </returns>
+   /// <remarks>
+   ///   Validate will return <see langword="false"/> if <paramref name="value"/>
+   ///   is mal-formed. Examples of mal-formed values are <see langword="null"/>,
+   ///   <see cref="String.Empty"/> or a string that is of invalid length for 
+   ///   this algorithm.
+   /// </remarks>
+   Boolean Validate(String value, ICheckDigitMask mask);
+}

--- a/Documentation/Stories/S0039-LuhnValidateMasked.md
+++ b/Documentation/Stories/S0039-LuhnValidateMasked.md
@@ -4,15 +4,15 @@ As a developer who uses CheckDigits.Net, I want to be able to perform a Luhn val
 
 ## Requirements
 
-* Define IValueMask, an inteface that defines if a character at a specific character position should be processed or ignored.
-* IValueMask should define AcceptCharacter method that has an integer parameter that identifies the character position to check and returns TRUE if the character should be processed or FALSE if the character should be ignored.
-* IValueMask should define RejectCharacter method that has an integer parameter that identifies the character position to check and returns TRUE if the character should be ignored or FALSE if the character should be processed.
-* Define IMaskedCheckDigitAlgorithm, derived from ICheckDigitAlgorithm that adds an overload of the ValidateMethid that accepts an IValueMask and that uses the mask to include or exclude characters while calculating the Luhn check digit.
-* Update LuhnAlgorithm to impliment IValidateCheckDigitWithMask. The overloaded Validate method should perform the check digit calculation in situ, an not require the allocation of a copy of the origonal value without format characters.
+* Define ICheckDigitMask, an inteface that defines if a character at a specific character position should be processed or ignored.
+* ICheckDigitMask should define IncludeCharacter method that has an integer parameter that identifies the character position to check and returns TRUE if the character should be processed or FALSE if the character should be ignored.
+* ICheckDigitMask should define ExcludeCharacter method that has an integer parameter that identifies the character position to check and returns TRUE if the character should be ignored or FALSE if the character should be processed.
+* Define IMaskedCheckDigitAlgorithm, derived from ICheckDigitAlgorithm that adds an overload of the ValidateMethid that accepts an ICheckDigitMask and that uses the mask to include or exclude characters while calculating the Luhn check digit.
+* Update LuhnAlgorithm to impliment IMaskedCheckDigitAlgorithm. The overloaded Validate method should perform the check digit calculation in situ, an not require the allocation of a copy of the origonal value without format characters.
 
 ## Definition of DONE
 
-1. New interfaces, IValueMask and IMaskedCheckDigitAlgorithm
+1. New interfaces, ICheckDigitMask and IMaskedCheckDigitAlgorithm
 2. LuhnAlgorithm updated to impliment IMaskedCheckDigitAlgorithm
 3. Full unit tests
 4. README updates

--- a/Documentation/Stories/S0039-LuhnValidateMasked.md
+++ b/Documentation/Stories/S0039-LuhnValidateMasked.md
@@ -8,7 +8,7 @@ As a developer who uses CheckDigits.Net, I want to be able to perform a Luhn val
 * ICheckDigitMask should define IncludeCharacter method that has an integer parameter that identifies the character position to check and returns TRUE if the character should be processed or FALSE if the character should be ignored.
 * ICheckDigitMask should define ExcludeCharacter method that has an integer parameter that identifies the character position to check and returns TRUE if the character should be ignored or FALSE if the character should be processed.
 * Define IMaskedCheckDigitAlgorithm, derived from ICheckDigitAlgorithm that adds an overload of the ValidateMethid that accepts an ICheckDigitMask and that uses the mask to include or exclude characters while calculating the Luhn check digit.
-* Update LuhnAlgorithm to impliment IMaskedCheckDigitAlgorithm. The overloaded Validate method should perform the check digit calculation in situ, an not require the allocation of a copy of the origonal value without format characters.
+* Update LuhnAlgorithm to impliment IMaskedCheckDigitAlgorithm. The overloaded Validate method should perform the check digit calculation in situ, and not require the allocation of a copy of the origional value without format characters.
 
 ## Definition of DONE
 

--- a/Documentation/Stories/S0039-LuhnValidateMasked.md
+++ b/Documentation/Stories/S0039-LuhnValidateMasked.md
@@ -7,13 +7,13 @@ As a developer who uses CheckDigits.Net, I want to be able to perform a Luhn val
 * Define IValueMask, an inteface that defines if a character at a specific character position should be processed or ignored.
 * IValueMask should define AcceptCharacter method that has an integer parameter that identifies the character position to check and returns TRUE if the character should be processed or FALSE if the character should be ignored.
 * IValueMask should define RejectCharacter method that has an integer parameter that identifies the character position to check and returns TRUE if the character should be ignored or FALSE if the character should be processed.
-* Define IValidateCheckDigitWithMask, derived from IValidateCheckDigit that adds an overload of the ValidateMethid that accepts an IValueMask and that uses the mask to include or exclude characters while calculating the Luhn check digit.
+* Define IMaskedCheckDigitAlgorithm, derived from ICheckDigitAlgorithm that adds an overload of the ValidateMethid that accepts an IValueMask and that uses the mask to include or exclude characters while calculating the Luhn check digit.
 * Update LuhnAlgorithm to impliment IValidateCheckDigitWithMask. The overloaded Validate method should perform the check digit calculation in situ, an not require the allocation of a copy of the origonal value without format characters.
 
 ## Definition of DONE
 
-1. New interfaces, IValueMask and IValidateCheckDigitWithMask
-2. LuhnAlgorithm updated to impliment IValidateCheckDigitWithMask
+1. New interfaces, IValueMask and IMaskedCheckDigitAlgorithm
+2. LuhnAlgorithm updated to impliment IMaskedCheckDigitAlgorithm
 3. Full unit tests
 4. README updates
 5. Performance benchmarks

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ support calculation of check digits.
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - ninth digit
 * Value length - 9 characters
-* Class name - AbaRtnAlgorithm
+* Class name - ```AbaRtnAlgorithm```
 
 #### Links
 
@@ -371,7 +371,7 @@ letters are mapped to their uppercase equivalent before conversion to integers.
 * Check digit size - two characters
 * Check digit value - decimal digits ('0' - '9')
 * Check digit location - assumed to be the trailing (right-most) characters when validating
-* Class name - AlphanumericMod97_10Algorithm
+* Class name - ```AlphanumericMod97_10Algorithm```
 
 #### Common Applications
 
@@ -402,7 +402,7 @@ support calculation of check digits.
 * Check digit size - one character
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - assumed to be the trailing (right-most) character when validating
-* Class name - CusipAlgorithm
+* Class name - ```CusipAlgorithm```
 
 #### Links
 
@@ -427,7 +427,7 @@ on page 111 of Damm's doctoral dissertation.
 * Check digit size - one character
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - assumed to be the trailing (right-most) character when validating
-* Class name - DammAlgorithm
+* Class name - ```DammAlgorithm```
 
 #### Links
 
@@ -460,7 +460,7 @@ calculation of check digits.
 * Check digit value - decimal digits ('0' - '9')
 * Check digit location - character position 12 (1-based)
 * Value length - 12
-* Class name - FigiAlgorithm
+* Class name - ```FigiAlgorithm```
 
 #### Links
 
@@ -491,7 +491,7 @@ contained in account number, etc.) are left to the application developer.
 * Check digit value - decimal digits ('0' - '9')
 * Check digit location - character positions 3 & 4 (1-based) when validating
 * Value minimum length - 5
-* Class name - IbanAlgorithm
+* Class name - ```IbanAlgorithm```
 
 #### Links
 
@@ -518,7 +518,7 @@ where the difference between the transposed characters is a multiple of 5, i.e.
 * Check digit size - one character
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - assumed to be the trailing (right-most) character when validating
-* Class name - Icao9303Algorithm
+* Class name - ```Icao9303Algorithm```
 
 #### Links
 
@@ -561,7 +561,7 @@ digits and does not support calculation of check digits.
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - trailing (right-most) character of individual fields, trailing character of second line for composite check digit
 * Value length - three lines of 30 characters plus additional line separator characters as specified by the LineSeparator property
-* Class name - Icao9303SizeTD1Algorithm
+* Class name - ```Icao9303SizeTD1Algorithm```
 
 #### Links
 
@@ -604,7 +604,7 @@ digits and does not support calculation of check digits.
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - trailing (right-most) character of individual fields, trailing character of second line for composite check digit
 * Value length - two lines of 36 characters plus additional line separator characters as specified by the LineSeparator property
-* Class name - Icao9303SizeTD2Algorithm
+* Class name - ```Icao9303SizeTD2Algorithm```
 
 #### Links
 
@@ -649,7 +649,7 @@ digits and does not support calculation of check digits.
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - trailing (right-most) character of individual fields, trailing character of entire string for composite check digit
 * Value length - two lines of 44 characters plus additional line separator characters as specified by the LineSeparator property
-* Class name - Icao9303SizeTD3Algorithm
+* Class name - ```Icao9303SizeTD3Algorithm```
 
 #### Links
 
@@ -700,7 +700,7 @@ digits and does not support calculation of check digits.
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - trailing (right-most) character of individual fields
 * Value length - two lines of either 44 characters (MRV-A) or 36 characters (MRV-B), plus additional line separator characters as specified by the LineSeparator property
-* Class name - Icao9303MachineReadableVisaAlgorithm
+* Class name - ```Icao9303MachineReadableVisaAlgorithm```
 
 #### Links
 
@@ -743,7 +743,7 @@ example formatted root/episode/version ISAN value is ISAN 0000-0000-C36D-002B-K-
 * Check digit size - one character
 * Check digit value - alphanumeric characters ('0' - '9', 'A' - 'Z')
 * Check digit location - the 17th non-format character (**and** the 26th non-format character for root+version values)
-* Class name - IsanAlgorithm
+* Class name - ```IsanAlgorithm```
 
 #### Links
 
@@ -774,7 +774,7 @@ algorithm cannot detect).
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - assumed to be the trailing (right-most) character when validating
 * Value length - 12
-* Class name - IsinAlgorithm
+* Class name - ```IsinAlgorithm```
 
 #### Links
 
@@ -791,7 +791,7 @@ The ISO 6346 algorithm is used for eleven character shipping container numbers.
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - assumed to be the trailing (right-most) character when validating
 * Value length - 11
-* Class name - Iso6346Algorithm
+* Class name - ```Iso6346Algorithm```
 
 #### Links
 
@@ -809,7 +809,7 @@ single check character that is a decimal digit.
 * Check digit size - one character
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - assumed to be the trailing (right-most) character when validating
-* Class name - Iso7064Mod11_10Algorithm
+* Class name - ```Iso7064Mod11_10Algorithm```
 
 ### ISO/IEC 7064 MOD 11-2 Algorithm
 
@@ -824,7 +824,7 @@ character.
 * Check digit size - one character
 * Check digit value - either decimal digit ('0' - '9') or an uppercase 'X'
 * Check digit location - assumed to be the trailing (right-most) character when validating
-* Class name - Iso7064Mod11_2Algorithm
+* Class name - ```Iso7064Mod11_2Algorithm```
 
 #### Common Applications
 
@@ -842,7 +842,7 @@ generates two check alphanumeric characters.
 * Check digit size - two characters
 * Check digit value - alphanumeric characters ('0' - '9', 'A' - 'Z')
 * Check digit location - assumed to be the trailing (right-most) characters when validating
-* Class name - Iso7064Mod1271_36Algorithm
+* Class name - ```Iso7064Mod1271_36Algorithm```
 
 ### ISO/IEC 7064 MOD 27,26 Algorithm
 
@@ -871,7 +871,7 @@ supplementary '*' character.
 * Check digit size - one character
 * Check digit value - either decimal digit ('0' - '9', 'A' - 'Z') or an asterisk '*'
 * Check digit location - assumed to be the trailing (right-most) character when validating
-* Class name - Iso7064Mod37_2Algorithm
+* Class name - ```Iso7064Mod37_2Algorithm```
 
 #### Common Applications
 
@@ -889,7 +889,7 @@ single check character that is an alphanumeric character.
 * Check digit size - one character
 * Check digit value - alphanumeric characters ('0' - '9', 'A' - 'Z')
 * Check digit location - assumed to be the trailing (right-most) character when validating
-* Class name - Iso7064Mod37_36Algorithm
+* Class name - ```Iso7064Mod37_36Algorithm```
 
 #### Common Applications
 
@@ -907,7 +907,7 @@ two check alphabetic characters.
 * Check digit size - two characters
 * Check digit value - alphabetic characters ('A' - 'Z')
 * Check digit location - assumed to be the trailing (right-most) characters when validating
-* Class name - Iso7064Mod661_26Algorithm
+* Class name - ```Iso7064Mod661_26Algorithm```
 
 ### ISO/IEC 7064 MOD 97-10 Algorithm
 
@@ -928,7 +928,7 @@ perform the mapping of alphabetic characters internally.
 * Check digit size - two characters
 * Check digit value - decimal digits ('0' - '9')
 * Check digit location - assumed to be the trailing (right-most) characters when validating
-* Class name - Iso7064Mod97_10Algorithm
+* Class name - ```Iso7064Mod97_10Algorithm```
 
 ### Luhn Algorithm
 
@@ -939,13 +939,17 @@ Peter Luhn. It can detect all single digit transcription errors and most two dig
 transposition errors except *09 -> 90* and vice versa. It can also detect most
 twin errors (i.e. *11 <-> 44*) except *22 <-> 55*,  *33 <-> 66* and *44 <-> 77*.
 
+```LuhnAlgorithm``` implements ```IMaskedCheckDigitAlgorithm``` and can be used 
+to validate values that are formatted with non-check digit characters (for example,
+a credit card number formatted with spaces or dashes).
+
 #### Details
 
 * Valid characters - decimal digits ('0' - '9')
 * Check digit size - one character
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - assumed to be the trailing (right-most) character when validating
-* Class name - LuhnAlgorithm
+* Class name - ```LuhnAlgorithm```
 
 #### Common Applications
 
@@ -969,7 +973,7 @@ in the value, starting with weight 1 for the right-most non-check digit characte
 * Check digit value - either decimal digit ('0' - '9')
 * Check digit location - assumed to be the trailing (right-most) character when validating
 * Max length - 9 characters when generating a check digit; 10 characters when validating
-* Class name - Modulus10_1Algorithm
+* Class name - ```Modulus10_1Algorithm```
 
 #### Common Applications
 
@@ -991,7 +995,7 @@ in the value, starting with weight 2 for the right-most non-check digit characte
 * Check digit value - either decimal digit ('0' - '9')
 * Check digit location - assumed to be the trailing (right-most) character when validating
 * Max length - 9 characters when generating a check digit; 10 characters when validating
-* Class name - Modulus10_2Algorithm
+* Class name - ```Modulus10_2Algorithm```
 
 #### Common Applications
 
@@ -1017,7 +1021,7 @@ etc.). The algorithm cannot detect two digit jump transpositions.
 * Check digit size - one character
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - assumed to be the trailing (right-most) character when validating
-* Class name - Modulus10_13Algorithm
+* Class name - ```Modulus10_13Algorithm```
 
 #### Common Applications
 
@@ -1054,7 +1058,7 @@ stored as numbers and instead must be strings.
 * Check digit value - either decimal digit ('0' - '9') or an uppercase 'X'
 * Check digit location - assumed to be the trailing (right-most) character when validating
 * Max length - 9 characters when generating a check digit; 10 characters when validating
-* Class name - Modulus11Algorithm
+* Class name - ```Modulus11Algorithm```
 
 #### Common Applications
 
@@ -1090,7 +1094,7 @@ calculation of check digits.
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - assumed to be the trailing (right-most) character when validating
 * Value length - 10 characters
-* Class name - NhsAlgorithm
+* Class name - ```NhsAlgorithm```
 
 #### Links
 
@@ -1153,7 +1157,7 @@ calculation of check digits.
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - assumed to be the trailing (right-most) character when validating
 * Value length - 10 characters
-* Class name - NpiAlgorithm
+* Class name - ```NpiAlgorithm```
 
 #### Links
 
@@ -1204,7 +1208,7 @@ twin errors.
 * Check digit size - one character
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - assumed to be the trailing (right-most) character when validating
-* Class name - VerhoeffAlgorithm
+* Class name - ```VerhoeffAlgorithm```
 
 #### Links
 
@@ -1227,7 +1231,7 @@ weighting, summing and calculating sum modulus 11.
 * Check digit value - either decimal digit ('0' - '9') or an uppercase 'X'
 * Check digit location - 9th character of 17
 * Length - 17 characters
-* Class name - VinAlgorithm
+* Class name - ```VinAlgorithm```
 
 #### Links
 
@@ -1671,7 +1675,30 @@ Note also that the values used for the NOID Check Digit algorithm do not include
 | VIN                             | 1G8ZG127XWZ157259                      | 12.377 ns       | -                    | 12.944 ns        | -                     | -5%                                          |
 | VIN                             | 1HGEM21292L047875                      | 12.398 ns       | -                    | 12.865 ns        | -                     | -4%                                          |
 | VIN                             | 1M8GDM9AXKP042788                      | 12.134 ns       | -                    | 13.088 ns        | -                     | -8%                                          |
-                        
+
+### Validate Method (with ICheckDigitMask)
+
+The following implementation of ICheckDigitMask is used for the benchmarks:
+```C#
+public class GroupsOfThreeCheckDigitMask : ICheckDigitMask
+{
+   public Boolean ExcludeCharacter(Int32 index) => (index + 1) % 4 == 0;
+
+   public Boolean IncludeCharacter(Int32 index) => (index + 1) % 4 != 0;
+}
+```
+
+#### General Numeric Algorithms
+
+| Algorithm Name         | Value                          | Mean (.Net 8.0) | Allocated (.Net 8.0) | Mean (.Net 10.0) | Allocated (.Net 10.0) | Performance Delta<br>(.Net 8.0 -> .Net 10.0) |
+|----------------------- |------------------------------- |-----------------|----------------------|------------------|-----------------------|----------------------------------------------|
+| Luhn                   | 140 4                          |  4.743 ns       | -                    |  4.675 ns        | -                     |  1%                                          |
+| Luhn                   | 140 662 8                      |  6.800 ns       | -                    |  6.032 ns        | -                     | 11%                                          |
+| Luhn                   | 140 662 538 2                  | 10.294 ns       | -                    |  7.948 ns        | -                     | 23%                                          |
+| Luhn                   | 140 662 538 042 1              | 11.998 ns       | -                    |  9.833 ns        | -                     | 18%                                          |
+| Luhn                   | 140 662 538 042 551 4          | 14.930 ns       | -                    | 12.079 ns        | -                     | 19%                                          |
+| Luhn                   | 140 662 538 042 551 028 5      | 17.257 ns       | -                    | 14.282 ns        | -                     | 17%                                          |
+| Luhn                   | 140 662 538 042 551 028 265 1  | 19.668 ns       | -                    | 16.428 ns        | -                     | 16%                                          |
 
 # Release History/Release Notes
 


### PR DESCRIPTION
# S0039-LuhnValidateMasked

As a developer who uses CheckDigits.Net, I want to be able to perform a Luhn validation on a string value that contains characters that should be ignored. For example, a Canadian Social Insurance Number with format characters that separate the three groups of digits (200-320-133).

## Requirements

* Define ICheckDigitMask, an interface that defines if a character at a specific character position should be processed or ignored.
* ICheckDigitMask should define IncludeCharacter method that has an integer parameter that identifies the character position to check and returns TRUE if the character should be processed or FALSE if the character should be ignored.
* ICheckDigitMask should define ExcludeCharacter method that has an integer parameter that identifies the character position to check and returns TRUE if the character should be ignored or FALSE if the character should be processed.
* Define IMaskedCheckDigitAlgorithm, derived from ICheckDigitAlgorithm that adds an overload of the ValidateMethod that accepts an ICheckDigitMask and that uses the mask to include or exclude characters while calculating the Luhn check digit.
* Update LuhnAlgorithm to implement IMaskedCheckDigitAlgorithm. The overloaded Validate method should perform the check digit calculation in situ, and not require the allocation of a copy of the original value without format characters.

## Definition of DONE

1. New interfaces, ICheckDigitMask and IMaskedCheckDigitAlgorithm
2. LuhnAlgorithm updated to impliment IMaskedCheckDigitAlgorithm
3. Full unit tests
4. README updates
5. Performance benchmarks
