### PR TITLE
S0044 verhoeff check digit attribute

### DIFF
--- a/AnnotationsDemoApi/HttpFiles/Verhoeff.http
+++ b/AnnotationsDemoApi/HttpFiles/Verhoeff.http
@@ -1,0 +1,55 @@
+@AnnotationsDemoApi_HostAddress = http://localhost:5079
+
+### [VerhoeffCheckDigit] Valid Verhoeff Card Number - Should return 200 OK
+POST {{AnnotationsDemoApi_HostAddress}}/verhoeff
+Content-Type: application/json
+
+{
+  "aadhaarIdNumber": "84736430954837284567892"
+}
+
+
+### [VerhoeffCheckDigit] Invalid Verhoeff Card Number - Should return 400 Bad Request
+POST {{AnnotationsDemoApi_HostAddress}}/verhoeff
+Content-Type: application/json
+
+{
+  "aadhaarIdNumber": "112255445566778899009"
+}
+
+### [VerhoeffCheckDigit(ErrorMessage =...)] Valid Verhoeff Card Number - Should return 200 OK
+POST {{AnnotationsDemoApi_HostAddress}}/verhoeffmessage
+Content-Type: application/json
+
+{
+  "aadhaarIdNumber": "84736430954837284567892"
+}
+
+
+### [VerhoeffCheckDigit(ErrorMessage =...)] Invalid Verhoeff Card Number - Should return 400 Bad Request
+POST {{AnnotationsDemoApi_HostAddress}}/verhoeffmessage
+Content-Type: application/json
+
+{
+  "aadhaarIdNumber": "112255445566778899009"
+}
+
+
+### [VerhoeffCheckDigit(ErrorMessageResourceName =...)] Valid Verhoeff Card Number - Should return 200 OK
+POST {{AnnotationsDemoApi_HostAddress}}/verhoeffglobal
+Content-Type: application/json
+Accept-Language: es-ES
+
+{
+  "aadhaarIdNumber": "84736430954837284567892"
+}
+
+
+### [VerhoeffCheckDigit(ErrorMessageResourceName =...)] Invalid Verhoeff Card Number - Should return 400 Bad Request and localized message
+POST {{AnnotationsDemoApi_HostAddress}}/verhoeffglobal
+Content-Type: application/json
+Accept-Language: es-ES
+
+{
+  "aadhaarIdNumber": "112255445566778899009"
+}

--- a/AnnotationsDemoApi/Models/VerhoeffRequest.cs
+++ b/AnnotationsDemoApi/Models/VerhoeffRequest.cs
@@ -1,0 +1,21 @@
+﻿// Ignore Spelling: Aadhaar, Verhoeff
+
+namespace AnnotationsDemoApi.Models;
+
+public class VerhoeffRequest
+{
+   [VerhoeffCheckDigit]
+   public String AadhaarIdNumber { get; set; } = null!;
+}
+
+public class VerhoeffRequestCustomErrorMessage
+{
+   [VerhoeffCheckDigit(ErrorMessage = "Aadhaar number check digit error")]
+   public String AadhaarIdNumber { get; set; } = null!;
+}
+
+public class VerhoeffRequestGlobalizedErrorMessage
+{
+   [VerhoeffCheckDigit(ErrorMessageResourceName = "InvalidAadhaarNumber", ErrorMessageResourceType = typeof(Resources.SharedStrings))]
+   public String AadhaarIdNumber { get; set; } = null!;
+}

--- a/AnnotationsDemoApi/Program.cs
+++ b/AnnotationsDemoApi/Program.cs
@@ -1,5 +1,3 @@
-// Ignore Spelling: Luhn
-
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
@@ -35,11 +33,8 @@ app.MapPost("/luhnmessage",
    (LuhnPaymentRequestCustomErrorMessage request) => Results.Ok("Credit card number is valid"));
 
 app.MapPost("/luhnglobal",
-   (LuhnPaymentRequestGlobalizedErrorMessage request, IStringLocalizer<SharedStrings> localizer) => 
-   {
-      var response = localizer["ValidRequest"];
-      return Results.Ok(response.ToString());
-   });
+   (LuhnPaymentRequestGlobalizedErrorMessage request, IStringLocalizer<SharedStrings> localizer)
+   => Results.Ok(localizer["ValidRequest"].ToString()));
 
 // Modulus 10_13 Check Digit Endpoints
 app.MapPost("/modulus1013",
@@ -49,11 +44,8 @@ app.MapPost("/modulus1013message",
    (Modulus10_13ItemDetailsCustomErrorMessage request) => Results.Ok("UPC code is valid"));
 
 app.MapPost("/modulus1013global",
-   (Modulus10_13ItemDetailsGlobalizedErrorMessage request, IStringLocalizer<SharedStrings> localizer) =>
-   {
-      var response = localizer["ValidRequest"];
-      return Results.Ok(response.ToString());
-   });
+   (Modulus10_13ItemDetailsGlobalizedErrorMessage request, IStringLocalizer<SharedStrings> localizer)
+   => Results.Ok(localizer["ValidRequest"].ToString()));
 
 // Modulus 11 Check Digit Endpoints
 app.MapPost("/modulus11",
@@ -63,11 +55,19 @@ app.MapPost("/modulus11message",
    (Modulus11PublicationCustomErrorMessage request) => Results.Ok("ISBN is valid"));
 
 app.MapPost("/modulus11global",
-   (Modulus11PublicationGlobalizedErrorMessage request, IStringLocalizer<SharedStrings> localizer) =>
-   {
-      var response = localizer["ValidRequest"];
-      return Results.Ok(response.ToString());
-   });
+   (Modulus11PublicationGlobalizedErrorMessage request, IStringLocalizer<SharedStrings> localizer)
+   => Results.Ok(localizer["ValidRequest"].ToString()));
+
+// Verhoeff Check Digit Endpoints
+app.MapPost("/verhoeff",
+   (VerhoeffRequest request) => Results.Ok("Aadhaar ID number is valid"));
+
+app.MapPost("/verhoeffmessage",
+   (VerhoeffRequestCustomErrorMessage request) => Results.Ok("Aadhaar ID number is valid"));
+
+app.MapPost("/verhoeffglobal",
+   (VerhoeffRequestGlobalizedErrorMessage request, IStringLocalizer<SharedStrings> localizer) 
+   => Results.Ok(localizer["ValidRequest"].ToString()));
 
 app.Run();
 

--- a/AnnotationsDemoApi/Resources/SharedStrings.Designer.cs
+++ b/AnnotationsDemoApi/Resources/SharedStrings.Designer.cs
@@ -61,6 +61,15 @@ namespace AnnotationsDemoApi.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid Aadhaar ID number.
+        /// </summary>
+        public static string InvalidAadhaarNumber {
+            get {
+                return ResourceManager.GetString("InvalidAadhaarNumber", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid card number.
         /// </summary>
         public static string InvalidCardNumber {

--- a/AnnotationsDemoApi/Resources/SharedStrings.de-DE.resx
+++ b/AnnotationsDemoApi/Resources/SharedStrings.de-DE.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="InvalidAadhaarNumber" xml:space="preserve">
+    <value>UngültigeAadhaar-Nummer</value>
+  </data>
   <data name="InvalidCardNumber" xml:space="preserve">
     <value>Ungültige Kartennummer</value>
   </data>

--- a/AnnotationsDemoApi/Resources/SharedStrings.en-US.resx
+++ b/AnnotationsDemoApi/Resources/SharedStrings.en-US.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="InvalidAadhaarNumber" xml:space="preserve">
+    <value>Invalid Aadhaar ID number</value>
+  </data>
   <data name="InvalidCardNumber" xml:space="preserve">
     <value>Invalid card number</value>
   </data>

--- a/AnnotationsDemoApi/Resources/SharedStrings.es-ES.resx
+++ b/AnnotationsDemoApi/Resources/SharedStrings.es-ES.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="InvalidAadhaarNumber" xml:space="preserve">
+    <value>Aadhaar no válido</value>
+  </data>
   <data name="InvalidCardNumber" xml:space="preserve">
     <value>Número de tarjeta inválido</value>
   </data>

--- a/AnnotationsDemoApi/Resources/SharedStrings.resx
+++ b/AnnotationsDemoApi/Resources/SharedStrings.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="InvalidAadhaarNumber" xml:space="preserve">
+    <value>Invalid Aadhaar ID number</value>
+  </data>
   <data name="InvalidCardNumber" xml:space="preserve">
     <value>Invalid card number</value>
   </data>

--- a/CheckDigits.Net.DataAnnotations.Tests.Unit/VerhoeffCheckDigitAttributeTests.cs
+++ b/CheckDigits.Net.DataAnnotations.Tests.Unit/VerhoeffCheckDigitAttributeTests.cs
@@ -1,0 +1,178 @@
+﻿// Ignore Spelling: Aadhaar, Verhoeff
+
+namespace CheckDigits.Net.DataAnnotations.Tests.Unit;
+
+public class VerhoeffCheckDigitAttributeTests
+{
+   private const String _customErrorMessage = "Need a valid Aadhaar ID number";
+
+   public class PersonRequest
+   {
+      [VerhoeffCheckDigit]
+      public String AadhaarIdNumber { get; set; } = null!;
+   }
+
+   public class PersonRequestCustomMessage
+   {
+      [VerhoeffCheckDigit(ErrorMessage = _customErrorMessage)]
+      public String AadhaarIdNumber { get; set; } = null!;
+   }
+
+   public class RequiredPersonRequest
+   {
+      [Required, VerhoeffCheckDigit]
+      public String AadhaarIdNumber { get; set; } = null!;
+   }
+
+   public class PersonRequestInvalidType
+   {
+      [VerhoeffCheckDigit]
+      public Int32 AadhaarIdNumber { get; set; }
+   }
+
+   #region Validate Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [InlineData("2363")]                      // Worked example from Wikipedia
+   [InlineData("123451")]                    // Test data from https://rosettacode.org/wiki/Verhoeff_algorithm
+   [InlineData("84736430954837284567892")]   // Test data from https://codereview.stackexchange.com/questions/221229/verhoeff-check-digit-algorithm
+   public void VerhoeffCheckDigitAttribute_Validate_ShouldReturnSuccess_WhenValueHasValidVerhoeffCheckDigit(String value)
+   {
+      // Arrange.
+      var request = new PersonRequest
+      {
+         AadhaarIdNumber = value
+      };
+
+      // Act.
+      var results = Utility.ValidateModel(request);
+
+      // Assert.
+      results.Should().BeEmpty();
+   }
+
+   [Fact]
+   public void VerhoeffCheckDigitAttribute_Validate_ShouldReturnSuccess_WhenNonRequiredValueIsNull()
+   {
+      // Arrange.
+      var request = new PersonRequest();
+
+      // Act.
+      var results = Utility.ValidateModel(request);
+
+      // Assert.
+      request.AadhaarIdNumber.Should().BeNull();
+      results.Should().BeEmpty();
+   }
+
+   [Fact]
+   public void VerhoeffCheckDigitAttribute_Validate_ShouldReturnSuccess_WhenNonRequiredValueIsEmpty()
+   {
+      // Arrange.
+      var request = new PersonRequest
+      {
+         AadhaarIdNumber = String.Empty
+      };
+
+      // Act.
+      var results = Utility.ValidateModel(request);
+
+      // Assert.
+      results.Should().BeEmpty();
+   }
+
+   [Fact]
+   public void VerhoeffCheckDigitAttribute_Validate_ShouldReturnFailure_WhenValueIsNotTypeString()
+   {
+      // Arrange.
+      var item = new PersonRequestInvalidType
+      {
+         AadhaarIdNumber = 123456
+      };
+      var expectedMessage = String.Format(Messages.InvalidPropertyType, nameof(item.AadhaarIdNumber));
+
+      // Act.
+      var results = Utility.ValidateModel(item);
+
+      // Assert.
+      results.Should().HaveCount(1);
+      results[0].ErrorMessage.Should().Be(expectedMessage);
+   }
+
+   [Fact]
+   public void VerhoeffCheckDigitAttribute_Validate_ShouldReturnFailure_WhenRequiredValueIsNull()
+   {
+      // Arrange.
+      var request = new RequiredPersonRequest();
+      var expectedMessage = "The AadhaarIdNumber field is required.";
+
+      // Act.
+      var results = Utility.ValidateModel(request);
+
+      // Assert.
+      results.Should().HaveCount(1);
+      results[0].ErrorMessage.Should().Be(expectedMessage);
+   }
+
+   [Fact]
+   public void VerhoeffCheckDigitAttribute_Validate_ShouldReturnFailure_WhenRequiredValueIsEmpty()
+   {
+      // Arrange.
+      var request = new RequiredPersonRequest
+      {
+         AadhaarIdNumber = String.Empty
+      };
+      var expectedMessage = "The AadhaarIdNumber field is required.";
+
+      // Act.
+      var results = Utility.ValidateModel(request);
+
+      // Assert.
+      results.Should().HaveCount(1);
+      results[0].ErrorMessage.Should().Be(expectedMessage);
+   }
+
+   [Theory]
+   [InlineData("84736430459837284567892")]   // Jump transposition error using "84736430954837284567892" as a valid value (954 -> 459)
+   [InlineData("112255445566778899009")]     // Twin error using "112233445566778899009" as a valid value (33 -> 55)
+   public void VerhoeffCheckDigitAttribute_Validate_ShouldReturnFailure_WhenValueHasInvalidVerhoeffCheckDigit(String value)
+   {
+      // Arrange.
+      var request = new PersonRequest
+      {
+         AadhaarIdNumber = value
+      };
+      var expectedMessage = String.Format(Messages.SingleCheckDigitFailure, nameof(request.AadhaarIdNumber));
+
+      // Act.
+      var results = Utility.ValidateModel(request);
+
+      // Assert.
+      results.Should().HaveCount(1);
+      results[0].ErrorMessage.Should().Be(expectedMessage);
+   }
+
+   [Theory]
+   [InlineData("84736430459837284567892")]   // Jump transposition error using "84736430954837284567892" as a valid value (954 -> 459)
+   [InlineData("112255445566778899009")]     // Twin error using "112233445566778899009" as a valid value (33 -> 55)
+   public void VerhoeffCheckDigitAttribute_Validate_ShouldReturnFailure_WhenValueHasInvalidVerhoeffCheckDigitAndCustomErrorMessageIsSupplied(String value)
+   {
+      // Arrange.
+      var request = new PersonRequestCustomMessage
+      {
+         AadhaarIdNumber = value
+      };
+      var expectedMessage = _customErrorMessage;
+
+      // Act.
+      var results = Utility.ValidateModel(request);
+
+      // Assert.
+      results.Should().HaveCount(1);
+      results[0].ErrorMessage.Should().Be(expectedMessage);
+   }
+
+   #endregion
+}

--- a/CheckDigits.Net.DataAnnotations/LuhnCheckDigitAttribute.cs
+++ b/CheckDigits.Net.DataAnnotations/LuhnCheckDigitAttribute.cs
@@ -4,7 +4,9 @@ namespace CheckDigits.Net.DataAnnotations;
 
 /// <summary>
 ///   Specifies that a string property or parameter must contain a valid Luhn 
-///   check digit sequence for validation to succeed.
+///   check digit sequence for validation to succeed. Successful validation 
+///   means that the value does not contain any transcription errors capable of
+///   being detected by the Luhn algorithm.
 /// </summary>
 /// <remarks>
 ///   <para>

--- a/CheckDigits.Net.DataAnnotations/Modulus10_13CheckDigitAttribute.cs
+++ b/CheckDigits.Net.DataAnnotations/Modulus10_13CheckDigitAttribute.cs
@@ -4,7 +4,9 @@
 /// <summary>
 ///   Specifies that a string property or parameter must contain a valid 
 ///   Modulus 10 (with weights 1 and 3) check digit sequence for validation to 
-///   succeed.
+///   succeed. Successful validation means that the value does not contain any 
+///   transcription errors capable of being detected by the Modulus10_13 
+///   algorithm.
 /// </summary>
 /// <remarks>
 ///   <para>

--- a/CheckDigits.Net.DataAnnotations/Modulus11CheckDigitAttribute.cs
+++ b/CheckDigits.Net.DataAnnotations/Modulus11CheckDigitAttribute.cs
@@ -2,7 +2,9 @@
 
 /// <summary>
 ///   Specifies that a string property or parameter must contain a valid 
-///   Modulus 11 check digit sequence for validation to succeed.
+///   Modulus 11 check digit sequence for validation to succeed. Successful 
+///   validation means that the value does not contain any transcription errors 
+///   capable of being detected by the Modulus11 algorithm.
 /// </summary>
 /// <remarks>
 ///   <para>

--- a/CheckDigits.Net.DataAnnotations/VerhoeffCheckDigitAttribute.cs
+++ b/CheckDigits.Net.DataAnnotations/VerhoeffCheckDigitAttribute.cs
@@ -1,0 +1,44 @@
+﻿// Ignore Spelling: Verhoeff
+
+namespace CheckDigits.Net.DataAnnotations;
+
+/// <summary>
+///   Specifies that a string property or parameter must contain a valid 
+///   Verhoeff check digit sequence for validation to succeed. Successful 
+///   validation means that the value does not contain any transcription errors 
+///   capable of being detected by the Verhoeff algorithm.
+/// </summary>
+/// <remarks>
+///   <para>
+///      Use this attribute to enforce that a value conforms to the Verhoeff 
+///      algorithm. The validation passes if the value is null or an empty 
+///      string or if the value contains a valid Verhoeff check digit in the 
+///      right-most character position.
+///   </para>
+///   <para>
+///      If applied to a non-empty string property, validation will fail under 
+///      the following conditions:
+///      <list type="bullet">
+///         <item>
+///            The value is less than two characters in length, which is the 
+///            minimum required for a valid Verhoeff check digit sequence.
+///         </item>
+///         <item>
+///            The value contains non-numeric characters, as the Verhoeff 
+///            algorithm only processes numeric digits.
+///         </item>
+///         <item>
+///            The value does not contain a valid Verhoeff check digit in the 
+///            right-most character position.
+///         </item>
+///      </list> 
+///   </para>
+///   <para>
+///      Validation will also fail if the attribute is applied to a non-string
+///      property.
+///   </para>
+/// </remarks>
+public class VerhoeffCheckDigitAttribute()
+   : BaseCheckDigitAttribute(Algorithms.Verhoeff, Messages.SingleCheckDigitFailure)
+{
+}

--- a/README_Annotations.md
+++ b/README_Annotations.md
@@ -15,6 +15,7 @@ to the CheckDigits.Net [README file]( https://github.com/KnowledgeForwardSolutio
     * [LuhnCheckDigitAttribute](#luhncheckdigitattribute)
     * [Modulus10_13CheckDigitAttribute](#modulus10_13checkdigitattribute)
     * [Modulus11CheckDigitAttribute](#modulus11checkdigitattribute)
+    * [VerhoeffCheckDigitAttribute](#verhoeffcheckdigitattribute)
 
 
 ## Using CheckDigits.Net.Annotations
@@ -97,6 +98,7 @@ The `LuhnCheckDigitAttribute` will return validation errors for the following co
 - The value does not contain a valid Luhn check digit.
 - The value contains non-ASCII digit characters.
 - The value is shorter than two characters (i.e., it cannot contain a check digit).
+- The value being validated is not of type `string`.
 
 ### Modulus10_13CheckDigitAttribute
 
@@ -108,6 +110,7 @@ The `Modulus10_13CheckDigitAttribute` will return validation errors for the foll
 - The value does not contain a valid Modulus10_13 check digit.
 - The value contains non-ASCII digit characters.
 - The value is shorter than two characters (i.e., it cannot contain a check digit).
+- The value being validated is not of type `string`.
 
 ### Modulus11CheckDigitAttribute
 
@@ -126,3 +129,19 @@ The `Modulus11CheckDigitAttribute` will return validation errors for the followi
 - The value contains characters other than ASCII digits or 'X'.
 - The value is shorter than two characters (i.e., it cannot contain a check digit).
 - The value is longer than 10 characters (the maximum length supported by the Modulus11 algorithm).
+- The value being validated is not of type `string`.
+
+### VerhoeffCheckDigitAttribute
+
+The `VerhoeffCheckDigitAttribute` validates that a string property conforms to the
+Verhoeff check digit algorithm. The Verhoeff algorithm was the first algorithm using 
+a single decimal check digit that was capable of detecting all single digit 
+transcription errors and all two digit transposition errors. It is used in a 
+variety of applications including the Aadhaar identification number in India.
+
+The `VerhoeffCheckDigitAttribute` will return validation errors for the following conditions:
+- The value does not contain a valid Verhoeff check digit.
+- The value contains non-ASCII digit characters.
+- The value is shorter than two characters (i.e., it cannot contain a check digit).
+- The value being validated is not of type `string`.
+


### PR DESCRIPTION
# S0044: Verhoeff Check Digit Data Annotation

## Story
**As a** .NET developer  
**I want** a reusable C# data annotation that validates values using the Verhoeff check digit algorithm via **CheckDigits.Net**  
**So that** I can declaratively enforce check digit validation on my model properties without duplicating validation logic.

## Background
Identifiers often include a check digit to ensure data integrity. Implementing check digit logic repeatedly across applications leads to duplication and inconsistencies. A custom data annotation backed by **CheckDigits.Net** enables consistent, maintainable validation using standard .NET validation mechanisms.

## Acceptance Criteria
- The annotation is implemented as a custom attribute derived from `System.ComponentModel.DataAnnotations.ValidationAttribute`.
- The annotation uses **CheckDigits.Net** to validate values according to the Verhoeff algorithm.
- The annotation can be applied to `string` model properties.
- Validation succeeds when the value is valid per the Verhoeff algorithm.
- Validation fails when the value does not pass the Verhoeff check.
- Validation succeeds when the value is `null` or empty and the field is not marked as required.
- A default error message is provided (e.g., *“The field {0} has an invalid Verhoeff check digit*).
- The error message can be customized using the `ErrorMessage` property.
- New annotation to exist in CheckDigits.Net.DataAnnotations namespace.
- New annotation named VerhoeffCheckDigit

## Definition of Done
- The annotation is usable in standard .NET model validation (e.g., ASP.NET Core MVC / Web API).
- Validation errors appear in model state and are returned in API responses where applicable.
- Unit tests exist for valid, invalid, and edge-case inputs.
- The implementation has no direct dependency on application-specific code.
- README updates

## Out of Scope
- Client-side validation.
- Generating or calculating Verhoeff check digits (validation only).
- Support for non-Verhoeff check digit algorithms.

## Example Usage
```csharp
public class Foo
{
    [VerhoeffCheckDigit]
    public string Bar { get; set; }
}