### PR TITLE
S0047 modulus10 1 check digit attribute

### DIFF
--- a/AnnotationsDemoApi/HttpFiles/Modulus10_1.http
+++ b/AnnotationsDemoApi/HttpFiles/Modulus10_1.http
@@ -1,0 +1,55 @@
+@AnnotationsDemoApi_HostAddress = http://localhost:5079
+
+### [Modulus10_1CheckDigit] Valid CAS Registry Number - Should return 200 OK
+POST {{AnnotationsDemoApi_HostAddress}}/modulus101
+Content-Type: application/json
+
+{
+  "casNumber": "7732185"
+}
+
+
+### [Modulus10_1CheckDigit] Invalid CAS Registry Number - Should return 400 Bad Request
+POST {{AnnotationsDemoApi_HostAddress}}/modulus101
+Content-Type: application/json
+
+{
+  "casNumber": "28827554"
+}
+
+### [Modulus10_1CheckDigit(ErrorMessage =...)] Valid CAS Registry Number - Should return 200 OK
+POST {{AnnotationsDemoApi_HostAddress}}/modulus101message
+Content-Type: application/json
+
+{
+  "casNumber": "7732185"
+}
+
+
+### [Modulus10_1CheckDigit(ErrorMessage =...)] Invalid CAS Registry Number - Should return 400 Bad Request
+POST {{AnnotationsDemoApi_HostAddress}}/modulus101message
+Content-Type: application/json
+
+{
+  "casNumber": "28827554"
+}
+
+
+### [Modulus10_1CheckDigit(ErrorMessageResourceName =...)] Valid CAS Registry Number - Should return 200 OK
+POST {{AnnotationsDemoApi_HostAddress}}/modulus101global
+Content-Type: application/json
+Accept-Language: de-DE
+
+{
+  "casNumber": "7732185"
+}
+
+
+### [Modulus10_1CheckDigit(ErrorMessageResourceName =...)] Invalid CAS Registry Number - Should return 400 Bad Request and localized message
+POST {{AnnotationsDemoApi_HostAddress}}/modulus101global
+Content-Type: application/json
+Accept-Language: de-DE
+
+{
+  "casNumber": "28827554"
+}

--- a/AnnotationsDemoApi/Models/Modulus10_1Request.cs
+++ b/AnnotationsDemoApi/Models/Modulus10_1Request.cs
@@ -1,0 +1,21 @@
+﻿// Ignore Spelling: Cas
+
+namespace AnnotationsDemoApi.Models;
+
+public class Modulus10_1Request
+{
+   [Modulus10_1CheckDigit]
+   public String CasNumber { get; set; } = null!;
+}
+
+public class Modulus10_1RequestCustomErrorMessage
+{
+   [Modulus10_1CheckDigit(ErrorMessage = "CAS Registry Number check digit error")]
+   public String CasNumber { get; set; } = null!;
+}
+
+public class Modulus10_1RequestGlobalizedErrorMessage
+{
+   [Modulus10_1CheckDigit(ErrorMessageResourceName = "InvalidIsbn10", ErrorMessageResourceType = typeof(Resources.SharedStrings))]
+   public String CasNumber { get; set; } = null!;
+}

--- a/AnnotationsDemoApi/Program.cs
+++ b/AnnotationsDemoApi/Program.cs
@@ -69,6 +69,17 @@ app.MapPost("/modulus1013global",
    (Modulus10_13RequestGlobalizedErrorMessage request, IStringLocalizer<SharedStrings> localizer)
    => Results.Ok(localizer["ValidRequest"].ToString()));
 
+// Modulus 10_1 Check Digit Endpoints
+app.MapPost("/modulus101",
+   (Modulus10_1Request request) => Results.Ok("CAS Registry Number is valid"));
+
+app.MapPost("/modulus101message",
+   (Modulus10_1RequestCustomErrorMessage request) => Results.Ok("CAS Registry Number is valid"));
+
+app.MapPost("/modulus101global",
+   (Modulus10_1RequestGlobalizedErrorMessage request, IStringLocalizer<SharedStrings> localizer)
+      => Results.Ok(localizer["ValidRequest"].ToString()));
+
 // Modulus 11 Check Digit Endpoints
 app.MapPost("/modulus11",
    (Modulus11Request request) => Results.Ok("ISBN is valid"));

--- a/AnnotationsDemoApi/Resources/SharedStrings.Designer.cs
+++ b/AnnotationsDemoApi/Resources/SharedStrings.Designer.cs
@@ -79,6 +79,15 @@ namespace AnnotationsDemoApi.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid CAS Registry Number.
+        /// </summary>
+        public static string InvalidCasNumber {
+            get {
+                return ResourceManager.GetString("InvalidCasNumber", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid ISBN-10.
         /// </summary>
         public static string InvalidIsbn10 {

--- a/AnnotationsDemoApi/Resources/SharedStrings.de-DE.resx
+++ b/AnnotationsDemoApi/Resources/SharedStrings.de-DE.resx
@@ -123,6 +123,9 @@
   <data name="InvalidCardNumber" xml:space="preserve">
     <value>Ungültige Kartennummer</value>
   </data>
+  <data name="InvalidCasNumber" xml:space="preserve">
+    <value>Ungültige CAS-Nummer</value>
+  </data>
   <data name="InvalidIsbn10" xml:space="preserve">
     <value>Ungültige ISBN-10-Nummer</value>
   </data>

--- a/AnnotationsDemoApi/Resources/SharedStrings.en-US.resx
+++ b/AnnotationsDemoApi/Resources/SharedStrings.en-US.resx
@@ -123,6 +123,9 @@
   <data name="InvalidCardNumber" xml:space="preserve">
     <value>Invalid card number</value>
   </data>
+  <data name="InvalidCasNumber" xml:space="preserve">
+    <value>Invalid CAS Registry Number</value>
+  </data>
   <data name="InvalidIsbn10" xml:space="preserve">
     <value>Invalid ISBN-10</value>
   </data>

--- a/AnnotationsDemoApi/Resources/SharedStrings.es-ES.resx
+++ b/AnnotationsDemoApi/Resources/SharedStrings.es-ES.resx
@@ -123,6 +123,9 @@
   <data name="InvalidCardNumber" xml:space="preserve">
     <value>Número de tarjeta inválido</value>
   </data>
+  <data name="InvalidCasNumber" xml:space="preserve">
+    <value>CAS Number no válido</value>
+  </data>
   <data name="InvalidIsbn10" xml:space="preserve">
     <value>USBN-10 no válido</value>
   </data>

--- a/AnnotationsDemoApi/Resources/SharedStrings.resx
+++ b/AnnotationsDemoApi/Resources/SharedStrings.resx
@@ -123,6 +123,9 @@
   <data name="InvalidCardNumber" xml:space="preserve">
     <value>Invalid card number</value>
   </data>
+  <data name="InvalidCasNumber" xml:space="preserve">
+    <value>Invalid CAS Registry Number</value>
+  </data>
   <data name="InvalidIsbn10" xml:space="preserve">
     <value>Invalid ISBN-10</value>
   </data>

--- a/CheckDigits.Net.DataAnnotations.Tests.Unit/Modulus10_1CheckDigitAttributeTests.cs
+++ b/CheckDigits.Net.DataAnnotations.Tests.Unit/Modulus10_1CheckDigitAttributeTests.cs
@@ -1,0 +1,179 @@
+﻿// Ignore Spelling: Cas
+
+namespace CheckDigits.Net.DataAnnotations.Tests.Unit;
+
+public class Modulus10_1CheckDigitAttributeTests
+{
+   private const String _customErrorMessage = "Need a valid CAS Registry Number";
+
+   public class Modulus10_1Request
+   {
+      [Modulus10_1CheckDigitAttribute]
+      public String CasNumber { get; set; } = null!;
+   }
+
+   public class Modulus10_1RequestCustomMessage
+   {
+      [Modulus10_1CheckDigitAttribute(ErrorMessage = _customErrorMessage)]
+      public String CasNumber { get; set; } = null!;
+   }
+
+   public class Modulus10_1RequestRequiredField
+   {
+      [Required, Modulus10_1CheckDigitAttribute]
+      public String CasNumber { get; set; } = null!;
+   }
+
+   public class Modulus10_1RequestInvalidType
+   {
+      [Modulus10_1CheckDigitAttribute]
+      public Int32 CasNumber { get; set; }
+   }
+
+   #region Validate Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [InlineData("7732185")]       // Worked example of CAS Registry Number from Wikipedia https://en.wikipedia.org/wiki/CAS_Registry_Number
+   [InlineData("58082")]         // CAS Registry Number for caffeine
+   public void Modulus10_1CheckDigitAttribute_Validate_ShouldReturnSuccess_WhenValueHasValidModulus10_1CheckDigit(String cas)
+   {
+      // Arrange.
+      var request = new Modulus10_1Request
+      {
+         CasNumber = cas
+      };
+
+      // Act.
+      var results = Utility.ValidateModel(request);
+
+      // Assert.
+      results.Should().BeEmpty();
+   }
+
+   [Fact]
+   public void Modulus10_1CheckDigitAttribute_Validate_ShouldReturnSuccess_WhenNonRequiredValueIsNull()
+   {
+      // Arrange.
+      var request = new Modulus10_1Request();
+
+      // Act.
+      var results = Utility.ValidateModel(request);
+
+      // Assert.
+      request.CasNumber.Should().BeNull();
+      results.Should().BeEmpty();
+   }
+
+   [Fact]
+   public void Modulus10_1CheckDigitAttribute_Validate_ShouldReturnSuccess_WhenNonRequiredValueIsEmpty()
+   {
+      // Arrange.
+      var request = new Modulus10_1Request
+      {
+         CasNumber = String.Empty
+      };
+
+      // Act.
+      var results = Utility.ValidateModel(request);
+
+      // Assert.
+      results.Should().BeEmpty();
+   }
+
+   [Fact]
+   public void Modulus10_1CheckDigitAttribute_Validate_ShouldReturnFailure_WhenValueIsNotTypeString()
+   {
+      // Arrange.
+      var item = new Modulus10_1RequestInvalidType
+      {
+         CasNumber = 123456
+      };
+      var expectedMessage = String.Format(Messages.InvalidPropertyType, nameof(item.CasNumber));
+
+      // Act.
+      var results = Utility.ValidateModel(item);
+
+      // Assert.
+      results.Should().HaveCount(1);
+      results[0].ErrorMessage.Should().Be(expectedMessage);
+   }
+
+   [Fact]
+   public void Modulus10_1CheckDigitAttribute_Validate_ShouldReturnFailure_WhenRequiredValueIsNull()
+   {
+      // Arrange.
+      var request = new Modulus10_1RequestRequiredField();
+      var expectedMessage = "The CasNumber field is required.";
+
+      // Act.
+      var results = Utility.ValidateModel(request);
+
+      // Assert.
+      results.Should().HaveCount(1);
+      results[0].ErrorMessage.Should().Be(expectedMessage);
+   }
+
+   [Fact]
+   public void Modulus10_1CheckDigitAttribute_Validate_ShouldReturnFailure_WhenRequiredValueIsEmpty()
+   {
+      // Arrange.
+      var request = new Modulus10_1RequestRequiredField
+      {
+         CasNumber = String.Empty
+      };
+      var expectedMessage = "The CasNumber field is required.";
+
+      // Act.
+      var results = Utility.ValidateModel(request);
+
+      // Assert.
+      results.Should().HaveCount(1);
+      results[0].ErrorMessage.Should().Be(expectedMessage);
+   }
+
+   [Theory]
+   [InlineData("7742185")]       // CAS Registry Number 7732185 with single digit transcription error 3 -> 4
+   [InlineData("50882")]         // CAS Registry Number 58082 with two digit transposition error 80 -> 08
+   [InlineData("28827554")]      // CAS Registry Number 28728554 with jump transposition 728 -> 827
+   public void Modulus10_1CheckDigitAttribute_Validate_ShouldReturnFailure_WhenValueHasInvalidModulus10_1CheckDigit(String cas)
+   {
+      // Arrange.
+      var request = new Modulus10_1Request
+      {
+         CasNumber = cas
+      };
+      var expectedMessage = String.Format(Messages.SingleCheckDigitFailure, nameof(request.CasNumber));
+
+      // Act.
+      var results = Utility.ValidateModel(request);
+
+      // Assert.
+      results.Should().HaveCount(1);
+      results[0].ErrorMessage.Should().Be(expectedMessage);
+   }
+
+   [Theory]
+   [InlineData("7742185")]       // CAS Registry Number 7732185 with single digit transcription error 3 -> 4
+   [InlineData("50882")]         // CAS Registry Number 58082 with two digit transposition error 80 -> 08
+   [InlineData("28827554")]      // CAS Registry Number 28728554 with jump transposition 728 -> 827
+   public void Modulus10_1CheckDigitAttribute_Validate_ShouldReturnFailure_WhenValueHasInvalidModulus10_1CheckDigitAndCustomErrorMessageIsSupplied(String cas)
+   {
+      // Arrange.
+      var request = new Modulus10_1RequestCustomMessage
+      {
+         CasNumber = cas
+      };
+      var expectedMessage = _customErrorMessage;
+
+      // Act.
+      var results = Utility.ValidateModel(request);
+
+      // Assert.
+      results.Should().HaveCount(1);
+      results[0].ErrorMessage.Should().Be(expectedMessage);
+   }
+
+   #endregion
+}

--- a/CheckDigits.Net.DataAnnotations/Modulus10_13CheckDigitAttribute.cs
+++ b/CheckDigits.Net.DataAnnotations/Modulus10_13CheckDigitAttribute.cs
@@ -1,20 +1,19 @@
 ﻿namespace CheckDigits.Net.DataAnnotations;
 
-
 /// <summary>
 ///   Specifies that a string property or parameter must contain a valid 
-///   Modulus 10 (with weights 1 and 3) check digit sequence for validation to 
-///   succeed. Successful validation means that the value does not contain any 
-///   transcription errors capable of being detected by the Modulus10_13 
-///   algorithm.
+///   Modulus 10 check digit calculated with alternating weights of 1 and 3 for 
+///   validation to succeed. Successful validation means that the value does not 
+///   contain any transcription errors capable of being detected by the 
+///   Modulus10_13 algorithm.
 /// </summary>
 /// <remarks>
 ///   <para>
 ///      Use this attribute to enforce that a value, such as a GTIN code, EAN 
-///      code UPC code or other identifier conforms to the Modulus 10 (with 
-///      weights 1 and 3) algorithm. The validation passes if the value is null 
-///      or an empty string or if the value contains a valid Modulus 10 (with 
-///      weights 1 and 3) check digit in the right-most character position.
+///      code UPC code or other identifier has a valid Modulus 10 (weights 1 and 
+///      3) check digit. The validation passes if the value is null or an empty 
+///      string or if the value contains a valid check digit in the right-most 
+///      character position.
 ///   </para>
 ///   <para>
 ///      If applied to a non-empty string property, validation will fail under 

--- a/CheckDigits.Net.DataAnnotations/Modulus10_1CheckDigitAttribute.cs
+++ b/CheckDigits.Net.DataAnnotations/Modulus10_1CheckDigitAttribute.cs
@@ -1,0 +1,48 @@
+﻿namespace CheckDigits.Net.DataAnnotations;
+
+/// <summary>
+///   Specifies that a string property or parameter must contain a valid 
+///   Modulus 10 check digit calculated with progressive weights starting with 1
+///   for validation to succeed. Successful validation means that the value does 
+///   not contain any transcription errors capable of being detected by the 
+///   Modulus10_1 algorithm.
+/// </summary>
+/// <remarks>
+///   <para>
+///      Use this attribute to enforce that a value, such as Chemical Abstracts
+///      Serivce (CAS) Registry Number, or other identifier conforms to the 
+///      Modulus10_1 algorithm. The validation passes if the 
+///      value is null or an empty string or if the value contains a valid 
+///      Modulus 11 check digit in the right-most character position.
+///   </para>
+///   <para>
+///      If applied to a non-empty string property, validation will fail under 
+///      the following conditions:
+///      <list type="bullet">
+///         <item>
+///            The value is less than two characters in length, which is the 
+///            minimum required for a valid Modulus10_1 check digit sequence.
+///         </item>
+///         <item>
+///            The value is greater than ten characters in length, which is the 
+///            maximum supported for a valid Modulus10_1 check digit sequence.
+///         </item>
+///         <item>
+///            The value contains non-numeric characters, as the Modulus10_1 
+///            algorithm only processes numeric digits.
+///         </item>
+///         <item>
+///            The value does not contain a valid Modulus10_1 check digit in the 
+///            right-most character position.
+///         </item>
+///      </list> 
+///   </para>
+///   <para>
+///      Validation will also fail if the attribute is applied to a non-string
+///      property.
+///   </para>
+/// </remarks>
+public class Modulus10_1CheckDigitAttribute()
+   : BaseCheckDigitAttribute(Algorithms.Modulus10_1, Messages.SingleCheckDigitFailure)
+{
+}

--- a/README_Annotations.md
+++ b/README_Annotations.md
@@ -130,9 +130,10 @@ The `LuhnCheckDigitAttribute` will return validation errors for the following co
 
 ### Modulus10_13CheckDigitAttribute
 
-The `Modulus10_13CheckDigitAttribute` validates that a string property conforms 
-to the Modulus10 (with weights 1 and 3) check digit algorithm. This is commonly 
-used for global item numbers such as GTIN, EAN and UPC codes.
+The `Modulus10_13CheckDigitAttribute` validates that a string property contains 
+a valid modulus 10 check digit computed using alternating weights of 1 and 3. 
+This algorithm is commonly used for global item numbers such as GTIN, EAN and 
+UPC codes.
 
 The `Modulus10_13CheckDigitAttribute` will return validation errors for the following conditions:
 - The value does not contain a valid Modulus10_13 check digit.
@@ -142,10 +143,10 @@ The `Modulus10_13CheckDigitAttribute` will return validation errors for the foll
 
 ### Modulus10_1CheckDigitAttribute
 
-The `Modulus10_1CheckDigitAttribute` validates that a string property conforms 
-to the Modulus10 check digit algorithm using progressive weights starting with 1. 
-One prominent use of this algorithm is by the Chemical Abstract Service for CAS 
-numbers.
+The `Modulus10_1CheckDigitAttribute` validates that a string property contains a 
+valid modulus 10 check digit computed using progressive weights starting with 1. 
+One prominent use of this algorithm is by the Chemical Abstracts Service (CAS) 
+Registry Number.
 
 The `Modulus10_1CheckDigitAttribute` will return validation errors for the following conditions:
 - The value does not contain a valid Modulus10_1 check digit.

--- a/README_Annotations.md
+++ b/README_Annotations.md
@@ -16,6 +16,7 @@ to the CheckDigits.Net [README file]( https://github.com/KnowledgeForwardSolutio
     * [DammCheckDigitAttribute](#dammcheckdigitattribute)
     * [LuhnCheckDigitAttribute](#luhncheckdigitattribute)
     * [Modulus10_13CheckDigitAttribute](#modulus10_13checkdigitattribute)
+    * [Modulus1_1CheckDigitAttribute](#modulus10_1checkdigitattribute)
     * [Modulus11CheckDigitAttribute](#modulus11checkdigitattribute)
     * [VerhoeffCheckDigitAttribute](#verhoeffcheckdigitattribute)
 
@@ -137,6 +138,20 @@ The `Modulus10_13CheckDigitAttribute` will return validation errors for the foll
 - The value does not contain a valid Modulus10_13 check digit.
 - The value contains non-ASCII digit characters.
 - The value is shorter than two characters (i.e., it cannot contain a check digit).
+- The value being validated is not of type `string`.
+
+### Modulus10_1CheckDigitAttribute
+
+The `Modulus10_1CheckDigitAttribute` validates that a string property conforms 
+to the Modulus10 check digit algorithm using progressive weights starting with 1. 
+One prominent use of this algorithm is by the Chemical Abstract Service for CAS 
+numbers.
+
+The `Modulus10_1CheckDigitAttribute` will return validation errors for the following conditions:
+- The value does not contain a valid Modulus10_1 check digit.
+- The value contains non-ASCII digit characters.
+- The value is shorter than two characters (i.e., it cannot contain a check digit).
+- The value is longer than 10 characters (the maximum length supported by the Modulus10_1 algorithm).
 - The value being validated is not of type `string`.
 
 ### Modulus11CheckDigitAttribute


### PR DESCRIPTION
# S0047: Modulus10_1 Check Digit Data Annotation

## Story
**As a** .NET developer  
**I want** a reusable C# data annotation that validates values using the Modulus10_1 check digit algorithm via **CheckDigits.Net**  
**So that** I can declaratively enforce check digit validation on my model properties without duplicating validation logic.

## Background
Identifiers often include a check digit to ensure data integrity. Implementing check digit logic repeatedly across applications leads to duplication and inconsistencies. A custom data annotation backed by **CheckDigits.Net** enables consistent, maintainable validation using standard .NET validation mechanisms.

## Acceptance Criteria
- The annotation is implemented as a custom attribute derived from `System.ComponentModel.DataAnnotations.ValidationAttribute`.
- The annotation uses **CheckDigits.Net** to validate values according to the Modulus10_1 algorithm.
- The annotation can be applied to `string` model properties.
- Validation succeeds when the value is valid per the Modulus10_1 algorithm.
- Validation fails when the value does not pass the Modulus10_1 check.
- Validation succeeds when the value is `null` or empty and the field is not marked as required.
- A default error message is provided (e.g., *“The field {0} has invalid Modulus10_1 check digits*).
- The error message can be customized using the `ErrorMessage` property.
- New annotation to exist in CheckDigits.Net.DataAnnotations namespace.
- New annotation named Modulus10_1CheckDigit

## Definition of Done
- The annotation is usable in standard .NET model validation (e.g., ASP.NET Core MVC / Web API).
- Validation errors appear in model state and are returned in API responses where applicable.
- Unit tests exist for valid, invalid, and edge-case inputs.
- The implementation has no direct dependency on application-specific code.
- README updates

## Out of Scope
- Client-side validation.
- Generating or calculating Modulus10_1 check digits (validation only).
- Support for non-Modulus10_1 check digit algorithms.

## Example Usage
```csharp
public class Foo
{
    [Modulus10_1CheckDigit]
    public string Bar { get; set; }
}