### PR TITLE
S0048 modulus10 2 check digit attribute

### DIFF
--- a/AnnotationsDemoApi/HttpFiles/Modulus10_2.http
+++ b/AnnotationsDemoApi/HttpFiles/Modulus10_2.http
@@ -1,0 +1,55 @@
+@AnnotationsDemoApi_HostAddress = http://localhost:5079
+
+### [Modulus10_2CheckDigit] Valid IMO Number - Should return 200 OK
+POST {{AnnotationsDemoApi_HostAddress}}/modulus102
+Content-Type: application/json
+
+{
+   "imoNumber": "9074729"
+}
+
+
+### [Modulus10_2CheckDigit] Invalid IMO Number - Should return 400 Bad Request
+POST {{AnnotationsDemoApi_HostAddress}}/modulus102
+Content-Type: application/json
+
+{
+  "imoNumber": "1020569"
+}
+
+### [Modulus10_2CheckDigit(ErrorMessage =...)] Valid IMO Number - Should return 200 OK
+POST {{AnnotationsDemoApi_HostAddress}}/modulus102message
+Content-Type: application/json
+
+{
+  "imoNumber": "9074729"
+}
+
+
+### [Modulus10_2CheckDigit(ErrorMessage =...)] Invalid IMO Number - Should return 400 Bad Request
+POST {{AnnotationsDemoApi_HostAddress}}/modulus102message
+Content-Type: application/json
+
+{
+  "imoNumber": "1020569"
+}
+
+
+### [Modulus10_2CheckDigit(ErrorMessageResourceName =...)] Valid IMO Number - Should return 200 OK
+POST {{AnnotationsDemoApi_HostAddress}}/modulus102global
+Content-Type: application/json
+Accept-Language: de-DE
+
+{
+  "imoNumber": "9074729"
+}
+
+
+### [Modulus10_2CheckDigit(ErrorMessageResourceName =...)] Invalid IMO Number - Should return 400 Bad Request and localized message
+POST {{AnnotationsDemoApi_HostAddress}}/modulus102global
+Content-Type: application/json
+Accept-Language: de-DE
+
+{
+  "imoNumber": "1020569"
+}

--- a/AnnotationsDemoApi/Models/Modulus10_1Request.cs
+++ b/AnnotationsDemoApi/Models/Modulus10_1Request.cs
@@ -16,6 +16,6 @@ public class Modulus10_1RequestCustomErrorMessage
 
 public class Modulus10_1RequestGlobalizedErrorMessage
 {
-   [Modulus10_1CheckDigit(ErrorMessageResourceName = "InvalidIsbn10", ErrorMessageResourceType = typeof(Resources.SharedStrings))]
+   [Modulus10_1CheckDigit(ErrorMessageResourceName = "InvalidCasNumber", ErrorMessageResourceType = typeof(Resources.SharedStrings))]
    public String CasNumber { get; set; } = null!;
 }

--- a/AnnotationsDemoApi/Models/Modulus10_2Request.cs
+++ b/AnnotationsDemoApi/Models/Modulus10_2Request.cs
@@ -1,0 +1,19 @@
+﻿namespace AnnotationsDemoApi.Models;
+
+public class Modulus10_2Request
+{
+   [Modulus10_2CheckDigit]
+   public String ImoNumber { get; set; } = null!;
+}
+
+public class Modulus10_2RequestCustomErrorMessage
+{
+   [Modulus10_2CheckDigit(ErrorMessage = "IMO Number check digit error")]
+   public String ImoNumber { get; set; } = null!;
+}
+
+public class Modulus10_2RequestGlobalizedErrorMessage
+{
+   [Modulus10_2CheckDigit(ErrorMessageResourceName = "InvalidImoNumber", ErrorMessageResourceType = typeof(Resources.SharedStrings))]
+   public String ImoNumber { get; set; } = null!;
+}

--- a/AnnotationsDemoApi/Program.cs
+++ b/AnnotationsDemoApi/Program.cs
@@ -80,6 +80,17 @@ app.MapPost("/modulus101global",
    (Modulus10_1RequestGlobalizedErrorMessage request, IStringLocalizer<SharedStrings> localizer)
       => Results.Ok(localizer["ValidRequest"].ToString()));
 
+// Modulus 10_2 Check Digit Endpoints
+app.MapPost("/modulus102",
+   (Modulus10_2Request request) => Results.Ok("IMO Number is valid"));
+
+app.MapPost("/modulus102message",
+   (Modulus10_2RequestCustomErrorMessage request) => Results.Ok("IMO Number is valid"));
+
+app.MapPost("/modulus102global",
+   (Modulus10_2RequestGlobalizedErrorMessage request, IStringLocalizer<SharedStrings> localizer)
+      => Results.Ok(localizer["ValidRequest"].ToString()));
+
 // Modulus 11 Check Digit Endpoints
 app.MapPost("/modulus11",
    (Modulus11Request request) => Results.Ok("ISBN is valid"));

--- a/AnnotationsDemoApi/Resources/SharedStrings.Designer.cs
+++ b/AnnotationsDemoApi/Resources/SharedStrings.Designer.cs
@@ -88,6 +88,15 @@ namespace AnnotationsDemoApi.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid International Maritime Organization (IMO) Number.
+        /// </summary>
+        public static string InvalidImoNumber {
+            get {
+                return ResourceManager.GetString("InvalidImoNumber", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid ISBN-10.
         /// </summary>
         public static string InvalidIsbn10 {

--- a/AnnotationsDemoApi/Resources/SharedStrings.de-DE.resx
+++ b/AnnotationsDemoApi/Resources/SharedStrings.de-DE.resx
@@ -126,6 +126,9 @@
   <data name="InvalidCasNumber" xml:space="preserve">
     <value>Ungültige CAS-Nummer</value>
   </data>
+  <data name="InvalidImoNumber" xml:space="preserve">
+    <value>Ungültige IMO-Nummer</value>
+  </data>
   <data name="InvalidIsbn10" xml:space="preserve">
     <value>Ungültige ISBN-10-Nummer</value>
   </data>

--- a/AnnotationsDemoApi/Resources/SharedStrings.en-US.resx
+++ b/AnnotationsDemoApi/Resources/SharedStrings.en-US.resx
@@ -126,6 +126,9 @@
   <data name="InvalidCasNumber" xml:space="preserve">
     <value>Invalid CAS Registry Number</value>
   </data>
+  <data name="InvalidImoNumber" xml:space="preserve">
+    <value>Invalid International Maritime Organization (IMO) Number</value>
+  </data>
   <data name="InvalidIsbn10" xml:space="preserve">
     <value>Invalid ISBN-10</value>
   </data>

--- a/AnnotationsDemoApi/Resources/SharedStrings.es-ES.resx
+++ b/AnnotationsDemoApi/Resources/SharedStrings.es-ES.resx
@@ -126,6 +126,9 @@
   <data name="InvalidCasNumber" xml:space="preserve">
     <value>CAS Number no válido</value>
   </data>
+  <data name="InvalidImoNumber" xml:space="preserve">
+    <value>IMO Number no válido</value>
+  </data>
   <data name="InvalidIsbn10" xml:space="preserve">
     <value>USBN-10 no válido</value>
   </data>

--- a/AnnotationsDemoApi/Resources/SharedStrings.resx
+++ b/AnnotationsDemoApi/Resources/SharedStrings.resx
@@ -126,6 +126,9 @@
   <data name="InvalidCasNumber" xml:space="preserve">
     <value>Invalid CAS Registry Number</value>
   </data>
+  <data name="InvalidImoNumber" xml:space="preserve">
+    <value>Invalid International Maritime Organization (IMO) Number</value>
+  </data>
   <data name="InvalidIsbn10" xml:space="preserve">
     <value>Invalid ISBN-10</value>
   </data>

--- a/CheckDigits.Net.DataAnnotations.Tests.Unit/Modulus10_1CheckDigitAttributeTests.cs
+++ b/CheckDigits.Net.DataAnnotations.Tests.Unit/Modulus10_1CheckDigitAttributeTests.cs
@@ -8,25 +8,25 @@ public class Modulus10_1CheckDigitAttributeTests
 
    public class Modulus10_1Request
    {
-      [Modulus10_1CheckDigitAttribute]
+      [Modulus10_1CheckDigit]
       public String CasNumber { get; set; } = null!;
    }
 
    public class Modulus10_1RequestCustomMessage
    {
-      [Modulus10_1CheckDigitAttribute(ErrorMessage = _customErrorMessage)]
+      [Modulus10_1CheckDigit(ErrorMessage = _customErrorMessage)]
       public String CasNumber { get; set; } = null!;
    }
 
    public class Modulus10_1RequestRequiredField
    {
-      [Required, Modulus10_1CheckDigitAttribute]
+      [Required, Modulus10_1CheckDigit]
       public String CasNumber { get; set; } = null!;
    }
 
    public class Modulus10_1RequestInvalidType
    {
-      [Modulus10_1CheckDigitAttribute]
+      [Modulus10_1CheckDigit]
       public Int32 CasNumber { get; set; }
    }
 

--- a/CheckDigits.Net.DataAnnotations.Tests.Unit/Modulus10_2CheckDigitAttributeTests.cs
+++ b/CheckDigits.Net.DataAnnotations.Tests.Unit/Modulus10_2CheckDigitAttributeTests.cs
@@ -1,0 +1,177 @@
+﻿namespace CheckDigits.Net.DataAnnotations.Tests.Unit;
+
+public class Modulus10_2CheckDigitAttributeTests
+{
+   private const String _customErrorMessage = "Need a valid IMO Number";
+
+   public class Modulus10_2Request
+   {
+      [Modulus10_2CheckDigit]
+      public String ImoNumber { get; set; } = null!;
+   }
+
+   public class Modulus10_2RequestCustomMessage
+   {
+      [Modulus10_2CheckDigit(ErrorMessage = _customErrorMessage)]
+      public String ImoNumber { get; set; } = null!;
+   }
+
+   public class Modulus10_2RequestRequiredField
+   {
+      [Required, Modulus10_2CheckDigit]
+      public String ImoNumber { get; set; } = null!;
+   }
+
+   public class Modulus10_2RequestInvalidType
+   {
+      [Modulus10_2CheckDigit]
+      public Int32 ImoNumber { get; set; }
+   }
+
+   #region Validate Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [InlineData("9074729")]       // Worked example of IMO Number from Wikipedia https://en.wikipedia.org/wiki/IMO_number
+   [InlineData("9707792")]       // IMO Number from https://www.marinetraffic.com/en/ais/details/ships/shipid:155821/mmsi:219018788/imo:9707792/vessel:CARRIER#:~:text=CARRIER%20(IMO%3A%209707792)%20is,under%20the%20flag%20of%20Denmark.
+   public void Modulus10_2CheckDigitAttribute_Validate_ShouldReturnSuccess_WhenValueHasValidModulus10_2CheckDigit(String imo)
+   {
+      // Arrange.
+      var request = new Modulus10_2Request
+      {
+         ImoNumber = imo
+      };
+
+      // Act.
+      var results = Utility.ValidateModel(request);
+
+      // Assert.
+      results.Should().BeEmpty();
+   }
+
+   [Fact]
+   public void Modulus10_2CheckDigitAttribute_Validate_ShouldReturnSuccess_WhenNonRequiredValueIsNull()
+   {
+      // Arrange.
+      var request = new Modulus10_2Request();
+
+      // Act.
+      var results = Utility.ValidateModel(request);
+
+      // Assert.
+      request.ImoNumber.Should().BeNull();
+      results.Should().BeEmpty();
+   }
+
+   [Fact]
+   public void Modulus10_2CheckDigitAttribute_Validate_ShouldReturnSuccess_WhenNonRequiredValueIsEmpty()
+   {
+      // Arrange.
+      var request = new Modulus10_2Request
+      {
+         ImoNumber = String.Empty
+      };
+
+      // Act.
+      var results = Utility.ValidateModel(request);
+
+      // Assert.
+      results.Should().BeEmpty();
+   }
+
+   [Fact]
+   public void Modulus10_2CheckDigitAttribute_Validate_ShouldReturnFailure_WhenValueIsNotTypeString()
+   {
+      // Arrange.
+      var item = new Modulus10_2RequestInvalidType
+      {
+         ImoNumber = 123456
+      };
+      var expectedMessage = String.Format(Messages.InvalidPropertyType, nameof(item.ImoNumber));
+
+      // Act.
+      var results = Utility.ValidateModel(item);
+
+      // Assert.
+      results.Should().HaveCount(1);
+      results[0].ErrorMessage.Should().Be(expectedMessage);
+   }
+
+   [Fact]
+   public void Modulus10_2CheckDigitAttribute_Validate_ShouldReturnFailure_WhenRequiredValueIsNull()
+   {
+      // Arrange.
+      var request = new Modulus10_2RequestRequiredField();
+      var expectedMessage = "The ImoNumber field is required.";
+
+      // Act.
+      var results = Utility.ValidateModel(request);
+
+      // Assert.
+      results.Should().HaveCount(1);
+      results[0].ErrorMessage.Should().Be(expectedMessage);
+   }
+
+   [Fact]
+   public void Modulus10_2CheckDigitAttribute_Validate_ShouldReturnFailure_WhenRequiredValueIsEmpty()
+   {
+      // Arrange.
+      var request = new Modulus10_2RequestRequiredField
+      {
+         ImoNumber = String.Empty
+      };
+      var expectedMessage = "The ImoNumber field is required.";
+
+      // Act.
+      var results = Utility.ValidateModel(request);
+
+      // Assert.
+      results.Should().HaveCount(1);
+      results[0].ErrorMessage.Should().Be(expectedMessage);
+   }
+
+   [Theory]
+   [InlineData("1020569")]       // IMO Number 1010569 with single digit transcription error 1 -> 2
+   [InlineData("9704729")]       // IMO Number 9074729 with two digit transposition error 07 -> 70
+   [InlineData("9470729")]       // IMO Number 9074729 with jump transposition 074 -> 470
+   public void Modulus10_2CheckDigitAttribute_Validate_ShouldReturnFailure_WhenValueHasInvalidModulus10_2CheckDigit(String imo)
+   {
+      // Arrange.
+      var request = new Modulus10_2Request
+      {
+         ImoNumber = imo
+      };
+      var expectedMessage = String.Format(Messages.SingleCheckDigitFailure, nameof(request.ImoNumber));
+
+      // Act.
+      var results = Utility.ValidateModel(request);
+
+      // Assert.
+      results.Should().HaveCount(1);
+      results[0].ErrorMessage.Should().Be(expectedMessage);
+   }
+
+   [Theory]
+   [InlineData("1020569")]       // IMO Number 1010569 with single digit transcription error 1 -> 2
+   [InlineData("9704729")]       // IMO Number 9074729 with two digit transposition error 07 -> 70
+   [InlineData("9470729")]       // IMO Number 9074729 with jump transposition 074 -> 470
+   public void Modulus10_2CheckDigitAttribute_Validate_ShouldReturnFailure_WhenValueHasInvalidModulus10_2CheckDigitAndCustomErrorMessageIsSupplied(String imo)
+   {
+      // Arrange.
+      var request = new Modulus10_2RequestCustomMessage
+      {
+         ImoNumber = imo
+      };
+      var expectedMessage = _customErrorMessage;
+
+      // Act.
+      var results = Utility.ValidateModel(request);
+
+      // Assert.
+      results.Should().HaveCount(1);
+      results[0].ErrorMessage.Should().Be(expectedMessage);
+   }
+
+   #endregion
+}

--- a/CheckDigits.Net.DataAnnotations/Modulus10_13CheckDigitAttribute.cs
+++ b/CheckDigits.Net.DataAnnotations/Modulus10_13CheckDigitAttribute.cs
@@ -10,10 +10,10 @@
 /// <remarks>
 ///   <para>
 ///      Use this attribute to enforce that a value, such as a GTIN code, EAN 
-///      code UPC code or other identifier has a valid Modulus 10 (weights 1 and 
-///      3) check digit. The validation passes if the value is null or an empty 
-///      string or if the value contains a valid check digit in the right-most 
-///      character position.
+///      code UPC code or other identifier has a valid Modulus10_13 check digit.
+///      The validation passes if the value is null or an empty string or if the
+///      value contains a valid check digit in the right-most character 
+///      position.
 ///   </para>
 ///   <para>
 ///      If applied to a non-empty string property, validation will fail under 

--- a/CheckDigits.Net.DataAnnotations/Modulus10_2CheckDigitAttribute.cs
+++ b/CheckDigits.Net.DataAnnotations/Modulus10_2CheckDigitAttribute.cs
@@ -2,17 +2,17 @@
 
 /// <summary>
 ///   Specifies that a string property or parameter must contain a valid 
-///   Modulus 10 check digit calculated with progressive weights starting with 1
+///   Modulus 10 check digit calculated with progressive weights starting with 2
 ///   for validation to succeed. Successful validation means that the value does 
 ///   not contain any transcription errors capable of being detected by the 
-///   Modulus10_1 algorithm.
+///   Modulus10_2 algorithm.
 /// </summary>
 /// <remarks>
 ///   <para>
-///      Use this attribute to enforce that a value, such as Chemical Abstracts
-///      Serivce (CAS) Registry Number, or other identifier conforms to the 
-///      Modulus10_1 algorithm. The validation passes if the value is null or an 
-///      empty string or if the value contains a valid Modulus10_1 check digit 
+///      Use this attribute to enforce that a value, such as an International
+///      Maritime Organization (IMO) Number, or other identifier conforms to the 
+///      Modulus10_2 algorithm. The validation passes if the value is null or an 
+///      empty string or if the value contains a valid Modulus10_2 check digit 
 ///      in the right-most character position.
 ///   </para>
 ///   <para>
@@ -21,18 +21,18 @@
 ///      <list type="bullet">
 ///         <item>
 ///            The value is less than two characters in length, which is the 
-///            minimum required for a valid Modulus10_1 check digit sequence.
+///            minimum required for a valid Modulus10_2 check digit sequence.
 ///         </item>
 ///         <item>
 ///            The value is greater than ten characters in length, which is the 
-///            maximum supported for a valid Modulus10_1 check digit sequence.
+///            maximum supported for a valid Modulus10_2 check digit sequence.
 ///         </item>
 ///         <item>
-///            The value contains non-numeric characters, as the Modulus10_1 
+///            The value contains non-numeric characters, as the Modulus10_2 
 ///            algorithm only processes numeric digits.
 ///         </item>
 ///         <item>
-///            The value does not contain a valid Modulus10_1 check digit in the 
+///            The value does not contain a valid Modulus10_2 check digit in the 
 ///            right-most character position.
 ///         </item>
 ///      </list> 
@@ -42,7 +42,7 @@
 ///      property.
 ///   </para>
 /// </remarks>
-public class Modulus10_1CheckDigitAttribute()
-   : BaseCheckDigitAttribute(Algorithms.Modulus10_1, Messages.SingleCheckDigitFailure)
+public class Modulus10_2CheckDigitAttribute()
+   : BaseCheckDigitAttribute(Algorithms.Modulus10_2, Messages.SingleCheckDigitFailure)
 {
 }

--- a/CheckDigits.Net.DataAnnotations/Modulus11CheckDigitAttribute.cs
+++ b/CheckDigits.Net.DataAnnotations/Modulus11CheckDigitAttribute.cs
@@ -9,9 +9,9 @@
 /// <remarks>
 ///   <para>
 ///      Use this attribute to enforce that a value, such as an ISBN-10 or ISSN
-///      conforms to the Modulus 11 algorithm. The validation passes if the 
+///      conforms to the Modulus11 algorithm. The validation passes if the 
 ///      value is null or an empty string or if the value contains a valid 
-///      Modulus 11 check digit in the right-most character position.
+///      Modulus11 check digit in the right-most character position.
 ///   </para>
 ///   <para>
 ///      If applied to a non-empty string property, validation will fail under 

--- a/README_Annotations.md
+++ b/README_Annotations.md
@@ -16,7 +16,8 @@ to the CheckDigits.Net [README file]( https://github.com/KnowledgeForwardSolutio
     * [DammCheckDigitAttribute](#dammcheckdigitattribute)
     * [LuhnCheckDigitAttribute](#luhncheckdigitattribute)
     * [Modulus10_13CheckDigitAttribute](#modulus10_13checkdigitattribute)
-    * [Modulus1_1CheckDigitAttribute](#modulus10_1checkdigitattribute)
+    * [Modulus10_1CheckDigitAttribute](#modulus10_1checkdigitattribute)
+    * [Modulus10_2CheckDigitAttribute](#modulus10_2checkdigitattribute)
     * [Modulus11CheckDigitAttribute](#modulus11checkdigitattribute)
     * [VerhoeffCheckDigitAttribute](#verhoeffcheckdigitattribute)
 
@@ -153,6 +154,20 @@ The `Modulus10_1CheckDigitAttribute` will return validation errors for the follo
 - The value contains non-ASCII digit characters.
 - The value is shorter than two characters (i.e., it cannot contain a check digit).
 - The value is longer than 10 characters (the maximum length supported by the Modulus10_1 algorithm).
+- The value being validated is not of type `string`.
+
+### Modulus10_2CheckDigitAttribute
+
+The `Modulus10_2CheckDigitAttribute` validates that a string property contains a 
+valid modulus 10 check digit computed using progressive weights starting with 2. 
+This algorithm is commonly used for International Maritime Organization (IMO) 
+numbers.
+
+The `Modulus10_2CheckDigitAttribute` will return validation errors for the following conditions:
+- The value does not contain a valid Modulus10_2 check digit.
+- The value contains non-ASCII digit characters.
+- The value is shorter than two characters (i.e., it cannot contain a check digit).
+- The value is longer than 10 characters (the maximum length supported by the Modulus10_2 algorithm).
 - The value being validated is not of type `string`.
 
 ### Modulus11CheckDigitAttribute


### PR DESCRIPTION
# S0048: Modulus10_2 Check Digit Data Annotation

## Story
**As a** .NET developer  
**I want** a reusable C# data annotation that validates values using the Modulus10_2 check digit algorithm via **CheckDigits.Net**  
**So that** I can declaratively enforce check digit validation on my model properties without duplicating validation logic.

## Background
Identifiers often include a check digit to ensure data integrity. Implementing check digit logic repeatedly across applications leads to duplication and inconsistencies. A custom data annotation backed by **CheckDigits.Net** enables consistent, maintainable validation using standard .NET validation mechanisms.

## Acceptance Criteria
- The annotation is implemented as a custom attribute derived from `System.ComponentModel.DataAnnotations.ValidationAttribute`.
- The annotation uses **CheckDigits.Net** to validate values according to the Modulus10_2 algorithm.
- The annotation can be applied to `string` model properties.
- Validation succeeds when the value is valid per the Modulus10_2 algorithm.
- Validation fails when the value does not pass the Modulus10_2 check.
- Validation succeeds when the value is `null` or empty and the field is not marked as required.
- A default error message is provided (e.g., *“The field {0} has invalid Modulus10_2 check digits*).
- The error message can be customized using the `ErrorMessage` property.
- New annotation to exist in CheckDigits.Net.DataAnnotations namespace.
- New annotation named Modulus10_2CheckDigit

## Definition of Done
- The annotation is usable in standard .NET model validation (e.g., ASP.NET Core MVC / Web API).
- Validation errors appear in model state and are returned in API responses where applicable.
- Unit tests exist for valid, invalid, and edge-case inputs.
- The implementation has no direct dependency on application-specific code.
- README updates

## Out of Scope
- Client-side validation.
- Generating or calculating Modulus10_2 check digits (validation only).
- Support for non-Modulus10_2 check digit algorithms.

## Example Usage
```csharp
public class Foo
{
    [Modulus10_2CheckDigit]
    public string Bar { get; set; }
}