### PR TITLE
S0068 masked modulus nhs

### DIFF
--- a/CheckDigits.Net.Tests.Benchmarks/NumericAlgorithmBenchmarks.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/NumericAlgorithmBenchmarks.cs
@@ -14,69 +14,75 @@ public class NumericAlgorithmBenchmarks
 
    public IEnumerable<Object[]> TryCalculateCheckDigitArguments()
    {
-      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140" ];
-      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662" ];
-      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538" ];
-      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538042" ];
-      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538042551" ];
-      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538042551028" ];
-      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538042551028265" ];
+      yield return [Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140"];
+      yield return [Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662"];
+      yield return [Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538"];
+      yield return [Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538042"];
+      yield return [Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538042551"];
+      yield return [Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538042551028"];
+      yield return [Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538042551028265"];
 
-      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140" ];
-      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662" ];
-      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538" ];
-      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538042" ];
-      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538042551" ];
-      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538042551028" ];
-      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538042551028265" ];
+      yield return [Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140"];
+      yield return [Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662"];
+      yield return [Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538"];
+      yield return [Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538042"];
+      yield return [Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538042551"];
+      yield return [Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538042551028"];
+      yield return [Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538042551028265"];
 
-      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140" ];
-      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662" ];
-      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538" ];
-      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042" ];
-      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042551" ];
-      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042551028" ];
-      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042551028265" ];
+      yield return [Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140"];
+      yield return [Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662"];
+      yield return [Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538"];
+      yield return [Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042"];
+      yield return [Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042551"];
+      yield return [Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042551028"];
+      yield return [Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042551028265"];
 
-      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140" ];
-      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662" ];
-      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662538" ];
-      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662538042" ];
-      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662538042551" ];
-      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662538042551028" ];
-      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662538042551028265" ];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662538"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662538042"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662538042551"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662538042551028"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662538042551028265"];
 
-      //yield return [ Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "140" ];
-      //yield return [ Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "140662" ];
-      //yield return [ Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "140662538" ];
+      yield return [Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "140"];
+      yield return [Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "140662"];
+      yield return [Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "140662538"];
 
-      //yield return [ Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "140" ];
-      //yield return [ Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "140662" ];
-      //yield return [ Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "140662538" ];
+      yield return [Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "140"];
+      yield return [Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "140662"];
+      yield return [Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "140662538"];
 
-      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140" ];
-      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662" ];
-      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538" ];
-      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538042" ];
-      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538042551" ];
-      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538042551028" ];
-      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538042551028265" ];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140"];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662"];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538"];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538042"];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538042551"];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538042551028"];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538042551028265"];
 
-      //yield return [Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "140"];
-      //yield return [Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "140662"];
-      //yield return [Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "140662538"];
+#pragma warning disable CS0618 // Type or member is obsolete
+      yield return [Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "140"];
+      yield return [Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "140662"];
+      yield return [Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "140662538"];
+#pragma warning restore CS0618 // Type or member is obsolete
 
       yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "140"];
       yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "140662"];
       yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "140662538"];
 
-      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140" ];
-      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662" ];
-      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538" ];
-      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538042" ];
-      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538042551" ];
-      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538042551028" ];
-      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538042551028265" ];
+      yield return [Algorithms.Modulus11Extended, Algorithms.Modulus11Extended.AlgorithmName, "140"];
+      yield return [Algorithms.Modulus11Extended, Algorithms.Modulus11Extended.AlgorithmName, "140662"];
+      yield return [Algorithms.Modulus11Extended, Algorithms.Modulus11Extended.AlgorithmName, "140662538"];
+
+      yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140"];
+      yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662"];
+      yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538"];
+      yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538042"];
+      yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538042551"];
+      yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538042551028"];
+      yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538042551028265"];
    }
 
    public IEnumerable<Object[]> TryCalculateCheckDigitsArguments()
@@ -92,88 +98,94 @@ public class NumericAlgorithmBenchmarks
 
    public IEnumerable<Object[]> ValidateArguments()
    {
-      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1402" ];
-      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406622" ];
-      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625388" ];
-      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625380422" ];
-      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625380425518" ];
-      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625380425510280" ];
-      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625380425510282654" ];
+      yield return [Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1402"];
+      yield return [Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406622"];
+      yield return [Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625388"];
+      yield return [Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625380422"];
+      yield return [Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625380425518"];
+      yield return [Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625380425510280"];
+      yield return [Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625380425510282654"];
 
-      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1409" ];
-      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406623" ];
-      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625381" ];
-      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625380426" ];
-      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625380425514" ];
-      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625380425510286" ];
-      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625380425510282657" ];
+      yield return [Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1409"];
+      yield return [Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406623"];
+      yield return [Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625381"];
+      yield return [Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625380426"];
+      yield return [Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625380425514"];
+      yield return [Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625380425510286"];
+      yield return [Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625380425510282657"];
 
-      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140X" ];
-      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406628" ];
-      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406625380" ];
-      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406625380426" ];
-      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406625380425511" ];
-      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042551028X" ];
-      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406625380425510282651" ];
+      yield return [Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140X"];
+      yield return [Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406628"];
+      yield return [Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406625380"];
+      yield return [Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406625380426"];
+      yield return [Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406625380425511"];
+      yield return [Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042551028X"];
+      yield return [Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406625380425510282651"];
 
-      //yield return [ Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066" ];
-      //yield return [ Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066262" ];
-      //yield return [ Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253823" ];
-      //yield return [ Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253804250" ];
-      //yield return [ Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253804255112" ];
-      //yield return [ Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253804255102853" ];
-      //yield return [ Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253804255102826587" ];
+      yield return [Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066"];
+      yield return [Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066262"];
+      yield return [Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253823"];
+      yield return [Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253804250"];
+      yield return [Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253804255112"];
+      yield return [Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253804255102853"];
+      yield return [Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253804255102826587"];
 
-      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1404" ];
-      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406628" ];
-      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406625382" ];
-      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406625380421" ];
-      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406625380425514" ];
-      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406625380425510285" ];
-      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406625380425510282651" ];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1404"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406628"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406625382"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406625380421"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406625380425514"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406625380425510285"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406625380425510282651"];
 
-      //yield return [ Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "1401" ];
-      //yield return [ Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "1406628" ];
-      //yield return [ Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "1406625384" ];
+      yield return [Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "1401"];
+      yield return [Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "1406628"];
+      yield return [Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "1406625384"];
 
-      //yield return [ Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "1406" ];
-      //yield return [ Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "1406627" ];
-      //yield return [ Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "1406625389" ];
+      yield return [Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "1406"];
+      yield return [Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "1406627"];
+      yield return [Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "1406625389"];
 
-      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1403" ];
-      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406627" ];
-      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625385" ];
-      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625380425" ];
-      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625380425518" ];
-      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625380425510288" ];
-      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625380425510282657" ];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1403"];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406627"];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625385"];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625380425"];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625380425518"];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625380425510288"];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625380425510282657"];
 
-      //yield return [Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "1406"];
-      //yield return [Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "1406625"];
-      //yield return [Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "1406625388"];
+#pragma warning disable CS0618 // Type or member is obsolete
+      yield return [Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "1406"];
+      yield return [Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "1406620"];
+      yield return [Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "1406625388"];
+#pragma warning restore CS0618 // Type or member is obsolete
 
       yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "1406"];
-      yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "1406625"];
+      yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "1406620"];
       yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "1406625388"];
 
-      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1401" ];
-      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625" ];
-      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625388" ];
-      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380426" ];
-      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380425512" ];
-      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380425510285" ];
-      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380425510282655" ];
+      yield return [Algorithms.Modulus11Extended, Algorithms.Modulus11Extended.AlgorithmName, "1406"];
+      yield return [Algorithms.Modulus11Extended, Algorithms.Modulus11Extended.AlgorithmName, "1406620"];
+      yield return [Algorithms.Modulus11Extended, Algorithms.Modulus11Extended.AlgorithmName, "1406625388"];
+
+      yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1401"];
+      yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406620"];
+      yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625388"];
+      yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380426"];
+      yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380425512"];
+      yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380425510285"];
+      yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380425510282655"];
    }
 
    public IEnumerable<Object[]> ValidateMaskedArguments()
    {
-      //yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 4"];
-      //yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 8"];
-      //yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 2"];
-      //yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 1"];
-      //yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 551 4"];
-      //yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 551 028 5"];
-      //yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 551 028 265 1"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 4"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 8"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 2"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 1"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 551 4"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 551 028 5"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 551 028 265 1"];
 
       yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140 3"];
       yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140 662 7"];
@@ -184,8 +196,12 @@ public class NumericAlgorithmBenchmarks
       yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140 662 538 042 551 028 265 7"];
 
       yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "140 6"];
-      yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "140 662 5"];
+      yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "140 662 0"];
       yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "140 662 538 8"];
+
+      yield return [Algorithms.Modulus11Extended, Algorithms.Modulus11Extended.AlgorithmName, "140 6"];
+      yield return [Algorithms.Modulus11Extended, Algorithms.Modulus11Extended.AlgorithmName, "140 662 0"];
+      yield return [Algorithms.Modulus11Extended, Algorithms.Modulus11Extended.AlgorithmName, "140 662 538 8"];
 
    }
 
@@ -196,12 +212,12 @@ public class NumericAlgorithmBenchmarks
       algorithm.TryCalculateCheckDigit(value, out var checkDigit);
    }
 
-   //[Benchmark]
-   //[ArgumentsSource(nameof(TryCalculateCheckDigitsArguments))]
-   //public void TryCalculateCheckDigits(IDoubleCheckDigitAlgorithm algorithm, String name, String value)
-   //{
-   //   algorithm.TryCalculateCheckDigits(value, out var first, out var second);
-   //}
+   [Benchmark]
+   [ArgumentsSource(nameof(TryCalculateCheckDigitsArguments))]
+   public void TryCalculateCheckDigits(IDoubleCheckDigitAlgorithm algorithm, String name, String value)
+   {
+      algorithm.TryCalculateCheckDigits(value, out var first, out var second);
+   }
 
    [Benchmark]
    [ArgumentsSource(nameof(ValidateArguments))]

--- a/CheckDigits.Net.Tests.Benchmarks/NumericAlgorithmBenchmarks.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/NumericAlgorithmBenchmarks.cs
@@ -14,65 +14,69 @@ public class NumericAlgorithmBenchmarks
 
    public IEnumerable<Object[]> TryCalculateCheckDigitArguments()
    {
-      yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140" ];
-      yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662" ];
-      yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538" ];
-      yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538042" ];
-      yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538042551" ];
-      yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538042551028" ];
-      yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538042551028265" ];
+      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140" ];
+      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662" ];
+      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538" ];
+      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538042" ];
+      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538042551" ];
+      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538042551028" ];
+      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140662538042551028265" ];
 
-      yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140" ];
-      yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662" ];
-      yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538" ];
-      yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538042" ];
-      yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538042551" ];
-      yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538042551028" ];
-      yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538042551028265" ];
+      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140" ];
+      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662" ];
+      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538" ];
+      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538042" ];
+      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538042551" ];
+      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538042551028" ];
+      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "140662538042551028265" ];
 
-      yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140" ];
-      yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662" ];
-      yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538" ];
-      yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042" ];
-      yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042551" ];
-      yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042551028" ];
-      yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042551028265" ];
+      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140" ];
+      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662" ];
+      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538" ];
+      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042" ];
+      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042551" ];
+      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042551028" ];
+      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042551028265" ];
 
-      yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140" ];
-      yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662" ];
-      yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662538" ];
-      yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662538042" ];
-      yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662538042551" ];
-      yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662538042551028" ];
-      yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662538042551028265" ];
+      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140" ];
+      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662" ];
+      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662538" ];
+      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662538042" ];
+      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662538042551" ];
+      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662538042551028" ];
+      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140662538042551028265" ];
 
-      yield return [ Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "140" ];
-      yield return [ Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "140662" ];
-      yield return [ Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "140662538" ];
+      //yield return [ Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "140" ];
+      //yield return [ Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "140662" ];
+      //yield return [ Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "140662538" ];
 
-      yield return [ Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "140" ];
-      yield return [ Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "140662" ];
-      yield return [ Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "140662538" ];
+      //yield return [ Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "140" ];
+      //yield return [ Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "140662" ];
+      //yield return [ Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "140662538" ];
 
-      yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140" ];
-      yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662" ];
-      yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538" ];
-      yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538042" ];
-      yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538042551" ];
-      yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538042551028" ];
-      yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538042551028265" ];
+      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140" ];
+      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662" ];
+      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538" ];
+      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538042" ];
+      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538042551" ];
+      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538042551028" ];
+      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140662538042551028265" ];
 
-      yield return [ Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "140" ];
-      yield return [ Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "140662" ];
-      yield return [ Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "140662538" ];
+      //yield return [Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "140"];
+      //yield return [Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "140662"];
+      //yield return [Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "140662538"];
 
-      yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140" ];
-      yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662" ];
-      yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538" ];
-      yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538042" ];
-      yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538042551" ];
-      yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538042551028" ];
-      yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538042551028265" ];
+      yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "140"];
+      yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "140662"];
+      yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "140662538"];
+
+      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140" ];
+      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662" ];
+      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538" ];
+      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538042" ];
+      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538042551" ];
+      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538042551028" ];
+      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140662538042551028265" ];
    }
 
    public IEnumerable<Object[]> TryCalculateCheckDigitsArguments()
@@ -88,84 +92,101 @@ public class NumericAlgorithmBenchmarks
 
    public IEnumerable<Object[]> ValidateArguments()
    {
-      yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1402" ];
-      yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406622" ];
-      yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625388" ];
-      yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625380422" ];
-      yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625380425518" ];
-      yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625380425510280" ];
-      yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625380425510282654" ];
+      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1402" ];
+      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406622" ];
+      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625388" ];
+      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625380422" ];
+      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625380425518" ];
+      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625380425510280" ];
+      //yield return [ Algorithms.Damm, Algorithms.Damm.AlgorithmName, "1406625380425510282654" ];
 
-      yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1409" ];
-      yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406623" ];
-      yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625381" ];
-      yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625380426" ];
-      yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625380425514" ];
-      yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625380425510286" ];
-      yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625380425510282657" ];
+      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1409" ];
+      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406623" ];
+      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625381" ];
+      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625380426" ];
+      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625380425514" ];
+      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625380425510286" ];
+      //yield return [ Algorithms.Iso7064Mod11_10, Algorithms.Iso7064Mod11_10.AlgorithmName, "1406625380425510282657" ];
 
-      yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140X" ];
-      yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406628" ];
-      yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406625380" ];
-      yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406625380426" ];
-      yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406625380425511" ];
-      yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042551028X" ];
-      yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406625380425510282651" ];
+      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140X" ];
+      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406628" ];
+      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406625380" ];
+      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406625380426" ];
+      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406625380425511" ];
+      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "140662538042551028X" ];
+      //yield return [ Algorithms.Iso7064Mod11_2, Algorithms.Iso7064Mod11_2.AlgorithmName, "1406625380425510282651" ];
 
-      yield return [ Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066" ];
-      yield return [ Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066262" ];
-      yield return [ Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253823" ];
-      yield return [ Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253804250" ];
-      yield return [ Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253804255112" ];
-      yield return [ Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253804255102853" ];
-      yield return [ Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253804255102826587" ];
+      //yield return [ Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066" ];
+      //yield return [ Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066262" ];
+      //yield return [ Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253823" ];
+      //yield return [ Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253804250" ];
+      //yield return [ Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253804255112" ];
+      //yield return [ Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253804255102853" ];
+      //yield return [ Algorithms.Iso7064Mod97_10, Algorithms.Iso7064Mod97_10.AlgorithmName, "14066253804255102826587" ];
 
-      yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1404" ];
-      yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406628" ];
-      yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406625382" ];
-      yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406625380421" ];
-      yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406625380425514" ];
-      yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406625380425510285" ];
-      yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406625380425510282651" ];
+      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1404" ];
+      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406628" ];
+      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406625382" ];
+      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406625380421" ];
+      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406625380425514" ];
+      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406625380425510285" ];
+      //yield return [ Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "1406625380425510282651" ];
 
-      yield return [ Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "1401" ];
-      yield return [ Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "1406628" ];
-      yield return [ Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "1406625384" ];
+      //yield return [ Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "1401" ];
+      //yield return [ Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "1406628" ];
+      //yield return [ Algorithms.Modulus10_1, Algorithms.Modulus10_1.AlgorithmName, "1406625384" ];
 
-      yield return [ Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "1406" ];
-      yield return [ Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "1406627" ];
-      yield return [ Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "1406625389" ];
+      //yield return [ Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "1406" ];
+      //yield return [ Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "1406627" ];
+      //yield return [ Algorithms.Modulus10_2, Algorithms.Modulus10_2.AlgorithmName, "1406625389" ];
 
-      yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1403" ];
-      yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406627" ];
-      yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625385" ];
-      yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625380425" ];
-      yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625380425518" ];
-      yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625380425510288" ];
-      yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625380425510282657" ];
+      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1403" ];
+      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406627" ];
+      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625385" ];
+      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625380425" ];
+      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625380425518" ];
+      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625380425510288" ];
+      //yield return [ Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "1406625380425510282657" ];
 
-      yield return [ Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "1406" ];
-      yield return [ Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "1406625" ];
-      yield return [ Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "1406625388" ];
+      //yield return [Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "1406"];
+      //yield return [Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "1406625"];
+      //yield return [Algorithms.Modulus11, Algorithms.Modulus11.AlgorithmName, "1406625388"];
 
-      yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1401" ];
-      yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625" ];
-      yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625388" ];
-      yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380426" ];
-      yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380425512" ];
-      yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380425510285" ];
-      yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380425510282655" ];
+      yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "1406"];
+      yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "1406625"];
+      yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "1406625388"];
+
+      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1401" ];
+      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625" ];
+      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625388" ];
+      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380426" ];
+      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380425512" ];
+      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380425510285" ];
+      //yield return [ Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380425510282655" ];
    }
 
    public IEnumerable<Object[]> ValidateMaskedArguments()
    {
-      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 4"];
-      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 8"];
-      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 2"];
-      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 1"];
-      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 551 4"];
-      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 551 028 5"];
-      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 551 028 265 1"];
+      //yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 4"];
+      //yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 8"];
+      //yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 2"];
+      //yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 1"];
+      //yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 551 4"];
+      //yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 551 028 5"];
+      //yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 551 028 265 1"];
+
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140 3"];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140 662 7"];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140 662 538 5"];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140 662 538 042 5"];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140 662 538 042 551 8"];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140 662 538 042 551 028 8"];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140 662 538 042 551 028 265 7"];
+
+      yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "140 6"];
+      yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "140 662 5"];
+      yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "140 662 538 8"];
+
    }
 
    [Benchmark]
@@ -175,12 +196,12 @@ public class NumericAlgorithmBenchmarks
       algorithm.TryCalculateCheckDigit(value, out var checkDigit);
    }
 
-   [Benchmark]
-   [ArgumentsSource(nameof(TryCalculateCheckDigitsArguments))]
-   public void TryCalculateCheckDigits(IDoubleCheckDigitAlgorithm algorithm, String name, String value)
-   {
-      algorithm.TryCalculateCheckDigits(value, out var first, out var second);
-   }
+   //[Benchmark]
+   //[ArgumentsSource(nameof(TryCalculateCheckDigitsArguments))]
+   //public void TryCalculateCheckDigits(IDoubleCheckDigitAlgorithm algorithm, String name, String value)
+   //{
+   //   algorithm.TryCalculateCheckDigits(value, out var first, out var second);
+   //}
 
    [Benchmark]
    [ArgumentsSource(nameof(ValidateArguments))]

--- a/CheckDigits.Net.Tests.Benchmarks/OptimizeBenchmarks.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/OptimizeBenchmarks.cs
@@ -1,4 +1,6 @@
-﻿namespace CheckDigits.Net.Tests.Benchmarks;
+﻿#pragma warning disable CS0618 // Type or member is obsolete
+
+namespace CheckDigits.Net.Tests.Benchmarks;
 
 [MemoryDiagnoser]
 public class OptimizeBenchmarks
@@ -6,7 +8,9 @@ public class OptimizeBenchmarks
    //private static readonly Iso7064Mod1271_36Algorithm _algorithm = new();
 
    private static readonly NhsAlgorithm _nhsAlgorithm = new();
+   private static readonly Modulus11Algorithm _modulus11Algorithm = new();
    private static readonly Modulus11DecimalAlgorithm _modulus11DecimalAlgorithm = new();
+   private static readonly Modulus11ExtendedAlgorithm _modulus11ExtendedAlgorithm = new();
 
    private static readonly ICheckDigitMask _groupsOfThreeMask = new GroupsOfThreeCheckDigitMask();
 
@@ -40,23 +44,45 @@ public class OptimizeBenchmarks
    //[Benchmark]
    //public void TryCalculate3() => _ = _algorithm.TryCalculateCheckDigits3(TryValue, out var ch, out var ch2);
 
-   [Benchmark(Baseline = true)]
-   [Arguments("9434765919")]
-   [Arguments("4505577104")]
-   [Arguments("5301194917")]
+   //[Benchmark(Baseline = true)]
+   //[Arguments("1406")]
+   //[Arguments("1406620")]
+   //[Arguments("1406625388")]
+   //public void Modulus11Validate(String value) => _ = _modulus11Algorithm.Validate(value);
+
+   //[Benchmark(Baseline = true)]
+   //[Arguments("1406")]
+   //[Arguments("1406620")]
+   //[Arguments("1406625388")]
+   //public void Modulus11ExtendedValidate0(String value) => _ = _modulus11ExtendedAlgorithm.Validate0(value);
+
+   [Benchmark()]
+   [Arguments("1406")]
+   [Arguments("1406620")]
+   [Arguments("1406625388")]
+   public void Modulus11ExtendedValidate(String value) => _ = _modulus11ExtendedAlgorithm.Validate(value);
+
+   //[Benchmark()]
+   //[Arguments("1406")]
+   //[Arguments("1406620")]
+   //[Arguments("1406625388")]
+   //public void Modulus11ExtendedValidate1(String value) => _ = _modulus11ExtendedAlgorithm.Validate1(value);
+
+   [Benchmark()]
+   [Arguments("1406625388")]
    public void NhsValidate(String value) => _ = _nhsAlgorithm.Validate(value);
 
    [Benchmark()]
-   [Arguments("9434765919")]
-   [Arguments("4505577104")]
-   [Arguments("5301194917")]
+   [Arguments("1406")]
+   [Arguments("1406620")]
+   [Arguments("1406625388")]
    public void Modulus11DecimalValidate(String value) => _ = _modulus11DecimalAlgorithm.Validate(value);
 
-   [Benchmark()]
-   [Arguments("943 476 591 9")]
-   [Arguments("450 557 710 4")]
-   [Arguments("530 119 491 7")]
-   public void Modulus11DecimalValidateMasked(String value) 
-      => _ = _modulus11DecimalAlgorithm.Validate(value, _groupsOfThreeMask);
+   //[Benchmark()]
+   //[Arguments("140 6")]
+   //[Arguments("140 662 0")]
+   //[Arguments("140 662 538 8")]
+   //public void Modulus11ExtendedValidateMasked(String value) 
+   //   => _ = _modulus11ExtendedAlgorithm.Validate(value, _groupsOfThreeMask);
 
 }

--- a/CheckDigits.Net.Tests.Benchmarks/OptimizeBenchmarks.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/OptimizeBenchmarks.cs
@@ -3,7 +3,12 @@
 [MemoryDiagnoser]
 public class OptimizeBenchmarks
 {
-   private static readonly Iso7064Mod1271_36Algorithm _algorithm = new();
+   //private static readonly Iso7064Mod1271_36Algorithm _algorithm = new();
+
+   private static readonly NhsAlgorithm _nhsAlgorithm = new();
+   private static readonly Modulus11DecimalAlgorithm _modulus11DecimalAlgorithm = new();
+
+   private static readonly ICheckDigitMask _groupsOfThreeMask = new GroupsOfThreeCheckDigitMask();
 
    //[Params("BE71096123456769", "GB82WEST12345698765432", "SC74MCBL01031234567890123456USD")]
    //public String Value { get; set; } = String.Empty;
@@ -20,18 +25,38 @@ public class OptimizeBenchmarks
    //[Benchmark]
    //public void Validate3() => _ = _algorithm.Validate3(Value);
 
-   [Params("U7Y", "U7Y8SX", "U7Y8SXRC0", "U7Y8SXRC0O3S", "U7Y8SXRC0O3SC4I", "U7Y8SXRC0O3SC4IHYQ", "U7Y8SXRC0O3SC4IHYQF4M")]
-   public String TryValue { get; set; } = String.Empty;
+   //[Params("U7Y", "U7Y8SX", "U7Y8SXRC0", "U7Y8SXRC0O3S", "U7Y8SXRC0O3SC4I", "U7Y8SXRC0O3SC4IHYQ", "U7Y8SXRC0O3SC4IHYQF4M")]
+   //public String TryValue { get; set; } = String.Empty;
 
-   [Benchmark]
-   public void Startup() => _algorithm.TryCalculateCheckDigits(TryValue, out var ch, out var ch2);
+   //[Benchmark]
+   //public void Startup() => _algorithm.TryCalculateCheckDigits(TryValue, out var ch, out var ch2);
 
-   [Benchmark(Baseline = true)]
-   public void TryCalculate() => _ = _algorithm.TryCalculateCheckDigits(TryValue, out var ch, out var ch2);
+   //[Benchmark(Baseline = true)]
+   //public void TryCalculate() => _ = _algorithm.TryCalculateCheckDigits(TryValue, out var ch, out var ch2);
 
    //[Benchmark]
    //public void TryCalculate2() => _ = _algorithm.TryCalculateCheckDigits2(TryValue, out var ch, out var ch2);
 
    //[Benchmark]
    //public void TryCalculate3() => _ = _algorithm.TryCalculateCheckDigits3(TryValue, out var ch, out var ch2);
+
+   [Benchmark(Baseline = true)]
+   [Arguments("9434765919")]
+   [Arguments("4505577104")]
+   [Arguments("5301194917")]
+   public void NhsValidate(String value) => _ = _nhsAlgorithm.Validate(value);
+
+   [Benchmark()]
+   [Arguments("9434765919")]
+   [Arguments("4505577104")]
+   [Arguments("5301194917")]
+   public void Modulus11DecimalValidate(String value) => _ = _modulus11DecimalAlgorithm.Validate(value);
+
+   [Benchmark()]
+   [Arguments("943 476 591 9")]
+   [Arguments("450 557 710 4")]
+   [Arguments("530 119 491 7")]
+   public void Modulus11DecimalValidateMasked(String value) 
+      => _ = _modulus11DecimalAlgorithm.Validate(value, _groupsOfThreeMask);
+
 }

--- a/CheckDigits.Net.Tests.Benchmarks/Program.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/Program.cs
@@ -1,10 +1,10 @@
 ﻿
-//BenchmarkRunner.Run<NumericAlgorithmBenchmarks>();
+BenchmarkRunner.Run<NumericAlgorithmBenchmarks>();
 
 //BenchmarkRunner.Run<AlphabeticAlgorithmsBenchmarks>();
 
 //BenchmarkRunner.Run<AlphanumericAlgorithmBenchmarks>();
 
-BenchmarkRunner.Run<ValueSpecificAlgorithmBenchmarks>();
+//BenchmarkRunner.Run<ValueSpecificAlgorithmBenchmarks>();
 
 //BenchmarkRunner.Run<OptimizeBenchmarks>();

--- a/CheckDigits.Net.Tests.Benchmarks/Program.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/Program.cs
@@ -1,5 +1,5 @@
 ﻿
-BenchmarkRunner.Run<NumericAlgorithmBenchmarks>();
+//BenchmarkRunner.Run<NumericAlgorithmBenchmarks>();
 
 //BenchmarkRunner.Run<AlphabeticAlgorithmsBenchmarks>();
 
@@ -7,4 +7,4 @@ BenchmarkRunner.Run<NumericAlgorithmBenchmarks>();
 
 //BenchmarkRunner.Run<ValueSpecificAlgorithmBenchmarks>();
 
-//BenchmarkRunner.Run<OptimizeBenchmarks>();
+BenchmarkRunner.Run<OptimizeBenchmarks>();

--- a/CheckDigits.Net.Tests.Benchmarks/ValueSpecificAlgorithmBenchmarks.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/ValueSpecificAlgorithmBenchmarks.cs
@@ -93,9 +93,11 @@ public class ValueSpecificAlgorithmBenchmarks
       yield return [Algorithms.Isin, Algorithms.Isin.AlgorithmName, "AU0000XVGZA3"];
       yield return [Algorithms.Isin, Algorithms.Isin.AlgorithmName, "GB0002634946"];
 
+#pragma warning disable CS0618 // Type or member is obsolete
       yield return [Algorithms.Nhs, Algorithms.Nhs.AlgorithmName, "9434765919"];
       yield return [Algorithms.Nhs, Algorithms.Nhs.AlgorithmName, "4505577104"];
       yield return [Algorithms.Nhs, Algorithms.Nhs.AlgorithmName, "5301194917"];
+#pragma warning restore CS0618 // Type or member is obsolete
 
       yield return [Algorithms.Npi, Algorithms.Npi.AlgorithmName, "1234567893"];
       yield return [Algorithms.Npi, Algorithms.Npi.AlgorithmName, "1245319599"];

--- a/CheckDigits.Net.Tests.Unit/AlgorithmsTests.cs
+++ b/CheckDigits.Net.Tests.Unit/AlgorithmsTests.cs
@@ -1,4 +1,4 @@
-﻿// Ignore Spelling: Aba Cusip Damm Figi Iban Icao Isan Isin Luhn Ncd Nhs Npi Rtn Sedol Verhoeff
+﻿// Ignore Spelling: Aba Cusip Damm Figi Iban Icao Isan Isin Luhn Ncd Nhs Npi Rtn Sedol Verhoeff Vin
 
 namespace CheckDigits.Net.Tests.Unit;
 
@@ -372,6 +372,7 @@ public class AlgorithmsTests
    // ==========================================================================
    // ==========================================================================
 
+#pragma warning disable CS0618 // Type or member is obsolete
    [Fact]
    public void Algorithms_Modulus11_ShouldNotBeNull()
       => Algorithms.Modulus11.Should().NotBeNull();
@@ -379,6 +380,35 @@ public class AlgorithmsTests
    [Fact]
    public void Algorithms_Modulus11_ShouldBeExpectedType()
       => Algorithms.Modulus11.Should().BeOfType<Modulus11Algorithm>();
+#pragma warning restore CS0618 // Type or member is obsolete
+
+   #endregion
+
+   #region Modulus11Decimal Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void Algorithms_Modulus11Decimal_ShouldNotBeNull()
+      => Algorithms.Modulus11Decimal.Should().NotBeNull();
+
+   [Fact]
+   public void Algorithms_Modulus11Decimal_ShouldBeExpectedType()
+      => Algorithms.Modulus11Decimal.Should().BeOfType<Modulus11DecimalAlgorithm>();
+
+   #endregion
+
+   #region Modulus11Extended Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void Algorithms_Modulus11Extended_ShouldNotBeNull()
+      => Algorithms.Modulus11Extended.Should().NotBeNull();
+
+   [Fact]
+   public void Algorithms_Modulus11Extended_ShouldBeExpectedType()
+      => Algorithms.Modulus11Extended.Should().BeOfType<Modulus11ExtendedAlgorithm>();
 
    #endregion
 
@@ -400,6 +430,7 @@ public class AlgorithmsTests
    // ==========================================================================
    // ==========================================================================
 
+#pragma warning disable CS0618 // Type or member is obsolete
    [Fact]
    public void Algorithms_Nhs_ShouldNotBeNull()
       => Algorithms.Nhs.Should().NotBeNull();
@@ -407,6 +438,7 @@ public class AlgorithmsTests
    [Fact]
    public void Algorithms_Nhs_ShouldBeExpectedType()
       => Algorithms.Nhs.Should().BeOfType<NhsAlgorithm>();
+#pragma warning restore CS0618 // Type or member is obsolete
 
    #endregion
 

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/LuhnAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/LuhnAlgorithmTests.cs
@@ -140,6 +140,17 @@ public class LuhnAlgorithmTests
       checkDigit.Should().Be('\0');
    }
 
+   [Theory]
+   [InlineData("140")]
+   [InlineData("140662")]
+   [InlineData("140662538")]
+   [InlineData("140662538042")]
+   [InlineData("140662538042551")]
+   [InlineData("140662538042551028")]
+   [InlineData("140662538042551028265")]
+   public void LuhnAlgorithm_TryCalculateValue_ShouldReturnTrue_ForBenchmarkValues(String value)
+      => _sut.TryCalculateCheckDigit(value, out _).Should().BeTrue();
+
    #endregion
 
    #region Validate Tests
@@ -206,17 +217,6 @@ public class LuhnAlgorithmTests
       => _sut.Validate(value).Should().BeTrue();
 
    [Theory]
-   [InlineData("1404")]
-   [InlineData("1406628")]
-   [InlineData("1406625382")]
-   [InlineData("1406625380421")]
-   [InlineData("1406625380425514")]
-   [InlineData("1406625380425510285")]
-   [InlineData("1406625380425510282651")]
-   public void LuhnAlgorithm_Validate_ShouldReturnTrue_ForBenchmarkValues(String value)
-      => _sut.Validate(value).Should().BeTrue();
-
-   [Theory]
    [InlineData("3056930090020004")]    // Diners Club test card number with two digit transposition 09 -> 90
    [InlineData("3056930000920004")]    // Diners Club test card number with two digit transposition 90 -> 09
    [InlineData("5555555225554444")]    // MasterCard test card number with two digit twin error 55 -> 22
@@ -252,6 +252,17 @@ public class LuhnAlgorithmTests
    [Fact]
    public void LuhnAlgorithm_Validate_ShouldReturnFalse_WhenCheckDigitCharacterIsNonDigit()
       => _sut.Validate("12345A").Should().BeFalse();
+
+   [Theory]
+   [InlineData("1404")]
+   [InlineData("1406628")]
+   [InlineData("1406625382")]
+   [InlineData("1406625380421")]
+   [InlineData("1406625380425514")]
+   [InlineData("1406625380425510285")]
+   [InlineData("1406625380425510282651")]
+   public void LuhnAlgorithm_Validate_ShouldReturnTrue_ForBenchmarkValues(String value)
+      => _sut.Validate(value).Should().BeTrue();
 
    #endregion
 
@@ -317,17 +328,6 @@ public class LuhnAlgorithmTests
       => _sut.Validate(value, _creditCardMask).Should().BeTrue();
 
    [Theory]
-   [InlineData("140 4")]
-   [InlineData("140 662 8")]
-   [InlineData("140 662 538 2")]
-   [InlineData("140 662 538 042 1")]
-   [InlineData("140 662 538 042 551 4")]
-   [InlineData("140 662 538 042 551 028 5")]
-   [InlineData("140 662 538 042 551 028 265 1")]
-   public void LuhnAlgorithm_ValidateMasked_ShouldReturnTrue_ForBenchmarkValues(String value)
-      => _sut.Validate(value, _groupsOfThreeMask).Should().BeTrue();
-
-   [Theory]
    [InlineData("3056 9300 9002 0004")]    // Diners Club test card number with two digit transposition 09 -> 90
    [InlineData("3056 9300 0092 0004")]    // Diners Club test card number with two digit transposition 90 -> 09
    [InlineData("5555 5552 2555 4444")]    // MasterCard test card number with two digit twin error 55 -> 22
@@ -363,6 +363,17 @@ public class LuhnAlgorithmTests
    [Fact]
    public void LuhnAlgorithm_ValidateMasked_ShouldReturnFalse_WhenCheckDigitCharacterIsNonDigit()
       => _sut.Validate("1234 5A", _creditCardMask).Should().BeFalse();
+
+   [Theory]
+   [InlineData("140 4")]
+   [InlineData("140 662 8")]
+   [InlineData("140 662 538 2")]
+   [InlineData("140 662 538 042 1")]
+   [InlineData("140 662 538 042 551 4")]
+   [InlineData("140 662 538 042 551 028 5")]
+   [InlineData("140 662 538 042 551 028 265 1")]
+   public void LuhnAlgorithm_ValidateMasked_ShouldReturnTrue_ForBenchmarkValues(String value)
+      => _sut.Validate(value, _groupsOfThreeMask).Should().BeTrue();
 
    #endregion
 }

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus10_13AlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus10_13AlgorithmTests.cs
@@ -275,7 +275,7 @@ public class Modulus10_13AlgorithmTests
 
    [Fact]
    public void Modulus10_13Algorithm_ValidateMasked_ShouldReturnFalse_WhenCheckDigitCharacterIsNonDigit()
-      => _sut.Validate("036 000 291 45A").Should().BeFalse();
+      => _sut.Validate("036 000 291 45A", _groupsOfThreeMask).Should().BeFalse();
 
    #endregion
 }

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11AlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11AlgorithmTests.cs
@@ -1,4 +1,6 @@
-﻿namespace CheckDigits.Net.Tests.Unit.GeneralAlgorithms;
+﻿#pragma warning disable CS0618 // Type or member is obsolete
+
+namespace CheckDigits.Net.Tests.Unit.GeneralAlgorithms;
 
 public class Modulus11AlgorithmTests
 {

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11DecimalAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11DecimalAlgorithmTests.cs
@@ -210,7 +210,7 @@ public class Modulus11DecimalAlgorithmTests
 
    [Fact]
    public void Modulus11DecimalAlgorithm_Validate_ShouldReturnFalse_WhenCheckDigitIsNonDigitCharacter()
-      => _sut.Validate("100030000X").Should().BeFalse();    // Actual check digit would be 5
+      => _sut.Validate("100030000?").Should().BeFalse();    // Actual check digit would be 5
 
    #endregion
 
@@ -265,9 +265,8 @@ public class Modulus11DecimalAlgorithmTests
    [InlineData("943 476 591 9")]    // Worked example from Wikipedia https://en.wikipedia.org/wiki/NHS_number#Format,_number_ranges,_and_check_characters
    [InlineData("450 557 710 4")]    // Example from https://www.clatterbridgecc.nhs.uk/patients/general-information/nhs-number#:~:text=Your%20NHS%20Number%20is%20printed,is%20an%20example%20number%20only).
    [InlineData("530 119 491 7")]    // Random NHS number from http://danielbayley.uk/nhs-number/
-   public void Modulus11Algorithm_ValidateMasked_ShouldReturnTrue_WhenValueContainsValidCheckDigit(String value)
+   public void Modulus11DecimalAlgorithm_ValidateMasked_ShouldReturnTrue_WhenValueContainsValidCheckDigit(String value)
       => _sut.Validate(value, _groupsOfThreeMask).Should().BeTrue();
-
 
    [Theory]
    [InlineData("1568656521")]    // ISBN-10 Island in the Stream of Time, S. M. Sterling
@@ -281,7 +280,7 @@ public class Modulus11DecimalAlgorithmTests
    [InlineData("9434765919")]    // Worked example from Wikipedia https://en.wikipedia.org/wiki/NHS_number#Format,_number_ranges,_and_check_characters
    [InlineData("4505577104")]    // Example from https://www.clatterbridgecc.nhs.uk/patients/general-information/nhs-number#:~:text=Your%20NHS%20Number%20is%20printed,is%20an%20example%20number%20only).
    [InlineData("5301194917")]    // Random NHS number from http://danielbayley.uk/nhs-number/
-   public void Modulus11Algorithm_ValidateMasked_ShouldReturnTrue_WhenValueContainsValidCheckDigitAndMaskAcceptsAllCharacters(String value)
+   public void Modulus11DecimalAlgorithm_ValidateMasked_ShouldReturnTrue_WhenValueContainsValidCheckDigitAndMaskAcceptsAllCharacters(String value)
       => _sut.Validate(value, _acceptAllMask).Should().BeTrue();
 
    [Theory]

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11DecimalAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11DecimalAlgorithmTests.cs
@@ -237,8 +237,8 @@ public class Modulus11DecimalAlgorithmTests
       => _sut.Validate(value, _acceptAllMask).Should().BeFalse();
 
    [Fact]
-   public void Modulus11DecimalAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputHasLengthGreaterThan10()
-      => _sut.Validate("000 000 000 00", _groupsOfThreeMask).Should().BeFalse();
+   public void Modulus11DecimalAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputHasMoreThan9UnmaskedDigits()
+      => _sut.Validate("00000000019", _acceptAllMask).Should().BeFalse();
 
    [Theory]
    [InlineData("000 000 001 9")]

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11DecimalAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11DecimalAlgorithmTests.cs
@@ -3,6 +3,9 @@
 public class Modulus11DecimalAlgorithmTests
 {
    private readonly Modulus11DecimalAlgorithm _sut = new();
+   private readonly ICheckDigitMask _acceptAllMask = new AcceptAllMask();
+   private readonly ICheckDigitMask _groupsOfThreeMask = new GroupsOfThreeCheckDigitMask();
+   private readonly ICheckDigitMask _rejectAllMask = new RejectAllMask();
 
    #region AlgorithmDescription Property Tests
    // ==========================================================================
@@ -21,6 +24,297 @@ public class Modulus11DecimalAlgorithmTests
    [Fact]
    public void Modulus11DecimalAlgorithm_AlgorithmName_ShouldReturnExpectedValue()
       => _sut.AlgorithmName.Should().Be(Resources.Modulus11DecimalAlgorithmName);
+
+   #endregion
+
+   #region TryCalculateCheckDigit Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void Modulus11DecimalAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenInputIsNull()
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(null!, out var checkDigit).Should().BeFalse();
+      checkDigit.Should().Be('\0');
+   }
+
+   [Fact]
+   public void Modulus11DecimalAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenInputIsEmpty()
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(String.Empty, out var checkDigit).Should().BeFalse();
+      checkDigit.Should().Be('\0');
+   }
+
+   [Fact]
+   public void Modulus11DecimalAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenInputHasLengthGreaterThanNine()
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit("1234567890", out var checkDigit).Should().BeFalse();
+      checkDigit.Should().Be('\0');
+   }
+
+   [Theory]
+   [InlineData("000000001", '9')]
+   [InlineData("000000010", '8')]
+   [InlineData("000000100", '7')]
+   [InlineData("000001000", '6')]
+   [InlineData("000010000", '5')]
+   [InlineData("000100000", '4')]
+   [InlineData("001000000", '3')]
+   [InlineData("010000000", '2')]
+   [InlineData("100000000", '1')]
+   public void Modulus11DecimalAlgorithm_TryCalculateCheckDigit_ShouldCorrectlyWeightCharactersByPosition(
+      String value,
+      Char expectedCheckDigit)
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
+      checkDigit.Should().Be(expectedCheckDigit);
+   }
+
+   [Theory]
+   // Note ISBN and ISSN test cases exclude values that would result in check digit = 'X'
+   [InlineData("156865652", '1')]   // ISBN-10 Island in the Stream of Time, S. M. Sterling
+   [InlineData("044100560", '8')]   // ISBN-10 The Warlock in Spite of Himself, Christopher Stasheff
+   [InlineData("071410544", '9')]   // ISBN-10 The Sutton Hoo Ship Burial, Angela Care Evans
+   //
+   [InlineData("030640615", '2')]   // Worked example of ISBN-10 from Wikipedia https://en.wikipedia.org/wiki/ISBN#ISBN-10_check_digits
+   [InlineData("0378595", '5')]     // Worked example of ISSN from Wikipedia https://en.wikipedia.org/wiki/ISSN
+   [InlineData("0317847", '1')]     // Example ISSN from https://www.issn.org/understanding-the-issn/what-is-an-issn/
+   //
+   [InlineData("530119491", '7')]   // Random NHS number from http://danielbayley.uk/nhs-number/
+   [InlineData("851446824", '3')]   // "
+   [InlineData("396748788", '1')]   // "
+   public void Modulus11DecimalAlgorithm_TryCalculateCheckDigit_ShouldCalculateExpectedCheckDigit(
+      String value,
+      Char expectedCheckDigit)
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
+      checkDigit.Should().Be(expectedCheckDigit);
+   }
+
+   [Fact]
+   public void Modulus11DecimalAlgorithm_TryCalculateCheckDigit_ShouldCalculateExpectedCheckDigit_WhenInputIsAllZeros()
+   {
+      // Arrange.
+      var value = "00000";
+      var expectedCheckDigit = Chars.DigitZero;
+
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
+      checkDigit.Should().Be(expectedCheckDigit);
+   }
+
+   [Theory]
+   [InlineData("100G00001")]
+   [InlineData("100+00001")]
+   public void Modulus11DecimalAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenInputContainsNonDigitCharacter(String value)
+   {
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeFalse();
+      checkDigit.Should().Be('\0');
+   }
+
+   [Theory]
+   // ISBN and ISSN test cases that would result in a check digit = 'X'
+   [InlineData("050027293")]        // ISBN-10 Roman London, Peter Marsden
+   //
+   [InlineData("2434561")]          // Example ISSN from Wikipedia
+   [InlineData("1050124")]          // Example ISSN from https://www.issn.org/understanding-the-issn/what-is-an-issn/
+   public void Modulus11DecimalAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenModulus11HasRemainderOf10(String value)
+   {
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeFalse();
+      checkDigit.Should().Be('\0');
+   }
+
+   #endregion
+
+   #region Validate Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void Modulus11DecimalAlgorithm_Validate_ShouldReturnFalse_WhenInputIsNull()
+      => _sut.Validate(null!).Should().BeFalse();
+
+   [Fact]
+   public void Modulus11DecimalAlgorithm_Validate_ShouldReturnFalse_WhenInputIsEmpty()
+      => _sut.Validate(String.Empty).Should().BeFalse();
+
+   [Theory]
+   [InlineData("0")]       // Zero would return true unless length is explicitly checked.
+   [InlineData("1")]
+   public void Modulus11DecimalAlgorithm_Validate_ShouldReturnFalse_WhenInputHasLengthLessThanTwo(String value)
+      => _sut.Validate(value).Should().BeFalse();
+
+   [Fact]
+   public void Modulus11DecimalAlgorithm_Validate_ShouldReturnFalse_WhenInputHasLengthGreaterThan10()
+      => _sut.Validate("00000000000").Should().BeFalse();
+
+   [Theory]
+   [InlineData("0000000019")]
+   [InlineData("0000000108")]
+   [InlineData("0000001007")]
+   [InlineData("0000010006")]
+   [InlineData("0000100005")]
+   [InlineData("0001000004")]
+   [InlineData("0010000003")]
+   [InlineData("0100000002")]
+   [InlineData("1000000001")]
+   public void Modulus11DecimalAlgorithm_Validate_ShouldCorrectlyWeightCharactersByPosition(String value)
+      => _sut.Validate(value).Should().BeTrue();
+
+   [Theory]
+   [InlineData("1568656521")]    // ISBN-10 Island in the Stream of Time, S. M. Sterling
+   [InlineData("0441005608")]    // ISBN-10 The Warlock in Spite of Himself, Christopher Stasheff
+   [InlineData("0714105449")]    // ISBN-10 The Sutton Hoo Ship Burial, Angela Care Evans
+   //
+   [InlineData("0306406152")]    // Worked example of ISBN-10 from Wikipedia https://en.wikipedia.org/wiki/ISBN#ISBN-10_check_digits
+   [InlineData("03785955")]      // Worked example of ISSN from Wikipedia https://en.wikipedia.org/wiki/ISSN
+   [InlineData("03178471")]      // Example ISSN from https://www.issn.org/understanding-the-issn/what-is-an-issn/
+   //
+   [InlineData("9434765919")]    // Worked example from Wikipedia https://en.wikipedia.org/wiki/NHS_number#Format,_number_ranges,_and_check_characters
+   [InlineData("4505577104")]    // Example from https://www.clatterbridgecc.nhs.uk/patients/general-information/nhs-number#:~:text=Your%20NHS%20Number%20is%20printed,is%20an%20example%20number%20only).
+   [InlineData("5301194917")]    // Random NHS number from http://danielbayley.uk/nhs-number/
+   public void Modulus11Algorithm_Validate_ShouldReturnTrue_WhenValueContainsValidCheckDigit(String value)
+      => _sut.Validate(value).Should().BeTrue();
+
+   [Theory]
+   [InlineData("1568646521")]    // ISBN-10 with single digit transcription error 5 -> 4
+   [InlineData("0441050608")]    // ISBN-10 with two digit transposition error 05 -> 50
+   [InlineData("3946787881")]    // Valid NHS number (9876544321) with jump transposition 674 -> 467
+   [InlineData("8515568243")]    // Valid NHS number (8514468243) with twin error 44 -> 55
+   public void Modulus11DecimalAlgorithm_Validate_ShouldReturnFalse_WhenInputContainsDetectableError(String value)
+      => _sut.Validate(value).Should().BeFalse();
+
+   [Fact]
+   public void Modulus11DecimalAlgorithm_Validate_ShouldReturnTrue_WhenInputIsAllZeros()
+      => _sut.Validate("0000000000").Should().BeTrue();
+
+   [Theory]
+   // ISBN and ISSN test cases that would result in a check digit = 'X', replaced with '0'
+   [InlineData("0500272930")]        // ISBN-10 Roman London, Peter Marsden
+   //
+   [InlineData("24345610")]          // Example ISSN from Wikipedia
+   [InlineData("10501240")]          // Example ISSN from https://www.issn.org/understanding-the-issn/what-is-an-issn/
+   public void Modulus11DecimalAlgorithm_Validate_ShouldReturnTrue_WhenModulus11HasRemainderOf10(String value)
+      => _sut.Validate(value).Should().BeFalse();
+
+   [Theory]
+   [InlineData("1000G00005")]    // Value 1000300005 would have a check digit = 5. G is 20 positions later in ASCII table than 3 and would also calculate check digit 5 unless code explicitly checks for non-digit
+   [InlineData("1000)00005")]    // ) is 10 positions earlier in ASCII table than 3 and would also calculate check digit 5 unless code explicitly checks for non-digit
+   public void Modulus11DecimalAlgorithm_Validate_ShouldReturnFalse_WhenInputContainsNonDigitCharacter(String value)
+      => _sut.Validate(value).Should().BeFalse();
+
+   [Fact]
+   public void Modulus11DecimalAlgorithm_Validate_ShouldReturnFalse_WhenCheckDigitIsNonDigitCharacter()
+      => _sut.Validate("100030000X").Should().BeFalse();    // Actual check digit would be 5
+
+   #endregion
+
+   #region Validate (ICheckDigitMask Overload) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void Modulus11DecimalAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputIsNull()
+      => _sut.Validate(null!, _acceptAllMask).Should().BeFalse();
+
+   [Fact]
+   public void Modulus11DecimalAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputIsEmpty()
+      => _sut.Validate(String.Empty, _acceptAllMask).Should().BeFalse();
+
+   [Fact]
+   public void Modulus11DecimalAlgorithm_ValidateMasked_ShouldReturnFalse_WhenAllNonCheckDigitCharactersAreMaskedOut()
+      => _sut.Validate("000 000 000 0", _rejectAllMask).Should().BeFalse();
+
+   [Theory]
+   [InlineData("0")]       // Zero would return true unless length is explicitly checked.
+   [InlineData("1")]
+   public void Modulus11DecimalAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInsufficientUnmaskedCharactersToCalculateCheckDigit(String value)
+      => _sut.Validate(value, _acceptAllMask).Should().BeFalse();
+
+   [Fact]
+   public void Modulus11DecimalAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputHasLengthGreaterThan10()
+      => _sut.Validate("000 000 000 00", _groupsOfThreeMask).Should().BeFalse();
+
+   [Theory]
+   [InlineData("000 000 001 9")]
+   [InlineData("000 000 010 8")]
+   [InlineData("000 000 100 7")]
+   [InlineData("000 001 000 6")]
+   [InlineData("000 010 000 5")]
+   [InlineData("000 100 000 4")]
+   [InlineData("001 000 000 3")]
+   [InlineData("010 000 000 2")]
+   [InlineData("100 000 000 1")]
+   public void Modulus11DecimalAlgorithm_ValidateMasked_ShouldCorrectlyWeightCharactersByPosition(String value)
+      => _sut.Validate(value, _groupsOfThreeMask).Should().BeTrue();
+
+   [Theory]
+   [InlineData("156 865 652 1")]    // ISBN-10 Island in the Stream of Time, S. M. Sterling
+   [InlineData("044 100 560 8")]    // ISBN-10 The Warlock in Spite of Himself, Christopher Stasheff
+   [InlineData("071 410 544 9")]    // ISBN-10 The Sutton Hoo Ship Burial, Angela Care Evans
+   //
+   [InlineData("030 640 615 2")]    // Worked example of ISBN-10 from Wikipedia https://en.wikipedia.org/wiki/ISBN#ISBN-10_check_digits
+   [InlineData("037 859 55")]       // Worked example of ISSN from Wikipedia https://en.wikipedia.org/wiki/ISSN
+   [InlineData("031 784 71")]       // Example ISSN from https://www.issn.org/understanding-the-issn/what-is-an-issn/
+   //
+   [InlineData("943 476 591 9")]    // Worked example from Wikipedia https://en.wikipedia.org/wiki/NHS_number#Format,_number_ranges,_and_check_characters
+   [InlineData("450 557 710 4")]    // Example from https://www.clatterbridgecc.nhs.uk/patients/general-information/nhs-number#:~:text=Your%20NHS%20Number%20is%20printed,is%20an%20example%20number%20only).
+   [InlineData("530 119 491 7")]    // Random NHS number from http://danielbayley.uk/nhs-number/
+   public void Modulus11Algorithm_ValidateMasked_ShouldReturnTrue_WhenValueContainsValidCheckDigit(String value)
+      => _sut.Validate(value, _groupsOfThreeMask).Should().BeTrue();
+
+
+   [Theory]
+   [InlineData("1568656521")]    // ISBN-10 Island in the Stream of Time, S. M. Sterling
+   [InlineData("0441005608")]    // ISBN-10 The Warlock in Spite of Himself, Christopher Stasheff
+   [InlineData("0714105449")]    // ISBN-10 The Sutton Hoo Ship Burial, Angela Care Evans
+   //
+   [InlineData("0306406152")]    // Worked example of ISBN-10 from Wikipedia https://en.wikipedia.org/wiki/ISBN#ISBN-10_check_digits
+   [InlineData("03785955")]      // Worked example of ISSN from Wikipedia https://en.wikipedia.org/wiki/ISSN
+   [InlineData("03178471")]      // Example ISSN from https://www.issn.org/understanding-the-issn/what-is-an-issn/
+   //
+   [InlineData("9434765919")]    // Worked example from Wikipedia https://en.wikipedia.org/wiki/NHS_number#Format,_number_ranges,_and_check_characters
+   [InlineData("4505577104")]    // Example from https://www.clatterbridgecc.nhs.uk/patients/general-information/nhs-number#:~:text=Your%20NHS%20Number%20is%20printed,is%20an%20example%20number%20only).
+   [InlineData("5301194917")]    // Random NHS number from http://danielbayley.uk/nhs-number/
+   public void Modulus11Algorithm_ValidateMasked_ShouldReturnTrue_WhenValueContainsValidCheckDigitAndMaskAcceptsAllCharacters(String value)
+      => _sut.Validate(value, _acceptAllMask).Should().BeTrue();
+
+   [Theory]
+   [InlineData("156 864 652 1")]    // ISBN-10 with single digit transcription error 5 -> 4
+   [InlineData("044 105 060 8")]    // ISBN-10 with two digit transposition error 05 -> 50
+   [InlineData("394 678 788 1")]    // Valid NHS number (9876544321) with jump transposition 674 -> 467
+   [InlineData("851 556 824 3")]    // Valid NHS number (8514468243) with twin error 44 -> 55
+   public void Modulus11DecimalAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputContainsDetectableError(String value)
+      => _sut.Validate(value).Should().BeFalse();
+
+   [Fact]
+   public void Modulus11DecimalAlgorithm_ValidateMasked_ShouldReturnTrue_WhenInputIsAllZeros()
+      => _sut.Validate("000 000 000 0", _groupsOfThreeMask).Should().BeTrue();
+
+   [Theory]
+   // ISBN and ISSN test cases that would result in a check digit = 'X', replaced with '0'
+   [InlineData("050 027 293 0")]    // ISBN-10 Roman London, Peter Marsden
+   //
+   [InlineData("243 456 10")]       // Example ISSN from Wikipedia
+   [InlineData("105 012 40")]       // Example ISSN from https://www.issn.org/understanding-the-issn/what-is-an-issn/
+   public void Modulus11DecimalAlgorithm_ValidateMasked_ShouldReturnTrue_WhenModulus11HasRemainderOf10(String value)
+      => _sut.Validate(value, _groupsOfThreeMask).Should().BeFalse();
+
+   [Theory]
+   [InlineData("100 0G0 000 5")]    // Value 1000300005 would have a check digit = 5. G is 20 positions later in ASCII table than 3 and would also calculate check digit 5 unless code explicitly checks for non-digit
+   [InlineData("100 0)0 000 5")]    // ) is 10 positions earlier in ASCII table than 3 and would also calculate check digit 5 unless code explicitly checks for non-digit
+   [InlineData("5 0 119 4 1 7")]    // Random NHS number from http://danielbayley.uk/nhs-number/ with extraneous spaces
+   public void Modulus11DecimalAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputContainsNonDigitCharacter(String value)
+      => _sut.Validate(value, _groupsOfThreeMask).Should().BeFalse();
+
+   [Fact]
+   public void Modulus11DecimalAlgorithm_ValidateMasked_ShouldReturnFalse_WhenCheckDigitIsNonDigitCharacter()
+      => _sut.Validate("100 030 000 X", _groupsOfThreeMask).Should().BeFalse();    // Actual check digit would be 5
 
    #endregion
 }

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11DecimalAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11DecimalAlgorithmTests.cs
@@ -1,0 +1,26 @@
+﻿namespace CheckDigits.Net.Tests.Unit.GeneralAlgorithms;
+
+public class Modulus11DecimalAlgorithmTests
+{
+   private readonly Modulus11DecimalAlgorithm _sut = new();
+
+   #region AlgorithmDescription Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void Modulus11DecimalAlgorithm_AlgorithmDescription_ShouldReturnExpectedValue()
+      => _sut.AlgorithmDescription.Should().Be(Resources.Modulus11DecimalAlgorithmDescription);
+
+   #endregion
+
+   #region AlgorithmName Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void Modulus11DecimalAlgorithm_AlgorithmName_ShouldReturnExpectedValue()
+      => _sut.AlgorithmName.Should().Be(Resources.Modulus11DecimalAlgorithmName);
+
+   #endregion
+}

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11DecimalAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11DecimalAlgorithmTests.cs
@@ -246,7 +246,7 @@ public class Modulus11DecimalAlgorithmTests
    [InlineData("1406")]
    [InlineData("1406620")]
    [InlineData("1406625388")]
-   public void Modulus10DecimalAlgorithm_Validate_ShouldReturnTrue_ForBenchmarkValues(String value)
+   public void Modulus11DecimalAlgorithm_Validate_ShouldReturnTrue_ForBenchmarkValues(String value)
       => _sut.Validate(value).Should().BeTrue();
 
    [Theory]
@@ -351,7 +351,7 @@ public class Modulus11DecimalAlgorithmTests
    [InlineData("394 678 788 1")]    // Valid NHS number (9876544321) with jump transposition 674 -> 467
    [InlineData("851 556 824 3")]    // Valid NHS number (8514468243) with twin error 44 -> 55
    public void Modulus11DecimalAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputContainsDetectableError(String value)
-      => _sut.Validate(value).Should().BeFalse();
+      => _sut.Validate(value, _groupsOfThreeMask).Should().BeFalse();
 
    [Fact]
    public void Modulus11DecimalAlgorithm_ValidateMasked_ShouldReturnTrue_WhenInputIsAllZeros()
@@ -363,7 +363,7 @@ public class Modulus11DecimalAlgorithmTests
    //
    [InlineData("243 456 10")]       // Example ISSN from Wikipedia
    [InlineData("105 012 40")]       // Example ISSN from https://www.issn.org/understanding-the-issn/what-is-an-issn/
-   public void Modulus11DecimalAlgorithm_ValidateMasked_ShouldReturnTrue_WhenModulus11HasRemainderOf10(String value)
+   public void Modulus11DecimalAlgorithm_ValidateMasked_ShouldReturnFalse_WhenModulus11HasRemainderOf10(String value)
       => _sut.Validate(value, _groupsOfThreeMask).Should().BeFalse();
 
    [Theory]
@@ -381,7 +381,7 @@ public class Modulus11DecimalAlgorithmTests
    [InlineData("140 6")]
    [InlineData("140 662 0")]
    [InlineData("140 662 538 8")]
-   public void Modulus10DecimalAlgorithm_ValidateMasked_ShouldReturnTrue_ForBenchmarkValues(String value)
+   public void Modulus11DecimalAlgorithm_ValidateMasked_ShouldReturnTrue_ForBenchmarkValues(String value)
       => _sut.Validate(value, _groupsOfThreeMask).Should().BeTrue();
 
    #endregion

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11ExtendedAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11ExtendedAlgorithmTests.cs
@@ -1,0 +1,315 @@
+﻿namespace CheckDigits.Net.Tests.Unit.GeneralAlgorithms;
+
+public class Modulus11ExtendedAlgorithmTests
+{
+   private readonly Modulus11ExtendedAlgorithm _sut = new();
+   private readonly ICheckDigitMask _acceptAllMask = new AcceptAllMask();
+   private readonly ICheckDigitMask _groupsOfThreeMask = new GroupsOfThreeCheckDigitMask();
+   private readonly ICheckDigitMask _rejectAllMask = new RejectAllMask();
+
+   #region AlgorithmDescription Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void Modulus11ExtendedAlgorithm_AlgorithmDescription_ShouldReturnExpectedValue()
+      => _sut.AlgorithmDescription.Should().Be(Resources.Modulus11ExtendedAlgorithmDescription);
+
+   #endregion
+
+   #region AlgorithmName Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void Modulus11ExtendedAlgorithm_AlgorithmName_ShouldReturnExpectedValue()
+      => _sut.AlgorithmName.Should().Be(Resources.Modulus11ExtendedAlgorithmName);
+
+   #endregion
+
+   #region TryCalculateCheckDigit Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void Modulus11ExtendedAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenInputIsNull()
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(null!, out var checkDigit).Should().BeFalse();
+      checkDigit.Should().Be('\0');
+   }
+
+   [Fact]
+   public void Modulus11ExtendedAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenInputIsEmpty()
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(String.Empty, out var checkDigit).Should().BeFalse();
+      checkDigit.Should().Be('\0');
+   }
+
+   [Fact]
+   public void Modulus11ExtendedAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenInputHasLengthGreaterThanNine()
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit("1234567890", out var checkDigit).Should().BeFalse();
+      checkDigit.Should().Be('\0');
+   }
+
+   [Theory]
+   [InlineData("000000001", '9')]
+   [InlineData("000000010", '8')]
+   [InlineData("000000100", '7')]
+   [InlineData("000001000", '6')]
+   [InlineData("000010000", '5')]
+   [InlineData("000100000", '4')]
+   [InlineData("001000000", '3')]
+   [InlineData("010000000", '2')]
+   [InlineData("100000000", '1')]
+   public void Modulus11ExtendedAlgorithm_TryCalculateCheckDigit_ShouldCorrectlyWeightCharactersByPosition(
+      String value,
+      Char expectedCheckDigit)
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
+      checkDigit.Should().Be(expectedCheckDigit);
+   }
+
+   [Theory]
+   [InlineData("156865652", '1')]    // ISBN-10 Island in the Stream of Time, S. M. Sterling
+   [InlineData("044100560", '8')]    // ISBN-10 The Warlock in Spite of Himself, Christopher Stasheff
+   [InlineData("071410544", '9')]    // ISBN-10 The Sutton Hoo Ship Burial, Angela Care Evans
+   [InlineData("050027293", 'X')]    // ISBN-10 Roman London, Peter Marsden
+                                     //
+   [InlineData("030640615", '2')]    // Worked example of ISBN-10 from Wikipedia https://en.wikipedia.org/wiki/ISBN#ISBN-10_check_digits
+   [InlineData("0378595", '5')]      // Worked example of ISSN from Wikipedia https://en.wikipedia.org/wiki/ISSN
+   [InlineData("2434561", 'X')]      // Example ISSN from Wikipedia
+   [InlineData("0317847", '1')]      // Example ISSN from https://www.issn.org/understanding-the-issn/what-is-an-issn/
+   [InlineData("1050124", 'X')]      // "
+   public void Modulus11ExtendedAlgorithm_TryCalculateCheckDigit_ShouldCalculateExpectedCheckDigit(
+      String value,
+      Char expectedCheckDigit)
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
+      checkDigit.Should().Be(expectedCheckDigit);
+   }
+
+   [Fact]
+   public void Modulus11ExtendedAlgorithm_TryCalculateCheckDigit_ShouldCalculateExpectedCheckDigit_WhenInputIsAllZeros()
+   {
+      // Arrange.
+      var value = "00000";
+      var expectedCheckDigit = Chars.DigitZero;
+
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
+      checkDigit.Should().Be(expectedCheckDigit);
+   }
+
+   [Theory]
+   [InlineData("100G00001")]
+   [InlineData("100+00001")]
+   public void Modulus11ExtendedAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenInputContainsNonDigitCharacter(String value)
+   {
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeFalse();
+      checkDigit.Should().Be('\0');
+   }
+
+   [Theory]
+   // ISBN and ISSN test cases that would result in a check digit = 'X'
+   [InlineData("050027293")]        // ISBN-10 Roman London, Peter Marsden
+   //
+   [InlineData("2434561")]          // Example ISSN from Wikipedia
+   [InlineData("1050124")]          // Example ISSN from https://www.issn.org/understanding-the-issn/what-is-an-issn/
+   public void Modulus11DecimalAlgorithm_TryCalculateCheckDigit_ShouldReturnTrue_WhenModulus11HasRemainderOf10(String value)
+   {
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
+      checkDigit.Should().Be(Chars.UpperCaseX);
+   }
+
+   #endregion
+
+   #region Validate Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void Modulus11ExtendedAlgorithm_Validate_ShouldReturnFalse_WhenInputIsNull()
+      => _sut.Validate(null!).Should().BeFalse();
+
+   [Fact]
+   public void Modulus11ExtendedAlgorithm_Validate_ShouldReturnFalse_WhenInputIsEmpty()
+      => _sut.Validate(String.Empty).Should().BeFalse();
+
+   [Theory]
+   [InlineData("0")]       // Zero would return true unless length is explicitly checked.
+   [InlineData("1")]
+   public void Modulus11ExtendedAlgorithm_Validate_ShouldReturnFalse_WhenInputHasLengthLessThanTwo(String value)
+      => _sut.Validate(value).Should().BeFalse();
+
+   [Fact]
+   public void Modulus11ExtendedAlgorithm_Validate_ShouldReturnFalse_WhenInputHasLengthGreaterThan10()
+      => _sut.Validate("00000000000").Should().BeFalse();
+
+   [Theory]
+   [InlineData("0000000019")]
+   [InlineData("0000000108")]
+   [InlineData("0000001007")]
+   [InlineData("0000010006")]
+   [InlineData("0000100005")]
+   [InlineData("0001000004")]
+   [InlineData("0010000003")]
+   [InlineData("0100000002")]
+   [InlineData("1000000001")]
+   public void Modulus11ExtendedAlgorithm_Validate_ShouldCorrectlyWeightCharactersByPosition(String value)
+      => _sut.Validate(value).Should().BeTrue();
+
+   [Theory]
+   [InlineData("1568656521")]    // ISBN-10 Island in the Stream of Time, S. M. Sterling
+   [InlineData("0441005608")]    // ISBN-10 The Warlock in Spite of Himself, Christopher Stasheff
+   [InlineData("0714105449")]    // ISBN-10 The Sutton Hoo Ship Burial, Angela Care Evans
+   [InlineData("050027293X")]    // ISBN-10 Roman London, Peter Marsden
+                                 //
+   [InlineData("0306406152")]    // Worked example of ISBN-10 from Wikipedia https://en.wikipedia.org/wiki/ISBN#ISBN-10_check_digits
+   [InlineData("03785955")]      // Worked example of ISSN from Wikipedia https://en.wikipedia.org/wiki/ISSN
+   [InlineData("2434561X")]      // Example ISSN from Wikipedia
+   [InlineData("03178471")]      // Example ISSN from https://www.issn.org/understanding-the-issn/what-is-an-issn/
+   [InlineData("1050124X")]      // "
+   //
+   [InlineData("9434765919")]    // Worked example from Wikipedia https://en.wikipedia.org/wiki/NHS_number#Format,_number_ranges,_and_check_characters
+   [InlineData("4505577104")]    // Example from https://www.clatterbridgecc.nhs.uk/patients/general-information/nhs-number#:~:text=Your%20NHS%20Number%20is%20printed,is%20an%20example%20number%20only).
+   [InlineData("5301194917")]    // Random NHS number from http://danielbayley.uk/nhs-number/
+   public void Modulus11ExtendedAlgorithm_Validate_ShouldReturnTrue_WhenValueContainsValidCheckDigit(String value)
+      => _sut.Validate(value).Should().BeTrue();
+
+   [Theory]
+   [InlineData("1568646521")]    // ISBN-10 with single digit transcription error 5 -> 4
+   [InlineData("0441050608")]    // ISBN-10 with two digit transposition error 05 -> 50
+   [InlineData("050029273X")]    // ISBN-10 with jump transposition 729 -> 927
+   [InlineData("0551005608")]    // ISBN-10 with twin error 44 -> 55
+   public void Modulus11ExtendedAlgorithm_Validate_ShouldReturnFalse_WhenInputContainsDetectableError(String value)
+      => _sut.Validate(value).Should().BeFalse();
+
+   [Fact]
+   public void Modulus11ExtendedAlgorithm_Validate_ShouldReturnTrue_WhenInputIsAllZeros()
+      => _sut.Validate("0000000000").Should().BeTrue();
+
+   [Fact]
+   public void Modulus11ExtendedAlgorithm_Validate_ShouldReturnTrue_WhenCheckDigitIsCalculatesAsX()
+      => _sut.Validate("010000010X").Should().BeTrue();
+
+   [Theory]
+   [InlineData("1000G00005")]    // Value 1000300005 would have check digit = 5. G is 20 positions later in ASCII table than 3 and would also calculate check digit 5 unless code explicitly checks for non-digit
+   [InlineData("1000)00005")]    // ) is 10 positions earlier in ASCII table than 3 and would also calculate check digit 5 unless code explicitly checks for non-digit
+   public void Modulus11ExtendedAlgorithm_Validate_ShouldReturnFalse_WhenInputContainsNonDigitCharacter(String value)
+      => _sut.Validate(value).Should().BeFalse();
+
+   [Fact]
+   public void Modulus11ExtendedAlgorithm_Validate_ShouldReturnFalse_WhenCheckDigitIsNonDigitCharacter()
+      => _sut.Validate("100030000?").Should().BeFalse();    // Actual check digit would be 5
+
+   #endregion
+
+   #region Validate (ICheckDigitMask Overload) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void Modulus11ExtendedAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputIsNull()
+      => _sut.Validate(null!, _acceptAllMask).Should().BeFalse();
+
+   [Fact]
+   public void Modulus11ExtendedAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputIsEmpty()
+      => _sut.Validate(String.Empty, _acceptAllMask).Should().BeFalse();
+
+   [Fact]
+   public void Modulus11ExtendedAlgorithm_ValidateMasked_ShouldReturnFalse_WhenAllNonCheckDigitCharactersAreMaskedOut()
+      => _sut.Validate("000 000 000 0", _rejectAllMask).Should().BeFalse();
+
+   [Theory]
+   [InlineData("0")]       // Zero would return true unless length is explicitly checked.
+   [InlineData("1")]
+   public void Modulus11ExtendedAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInsufficientUnmaskedCharactersToCalculateCheckDigit(String value)
+      => _sut.Validate(value, _acceptAllMask).Should().BeFalse();
+
+   [Fact]
+   public void Modulus11ExtendedAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputHasLengthGreaterThan10()
+      => _sut.Validate("000 000 000 00", _groupsOfThreeMask).Should().BeFalse();
+
+   [Theory]
+   [InlineData("000 000 001 9")]
+   [InlineData("000 000 010 8")]
+   [InlineData("000 000 100 7")]
+   [InlineData("000 001 000 6")]
+   [InlineData("000 010 000 5")]
+   [InlineData("000 100 000 4")]
+   [InlineData("001 000 000 3")]
+   [InlineData("010 000 000 2")]
+   [InlineData("100 000 000 1")]
+   public void Modulus11ExtendedAlgorithm_ValidateMasked_ShouldCorrectlyWeightCharactersByPosition(String value)
+      => _sut.Validate(value, _groupsOfThreeMask).Should().BeTrue();
+
+   [Theory]
+   [InlineData("156 865 652 1")] // ISBN-10 Island in the Stream of Time, S. M. Sterling
+   [InlineData("044 100 560 8")] // ISBN-10 The Warlock in Spite of Himself, Christopher Stasheff
+   [InlineData("071 410 544 9")] // ISBN-10 The Sutton Hoo Ship Burial, Angela Care Evans
+   [InlineData("050 027 293 X")] // ISBN-10 Roman London, Peter Marsden
+                                 //
+   [InlineData("030 640 615 2")] // Worked example of ISBN-10 from Wikipedia https://en.wikipedia.org/wiki/ISBN#ISBN-10_check_digits
+   [InlineData("037 859 55")]    // Worked example of ISSN from Wikipedia https://en.wikipedia.org/wiki/ISSN
+   [InlineData("243 456 1X")]    // Example ISSN from Wikipedia
+   [InlineData("031 784 71")]    // Example ISSN from https://www.issn.org/understanding-the-issn/what-is-an-issn/
+   [InlineData("105 012 4X")]    // "
+   //
+   [InlineData("943 476 591 9")] // Worked example from Wikipedia https://en.wikipedia.org/wiki/NHS_number#Format,_number_ranges,_and_check_characters
+   [InlineData("450 557 710 4")] // Example from https://www.clatterbridgecc.nhs.uk/patients/general-information/nhs-number#:~:text=Your%20NHS%20Number%20is%20printed,is%20an%20example%20number%20only).
+   [InlineData("530 119 491 7")] // Random NHS number from http://danielbayley.uk/nhs-number/
+   public void Modulus11ExtendedAlgorithm_ValidateMasked_ShouldReturnTrue_WhenValueContainsValidCheckDigit(String value)
+      => _sut.Validate(value, _groupsOfThreeMask).Should().BeTrue();
+
+   [Theory]
+   [InlineData("1568656521")]    // ISBN-10 Island in the Stream of Time, S. M. Sterling
+   [InlineData("0441005608")]    // ISBN-10 The Warlock in Spite of Himself, Christopher Stasheff
+   [InlineData("0714105449")]    // ISBN-10 The Sutton Hoo Ship Burial, Angela Care Evans
+   [InlineData("050027293X")]    // ISBN-10 Roman London, Peter Marsden
+   //
+   [InlineData("0306406152")]    // Worked example of ISBN-10 from Wikipedia https://en.wikipedia.org/wiki/ISBN#ISBN-10_check_digits
+   [InlineData("03785955")]      // Worked example of ISSN from Wikipedia https://en.wikipedia.org/wiki/ISSN
+   [InlineData("2434561X")]      // Example ISSN from Wikipedia
+   [InlineData("03178471")]      // Example ISSN from https://www.issn.org/understanding-the-issn/what-is-an-issn/
+   [InlineData("1050124X")]      // "
+   //
+   [InlineData("9434765919")]    // Worked example from Wikipedia https://en.wikipedia.org/wiki/NHS_number#Format,_number_ranges,_and_check_characters
+   [InlineData("4505577104")]    // Example from https://www.clatterbridgecc.nhs.uk/patients/general-information/nhs-number#:~:text=Your%20NHS%20Number%20is%20printed,is%20an%20example%20number%20only).
+   [InlineData("5301194917")]    // Random NHS number from http://danielbayley.uk/nhs-number/
+   public void Modulus11ExtendedAlgorithm_ValidateMasked_ShouldReturnTrue_WhenValueContainsValidCheckDigitAndMaskAcceptsAllCharacters(String value)
+      => _sut.Validate(value, _acceptAllMask).Should().BeTrue();
+
+   [Theory]
+   [InlineData("156 864 652 1")] // ISBN-10 with single digit transcription error 5 -> 4
+   [InlineData("044 105 060 8")] // ISBN-10 with two digit transposition error 05 -> 50
+   [InlineData("050 029 273 X")] // ISBN-10 with jump transposition 729 -> 927
+   [InlineData("055 100 560 8")] // ISBN-10 with twin error 44 -> 55
+   public void Modulus11ExtendedAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputContainsDetectableError(String value)
+      => _sut.Validate(value, _groupsOfThreeMask).Should().BeFalse();
+
+   [Fact]
+   public void Modulus11ExtendedAlgorithm_ValidateMasked_ShouldReturnTrue_WhenInputIsAllZeros()
+      => _sut.Validate("000 000 000 0", _groupsOfThreeMask).Should().BeTrue();
+
+   [Fact]
+   public void Modulus11ExtendedAlgorithm_ValidateMasked_ShouldReturnTrue_WhenCheckDigitIsCalculatesAsX()
+      => _sut.Validate("010 000 010 X", _groupsOfThreeMask).Should().BeTrue();
+
+   [Theory]
+   [InlineData("100 0G0 000 5")] // Value 1000300005 would have check digit = 5. G is 20 positions later in ASCII table than 3 and would also calculate check digit 5 unless code explicitly checks for non-digit
+   [InlineData("100 0)0 000 5")] // ) is 10 positions earlier in ASCII table than 3 and would also calculate check digit 5 unless code explicitly checks for non-digit
+   public void Modulus11ExtendedAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputContainsNonDigitCharacter(String value)
+      => _sut.Validate(value, _groupsOfThreeMask).Should().BeFalse();
+
+   [Fact]
+   public void Modulus11ExtendedAlgorithm_ValidateMasked_ShouldReturnFalse_WhenCheckDigitIsNonDigitCharacter()
+      => _sut.Validate("100 030 000 ?", _groupsOfThreeMask).Should().BeFalse();    // Actual check digit would be 5
+
+   #endregion
+}

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11ExtendedAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11ExtendedAlgorithmTests.cs
@@ -275,7 +275,7 @@ public class Modulus11ExtendedAlgorithmTests
    [InlineData("1406")]
    [InlineData("1406620")]
    [InlineData("1406625388")]
-   public void Modulus10ExtendedAlgorithm_Validate_ShouldReturnTrue_ForBenchmarkValues(String value)
+   public void Modulus11ExtendedAlgorithm_Validate_ShouldReturnTrue_ForBenchmarkValues(String value)
       => _sut.Validate(value).Should().BeTrue();
 
    [Theory]
@@ -425,7 +425,7 @@ public class Modulus11ExtendedAlgorithmTests
    [InlineData("140 6")]
    [InlineData("140 662 0")]
    [InlineData("140 662 538 8")]
-   public void Modulus10DecimalAlgorithm_ValidateMasked_ShouldReturnTrue_ForBenchmarkValues(String value)
+   public void Modulus11ExtendedAlgorithm_ValidateMasked_ShouldReturnTrue_ForBenchmarkValues(String value)
       => _sut.Validate(value, _groupsOfThreeMask).Should().BeTrue();
 
    #endregion

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11ExtendedAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11ExtendedAlgorithmTests.cs
@@ -56,6 +56,27 @@ public class Modulus11ExtendedAlgorithmTests
    }
 
    [Theory]
+   [InlineData("0", '0')]        // Sum = 0, mod = (11-(0%11))%11=0
+   [InlineData("1", '9')]        // Sum = 2, mod = (11-(1%11))%11=9
+   [InlineData("2", '7')]        // Sum = 4, mod = (11-(4%11))%11=7
+   [InlineData("3", '5')]        // Sum = 6, mod = (11-(6%11))%11=5
+   [InlineData("4", '3')]        // Sum = 8, mod = (11-(8%11))%11=3
+   [InlineData("5", '1')]        // Sum = 10, mod = (11-(10%11))%11=1
+   [InlineData("6", 'X')]        // Sum = 12, mod = (11-(12%11))%11=X
+   [InlineData("7", '8')]        // Sum = 14, mod = (11-(14%11))%11=8
+   [InlineData("8", '6')]        // Sum = 16, mod = (11-(16%11))%11=6
+   [InlineData("9", '4')]        // Sum = 18, mod = (11-(18%11))%11=4
+   [InlineData("61", '2')]        // Sum = 20, mod = (11-(20%11))%11=2
+   public void Modulus11ExtendedAlgorithm_TryCalculateCheckDigit_ShouldReturnAllPossibleValidCheckDigits(
+      String value,
+      Char expectedCheckDigit)
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
+      checkDigit.Should().Be(expectedCheckDigit);
+   }
+
+   [Theory]
    [InlineData("000000001", '9')]
    [InlineData("000000010", '8')]
    [InlineData("000000100", '7')]
@@ -121,10 +142,36 @@ public class Modulus11ExtendedAlgorithmTests
    //
    [InlineData("2434561")]          // Example ISSN from Wikipedia
    [InlineData("1050124")]          // Example ISSN from https://www.issn.org/understanding-the-issn/what-is-an-issn/
-   public void Modulus11DecimalAlgorithm_TryCalculateCheckDigit_ShouldReturnTrue_WhenModulus11HasRemainderOf10(String value)
+   public void Modulus11ExtendedAlgorithm_TryCalculateCheckDigit_ShouldReturnTrue_WhenModulus11HasRemainderOf10(String value)
    {
       _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
       checkDigit.Should().Be(Chars.UpperCaseX);
+   }
+
+   [Theory]
+   [InlineData("156865652")]    // ISBN-10 Island in the Stream of Time, S. M. Sterling
+   [InlineData("044100560")]    // ISBN-10 The Warlock in Spite of Himself, Christopher Stasheff
+   [InlineData("071410544")]    // ISBN-10 The Sutton Hoo Ship Burial, Angela Care Evans
+   [InlineData("050027293")]    // ISBN-10 Roman London, Peter Marsden
+   //
+   [InlineData("030640615")]    // Worked example of ISBN-10 from Wikipedia https://en.wikipedia.org/wiki/ISBN#ISBN-10_check_digits
+   [InlineData("0378595")]      // Worked example of ISSN from Wikipedia https://en.wikipedia.org/wiki/ISSN
+   [InlineData("2434561")]      // Example ISSN from Wikipedia
+   [InlineData("0317847")]      // Example ISSN from https://www.issn.org/understanding-the-issn/what-is-an-issn/
+   [InlineData("1050124")]      // "
+   public void Modulus11ExtendedAlgorithm_TryCalculateCheckDigit_ShouldProduceSameResultAsDepreciatedModulus11Algorithm(String value)
+   {
+      // Arrange.
+      var deprecatedAlgorithm = new Modulus11Algorithm();
+      var extendedAlgorithm = new Modulus11ExtendedAlgorithm();
+
+      // Act.
+      var deprecatedResult = deprecatedAlgorithm.TryCalculateCheckDigit(value, out var depreciatedCheckDigit);
+      var extendedResult = extendedAlgorithm.TryCalculateCheckDigit(value, out var extendedCheckDigit);
+
+      // Assert.
+      extendedResult.Should().Be(deprecatedResult);
+      extendedCheckDigit.Should().Be(extendedCheckDigit);
    }
 
    #endregion
@@ -208,6 +255,44 @@ public class Modulus11ExtendedAlgorithmTests
    public void Modulus11ExtendedAlgorithm_Validate_ShouldReturnFalse_WhenCheckDigitIsNonDigitCharacter()
       => _sut.Validate("100030000?").Should().BeFalse();    // Actual check digit would be 5
 
+   [Fact]
+   public void Modulus11ExtendedAlgorithm_Validate_ShouldReturnFalse_WhenCheckDigitIsLowerCaseXInsteadOfUpperCase()
+      => _sut.Validate("050027293x").Should().BeFalse();    // SBN-10 Roman London, Peter Marsden
+
+   [Theory]
+   [InlineData("1568656521")]    // ISBN-10 Island in the Stream of Time, S. M. Sterling
+   [InlineData("0441005608")]    // ISBN-10 The Warlock in Spite of Himself, Christopher Stasheff
+   [InlineData("0714105449")]    // ISBN-10 The Sutton Hoo Ship Burial, Angela Care Evans
+   [InlineData("050027293X")]    // ISBN-10 Roman London, Peter Marsden
+   //
+   [InlineData("0306406152")]    // Worked example of ISBN-10 from Wikipedia https://en.wikipedia.org/wiki/ISBN#ISBN-10_check_digits
+   [InlineData("03785955")]      // Worked example of ISSN from Wikipedia https://en.wikipedia.org/wiki/ISSN
+   [InlineData("2434561X")]      // Example ISSN from Wikipedia
+   [InlineData("03178471")]      // Example ISSN from https://www.issn.org/understanding-the-issn/what-is-an-issn/
+   [InlineData("1050124X")]      // "
+   //
+   [InlineData("9434765919")]    // Worked example from Wikipedia https://en.wikipedia.org/wiki/NHS_number#Format,_number_ranges,_and_check_characters
+   [InlineData("4505577104")]    // Example from https://www.clatterbridgecc.nhs.uk/patients/general-information/nhs-number#:~:text=Your%20NHS%20Number%20is%20printed,is%20an%20example%20number%20only).
+   [InlineData("5301194917")]    // Random NHS number from http://danielbayley.uk/nhs-number/
+   //
+   [InlineData("1568646521")]    // ISBN-10 with single digit transcription error 5 -> 4
+   [InlineData("0441050608")]    // ISBN-10 with two digit transposition error 05 -> 50
+   [InlineData("050029273X")]    // ISBN-10 with jump transposition 729 -> 927
+   [InlineData("0551005608")]    // ISBN-10 with twin error 44 -> 55
+   public void Modulus11ExtendedAlgorithm_Validate_ShouldProduceSameResultAsDepreciatedModulus11Algorithm(String value)
+   {
+      // Arrange.
+      var deprecatedAlgorithm = new Modulus11Algorithm();
+      var extendedAlgorithm = new Modulus11ExtendedAlgorithm();
+
+      // Act.
+      var deprecatedResult = deprecatedAlgorithm.Validate(value);
+      var extendedResult = extendedAlgorithm.Validate(value);
+
+      // Assert.
+      extendedResult.Should().Be(deprecatedResult);
+   }
+
    #endregion
 
    #region Validate (ICheckDigitMask Overload) Tests
@@ -233,8 +318,8 @@ public class Modulus11ExtendedAlgorithmTests
       => _sut.Validate(value, _acceptAllMask).Should().BeFalse();
 
    [Fact]
-   public void Modulus11ExtendedAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputHasLengthGreaterThan10()
-      => _sut.Validate("000 000 000 00", _groupsOfThreeMask).Should().BeFalse();
+   public void Modulus11ExtendedAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputHasMoreThan9UnmaskedDigits()
+      => _sut.Validate("00000000019", _acceptAllMask).Should().BeFalse();
 
    [Theory]
    [InlineData("000 000 001 9")]
@@ -310,6 +395,10 @@ public class Modulus11ExtendedAlgorithmTests
    [Fact]
    public void Modulus11ExtendedAlgorithm_ValidateMasked_ShouldReturnFalse_WhenCheckDigitIsNonDigitCharacter()
       => _sut.Validate("100 030 000 ?", _groupsOfThreeMask).Should().BeFalse();    // Actual check digit would be 5
+
+   [Fact]
+   public void Modulus11ExtendedAlgorithm_ValidateMasked_ShouldReturnFalse_WhenCheckDigitIsLowerCaseXInsteadOfUpperCase()
+      => _sut.Validate("050 027 293 x", _groupsOfThreeMask).Should().BeFalse();    // SBN-10 Roman London, Peter Marsden
 
    #endregion
 }

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11ExtendedAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11ExtendedAlgorithmTests.cs
@@ -149,6 +149,13 @@ public class Modulus11ExtendedAlgorithmTests
    }
 
    [Theory]
+   [InlineData("140")]
+   [InlineData("140662")]
+   [InlineData("140662538")]
+   public void Modulus11ExtendedAlgorithm_TryCalculateCheckDigit_ShouldReturnTrue_ForBenchmarkValues(String value)
+      => _sut.TryCalculateCheckDigit(value, out _).Should().BeTrue();
+
+   [Theory]
    [InlineData("156865652")]    // ISBN-10 Island in the Stream of Time, S. M. Sterling
    [InlineData("044100560")]    // ISBN-10 The Warlock in Spite of Himself, Christopher Stasheff
    [InlineData("071410544")]    // ISBN-10 The Sutton Hoo Ship Burial, Angela Care Evans
@@ -162,7 +169,9 @@ public class Modulus11ExtendedAlgorithmTests
    public void Modulus11ExtendedAlgorithm_TryCalculateCheckDigit_ShouldProduceSameResultAsDepreciatedModulus11Algorithm(String value)
    {
       // Arrange.
+#pragma warning disable CS0618 // Type or member is obsolete
       var deprecatedAlgorithm = new Modulus11Algorithm();
+#pragma warning restore CS0618 // Type or member is obsolete
       var extendedAlgorithm = new Modulus11ExtendedAlgorithm();
 
       // Act.
@@ -171,7 +180,7 @@ public class Modulus11ExtendedAlgorithmTests
 
       // Assert.
       extendedResult.Should().Be(deprecatedResult);
-      extendedCheckDigit.Should().Be(extendedCheckDigit);
+      extendedCheckDigit.Should().Be(depreciatedCheckDigit);
    }
 
    #endregion
@@ -212,6 +221,9 @@ public class Modulus11ExtendedAlgorithmTests
       => _sut.Validate(value).Should().BeTrue();
 
    [Theory]
+   [InlineData("1406")]
+   [InlineData("1406620")]
+   [InlineData("1406625388")]
    [InlineData("1568656521")]    // ISBN-10 Island in the Stream of Time, S. M. Sterling
    [InlineData("0441005608")]    // ISBN-10 The Warlock in Spite of Himself, Christopher Stasheff
    [InlineData("0714105449")]    // ISBN-10 The Sutton Hoo Ship Burial, Angela Care Evans
@@ -260,6 +272,13 @@ public class Modulus11ExtendedAlgorithmTests
       => _sut.Validate("050027293x").Should().BeFalse();    // SBN-10 Roman London, Peter Marsden
 
    [Theory]
+   [InlineData("1406")]
+   [InlineData("1406620")]
+   [InlineData("1406625388")]
+   public void Modulus10ExtendedAlgorithm_Validate_ShouldReturnTrue_ForBenchmarkValues(String value)
+      => _sut.Validate(value).Should().BeTrue();
+
+   [Theory]
    [InlineData("1568656521")]    // ISBN-10 Island in the Stream of Time, S. M. Sterling
    [InlineData("0441005608")]    // ISBN-10 The Warlock in Spite of Himself, Christopher Stasheff
    [InlineData("0714105449")]    // ISBN-10 The Sutton Hoo Ship Burial, Angela Care Evans
@@ -282,7 +301,9 @@ public class Modulus11ExtendedAlgorithmTests
    public void Modulus11ExtendedAlgorithm_Validate_ShouldProduceSameResultAsDepreciatedModulus11Algorithm(String value)
    {
       // Arrange.
+#pragma warning disable CS0618 // Type or member is obsolete
       var deprecatedAlgorithm = new Modulus11Algorithm();
+#pragma warning restore CS0618 // Type or member is obsolete
       var extendedAlgorithm = new Modulus11ExtendedAlgorithm();
 
       // Act.
@@ -399,6 +420,13 @@ public class Modulus11ExtendedAlgorithmTests
    [Fact]
    public void Modulus11ExtendedAlgorithm_ValidateMasked_ShouldReturnFalse_WhenCheckDigitIsLowerCaseXInsteadOfUpperCase()
       => _sut.Validate("050 027 293 x", _groupsOfThreeMask).Should().BeFalse();    // SBN-10 Roman London, Peter Marsden
+
+   [Theory]
+   [InlineData("140 6")]
+   [InlineData("140 662 0")]
+   [InlineData("140 662 538 8")]
+   public void Modulus10DecimalAlgorithm_ValidateMasked_ShouldReturnTrue_ForBenchmarkValues(String value)
+      => _sut.Validate(value, _groupsOfThreeMask).Should().BeTrue();
 
    #endregion
 }

--- a/CheckDigits.Net.Tests.Unit/MaskedAlgorithmsTests.cs
+++ b/CheckDigits.Net.Tests.Unit/MaskedAlgorithmsTests.cs
@@ -31,4 +31,32 @@ public class MaskedAlgorithmsTests
       => MaskedAlgorithms.Modulus10_13.Should().BeOfType<Modulus10_13Algorithm>();
 
    #endregion
+
+   #region Modulus11Decimal Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void Algorithms_Modulus11Decimal_ShouldNotBeNull()
+      => Algorithms.Modulus11Decimal.Should().NotBeNull();
+
+   [Fact]
+   public void Algorithms_Modulus11Decimal_ShouldBeExpectedType()
+      => Algorithms.Modulus11Decimal.Should().BeOfType<Modulus11DecimalAlgorithm>();
+
+   #endregion
+
+   #region Modulus11Extended Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void Algorithms_Modulus11Extended_ShouldNotBeNull()
+      => Algorithms.Modulus11Extended.Should().NotBeNull();
+
+   [Fact]
+   public void Algorithms_Modulus11Extended_ShouldBeExpectedType()
+      => Algorithms.Modulus11Extended.Should().BeOfType<Modulus11ExtendedAlgorithm>();
+
+   #endregion
 }

--- a/CheckDigits.Net.Tests.Unit/TestData/BenchmarkData.cs
+++ b/CheckDigits.Net.Tests.Unit/TestData/BenchmarkData.cs
@@ -103,7 +103,9 @@ public class BenchmarkData
          Algorithms.Modulus10_1,
          Algorithms.Modulus10_2,
          Algorithms.Modulus10_13,
+#pragma warning disable CS0618 // Type or member is obsolete
          Algorithms.Modulus11,
+#pragma warning restore CS0618 // Type or member is obsolete
          Algorithms.Verhoeff
       };
 

--- a/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/NhsAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/NhsAlgorithmTests.cs
@@ -1,5 +1,7 @@
 ﻿// Ignore Spelling: Nhs
 
+#pragma warning disable CS0618 // Type or member is obsolete
+
 namespace CheckDigits.Net.Tests.Unit.ValueSpecificAlgorithms;
 
 public class NhsAlgorithmTests

--- a/CheckDigits.Net/Algorithms.cs
+++ b/CheckDigits.Net/Algorithms.cs
@@ -1,4 +1,4 @@
-﻿// Ignore Spelling: Aba Cusip Damm Figi Iban Icao Isan Isin Luhn Ncd Nhs Npi Rtn Sedol Verhoeff
+﻿// Ignore Spelling: Aba Cusip Damm Figi Iban Icao Isan Isin Luhn Ncd Nhs Npi Rtn Sedol Verhoeff Vin
 
 namespace CheckDigits.Net;
 
@@ -87,16 +87,23 @@ public static class Algorithms
      new(() => new Modulus10_13Algorithm());
 
    private static readonly Lazy<ISingleCheckDigitAlgorithm> _modulus11 =
+#pragma warning disable CS0618 // Type or member is obsolete
       new(() => new Modulus11Algorithm());
+#pragma warning restore CS0618 // Type or member is obsolete
 
    private static readonly Lazy<ISingleCheckDigitAlgorithm> _modulus11Decimal =
       new(() => new Modulus11DecimalAlgorithm());
+
+   private static readonly Lazy<ISingleCheckDigitAlgorithm> _modulus11Extended =
+      new(() => new Modulus11ExtendedAlgorithm());
 
    private static readonly Lazy<ISingleCheckDigitAlgorithm> _ncd =
      new(() => new NcdAlgorithm());
 
    private static readonly Lazy<ICheckDigitAlgorithm> _nhs =
+#pragma warning disable CS0618 // Type or member is obsolete
      new(() => new NhsAlgorithm());
+#pragma warning restore CS0618 // Type or member is obsolete
 
    private static readonly Lazy<ICheckDigitAlgorithm> _npi =
      new(() => new NpiAlgorithm());
@@ -249,12 +256,18 @@ public static class Algorithms
    /// <summary>
    ///   Modulus11 algorithm.
    /// </summary>
+   [Obsolete("Modulus11 algorithm is depreciated in favor of Modulus11Extended algorithm.")]
    public static ISingleCheckDigitAlgorithm Modulus11 => _modulus11.Value;
 
    /// <summary>
    ///   Modulus11Decimal algorithm.
    /// </summary>
    public static ISingleCheckDigitAlgorithm Modulus11Decimal => _modulus11Decimal.Value;
+
+   /// <summary>
+   ///   Modulus11Extended algorithm.
+   /// </summary>
+   public static ISingleCheckDigitAlgorithm Modulus11Extended => _modulus11Extended.Value;
 
    /// <summary>
    ///   NOID (Nice Opaque Identifier) Check Digit algorithm.
@@ -264,6 +277,7 @@ public static class Algorithms
    /// <summary>
    ///   UK National Health Service (NHS) algorithm.
    /// </summary>
+   [Obsolete("Nhs algorithm is depreciated in favor of Modulus11Decimal algorithm.")]
    public static ICheckDigitAlgorithm Nhs => _nhs.Value;
 
    /// <summary>

--- a/CheckDigits.Net/Algorithms.cs
+++ b/CheckDigits.Net/Algorithms.cs
@@ -256,7 +256,7 @@ public static class Algorithms
    /// <summary>
    ///   Modulus11 algorithm.
    /// </summary>
-   [Obsolete("Modulus11 algorithm is depreciated in favor of Modulus11Extended algorithm.")]
+   [Obsolete("Modulus11 algorithm is deprecated in favor of Modulus11Extended algorithm.")]
    public static ISingleCheckDigitAlgorithm Modulus11 => _modulus11.Value;
 
    /// <summary>
@@ -277,7 +277,7 @@ public static class Algorithms
    /// <summary>
    ///   UK National Health Service (NHS) algorithm.
    /// </summary>
-   [Obsolete("Nhs algorithm is depreciated in favor of Modulus11Decimal algorithm.")]
+   [Obsolete("Nhs algorithm is deprecated in favor of Modulus11Decimal algorithm.")]
    public static ICheckDigitAlgorithm Nhs => _nhs.Value;
 
    /// <summary>

--- a/CheckDigits.Net/Algorithms.cs
+++ b/CheckDigits.Net/Algorithms.cs
@@ -87,7 +87,10 @@ public static class Algorithms
      new(() => new Modulus10_13Algorithm());
 
    private static readonly Lazy<ISingleCheckDigitAlgorithm> _modulus11 =
-     new(() => new Modulus11Algorithm());
+      new(() => new Modulus11Algorithm());
+
+   private static readonly Lazy<ISingleCheckDigitAlgorithm> _modulus11Decimal =
+      new(() => new Modulus11DecimalAlgorithm());
 
    private static readonly Lazy<ISingleCheckDigitAlgorithm> _ncd =
      new(() => new NcdAlgorithm());
@@ -247,6 +250,11 @@ public static class Algorithms
    ///   Modulus11 algorithm.
    /// </summary>
    public static ISingleCheckDigitAlgorithm Modulus11 => _modulus11.Value;
+
+   /// <summary>
+   ///   Modulus11Decimal algorithm.
+   /// </summary>
+   public static ISingleCheckDigitAlgorithm Modulus11Decimal => _modulus11Decimal.Value;
 
    /// <summary>
    ///   NOID (Nice Opaque Identifier) Check Digit algorithm.

--- a/CheckDigits.Net/GeneralAlgorithms/Modulus10_13Algorithm.cs
+++ b/CheckDigits.Net/GeneralAlgorithms/Modulus10_13Algorithm.cs
@@ -46,7 +46,7 @@ public sealed class Modulus10_13Algorithm : ISingleCheckDigitAlgorithm, IMaskedC
       for (var index = value.Length - 1; index >= 0; index--)
       {
          var digit = value[index].ToIntegerDigit();
-         if (digit < 0 || digit > 9)
+         if (digit.IsInvalidDigit())
          {
                return false;
          }
@@ -71,7 +71,7 @@ public sealed class Modulus10_13Algorithm : ISingleCheckDigitAlgorithm, IMaskedC
       for (var index = value.Length - 2; index >= 0; index--)
       {
          var digit = value[index].ToIntegerDigit();
-         if (digit is < 0 or > 9)
+         if (digit.IsInvalidDigit())
          {
             return false;
          }
@@ -102,7 +102,7 @@ public sealed class Modulus10_13Algorithm : ISingleCheckDigitAlgorithm, IMaskedC
          }
 
          var digit = value[index].ToIntegerDigit();
-         if (digit is < 0 or > 9)
+         if (digit.IsInvalidDigit())
          {
             return false;
          }

--- a/CheckDigits.Net/GeneralAlgorithms/Modulus11Algorithm.cs
+++ b/CheckDigits.Net/GeneralAlgorithms/Modulus11Algorithm.cs
@@ -6,7 +6,7 @@
 /// </summary>
 /// <remarks>
 ///   <para>
-///   This algorithm is depreciated in favor of the 
+///   This algorithm is deprecated in favor of the 
 ///   <see cref="Modulus11ExtendedAlgorithm"/> algorithm. Modulus11Extended 
 ///   produces the same results as this algorithm but is slightly more efficient 
 ///   and follows the naming convention (Decimal/Extended) used for other
@@ -32,7 +32,7 @@
 ///   and 10 characters for validating a value that contains a check digit.
 ///   </para>
 /// </remarks>
-[Obsolete("Modulus11Algorithm is depreciated in favor of Modulus11ExtendedAlgorithm.")]
+[Obsolete("Modulus11Algorithm is deprecated in favor of Modulus11ExtendedAlgorithm.")]
 public sealed class Modulus11Algorithm : ISingleCheckDigitAlgorithm
 {
    private const Int32 _tryCalculateMaxLength = 9;

--- a/CheckDigits.Net/GeneralAlgorithms/Modulus11Algorithm.cs
+++ b/CheckDigits.Net/GeneralAlgorithms/Modulus11Algorithm.cs
@@ -6,6 +6,13 @@
 /// </summary>
 /// <remarks>
 ///   <para>
+///   This algorithm is depreciated in favor of the 
+///   <see cref="Modulus11ExtendedAlgorithm"/> algorithm. Modulus11Extended 
+///   produces the same results as this algorithm but is slightly more efficient 
+///   and follows the naming convention (Decimal/Extended) used for other
+///   modulus 11 algorithms in this library.
+///   </para>
+///   <para>
 ///   Valid characters are decimal digits (0-9).
 ///   </para>
 ///   <para>
@@ -25,6 +32,7 @@
 ///   and 10 characters for validating a value that contains a check digit.
 ///   </para>
 /// </remarks>
+[Obsolete("Modulus11Algorithm is depreciated in favor of Modulus11ExtendedAlgorithm.")]
 public sealed class Modulus11Algorithm : ISingleCheckDigitAlgorithm
 {
    private const Int32 _tryCalculateMaxLength = 9;

--- a/CheckDigits.Net/GeneralAlgorithms/Modulus11DecimalAlgorithm.cs
+++ b/CheckDigits.Net/GeneralAlgorithms/Modulus11DecimalAlgorithm.cs
@@ -62,10 +62,11 @@ public class Modulus11DecimalAlgorithm : ISingleCheckDigitAlgorithm, IMaskedChec
 
       var s = 0;
       var t = 0;
-      for (var index = 0; index < value.Length; index++)
+      var processLength = value.Length;
+      for (var index = 0; index < processLength; index++)
       {
-         var currentDigit = value![index].ToIntegerDigit();
-         if (currentDigit is < 0 or > 9)
+         var currentDigit = value[index].ToIntegerDigit();
+         if (currentDigit.IsInvalidDigit())
          {
             return false;
          }
@@ -99,10 +100,11 @@ public class Modulus11DecimalAlgorithm : ISingleCheckDigitAlgorithm, IMaskedChec
       // for use of accumulators s and t instead of multiplying by weights.
       var s = 0;
       var t = 0;
-      for (var index = 0; index < value.Length; index++)
+      var processLength = value.Length;
+      for (var index = 0; index < processLength; index++)
       {
-         var currentDigit = value![index].ToIntegerDigit();
-         if (currentDigit is < 0 or > 9)
+         var currentDigit = value[index].ToIntegerDigit();
+         if (currentDigit.IsInvalidDigit())
          {
             return false;
          }
@@ -126,14 +128,15 @@ public class Modulus11DecimalAlgorithm : ISingleCheckDigitAlgorithm, IMaskedChec
       var s = 0;
       var t = 0;
       var processedDigits = 0;
-      for (var index = 0; index < value.Length - 1; index++)
+      var processLength = value.Length - 1;
+      for (var index = 0; index < processLength; index++)
       {
          if (mask.ExcludeCharacter(index))
          {
             continue;
          }
-         var currentDigit = value![index].ToIntegerDigit();
-         if (currentDigit is < 0 or > 9)
+         var currentDigit = value[index].ToIntegerDigit();
+         if (currentDigit.IsInvalidDigit())
          {
             return false;
          }
@@ -141,7 +144,7 @@ public class Modulus11DecimalAlgorithm : ISingleCheckDigitAlgorithm, IMaskedChec
          s += t;
          processedDigits++;
       }
-      if (processedDigits is 0 or >= _validateMaxLength)
+      if (processedDigits == 0 || processedDigits >= _validateMaxLength)
       {
          return false;
       }
@@ -152,7 +155,7 @@ public class Modulus11DecimalAlgorithm : ISingleCheckDigitAlgorithm, IMaskedChec
 
       // Check digit is never masked so handle separately.
       var checkDigit = value![^1].ToIntegerDigit();
-      if (checkDigit is < 0 or > 9)
+      if (checkDigit.IsInvalidDigit())
       {
          return false;
       }

--- a/CheckDigits.Net/GeneralAlgorithms/Modulus11DecimalAlgorithm.cs
+++ b/CheckDigits.Net/GeneralAlgorithms/Modulus11DecimalAlgorithm.cs
@@ -42,7 +42,7 @@
 ///   and 10 characters for validating a value that contains a check digit.
 ///   </para>
 /// </remarks>
-public class Modulus11DecimalAlgorithm : ISingleCheckDigitAlgorithm, IMaskedCheckDigitAlgorithm
+public sealed class Modulus11DecimalAlgorithm : ISingleCheckDigitAlgorithm, IMaskedCheckDigitAlgorithm
 {
    private const Int32 _tryCalculateMaxLength = 9;
    private const Int32 _validateMinLength = 2;

--- a/CheckDigits.Net/GeneralAlgorithms/Modulus11DecimalAlgorithm.cs
+++ b/CheckDigits.Net/GeneralAlgorithms/Modulus11DecimalAlgorithm.cs
@@ -1,0 +1,66 @@
+﻿namespace CheckDigits.Net.GeneralAlgorithms;
+
+/// <summary>
+///   Modulus 11 (Decimal) algorithm where every digit is weighted by its 
+///   position in the value, starting from the right-most position, and the 
+///   check digit being the modulus 11 of the sum of weighted values.
+/// </summary>
+///   <para>
+///   Calculating modulus 11 of the sum of weighted values results in a check
+///   value from 0 to 10 (11 distinct values). Since it is not possible to 
+///   represent 10 with a single decimal digit, any value with a check value of
+///   10 is rejected by this algorithm. Both the Validate and 
+///   TryCalculateCheckDigit methods will return false if the value results in
+///   a check value of 10. This eliminates approximately 9.09% of possible 
+///   numbers from consideration.
+///   </para>
+/// <remarks>
+///   <para>
+///   Valid characters are decimal digits (0-9).
+///   </para>
+///   <para>
+///   Check digit calculated by the algorithm is a decimal digit (0-9).
+///   </para>
+///   <para>
+///   Assumes that the check digit (if present) is the right-most digit in the
+///   input value.
+///   </para>
+///   <para>
+///   Will detect all single-digit transcription errors and all two digit 
+///   transposition errors.
+///   </para>
+///   <para>
+///   Maximum length allowed is 9 characters for calculating a new check digit 
+///   and 10 characters for validating a value that contains a check digit.
+///   </para>
+/// </remarks>
+public class Modulus11DecimalAlgorithm : ISingleCheckDigitAlgorithm, IMaskedCheckDigitAlgorithm
+{
+   private const Int32 _tryCalculateMaxLength = 9;
+   private const Int32 _validateMinLength = 2;
+   private const Int32 _validateMaxLength = 10;
+
+   /// <inheritdoc/>
+   public String AlgorithmDescription => Resources.Modulus11DecimalAlgorithmDescription;
+
+   /// <inheritdoc/>
+   public String AlgorithmName => Resources.Modulus11DecimalAlgorithmName;
+
+   /// <inheritdoc/>
+   public Boolean TryCalculateCheckDigit(String value, out Char checkDigit)
+   {
+      throw new NotImplementedException();
+   }
+
+   /// <inheritdoc/>
+   public Boolean Validate(String value)
+   {
+      throw new NotImplementedException();
+   }
+
+   /// <inheritdoc/>
+   public Boolean Validate(String value, ICheckDigitMask mask)
+   {
+      throw new NotImplementedException();
+   }
+}

--- a/CheckDigits.Net/GeneralAlgorithms/Modulus11ExtendedAlgorithm.cs
+++ b/CheckDigits.Net/GeneralAlgorithms/Modulus11ExtendedAlgorithm.cs
@@ -38,7 +38,7 @@
 ///   and 10 characters for validating a value that contains a check digit.
 ///   </para>
 /// </remarks>
-public class Modulus11ExtendedAlgorithm : ISingleCheckDigitAlgorithm, IMaskedCheckDigitAlgorithm
+public sealed class Modulus11ExtendedAlgorithm : ISingleCheckDigitAlgorithm, IMaskedCheckDigitAlgorithm
 {
    private const Int32 _tryCalculateMaxLength = 9;
    private const Int32 _validateMinLength = 2;

--- a/CheckDigits.Net/MaskedAlgorithms.cs
+++ b/CheckDigits.Net/MaskedAlgorithms.cs
@@ -14,6 +14,12 @@ public static class MaskedAlgorithms
    private static readonly Lazy<IMaskedCheckDigitAlgorithm> _modulus10_13 =
       new(() => new Modulus10_13Algorithm());
 
+   private static readonly Lazy<IMaskedCheckDigitAlgorithm> _modulus11Decimal =
+      new(() => new Modulus11DecimalAlgorithm());
+
+   private static readonly Lazy<IMaskedCheckDigitAlgorithm> _modulus11Extended =
+      new(() => new Modulus11ExtendedAlgorithm());
+
    /// <summary>
    ///   Luhn algorithm.
    /// </summary>
@@ -23,5 +29,15 @@ public static class MaskedAlgorithms
    ///   Modulus10_13 algorithm.
    /// </summary>
    public static IMaskedCheckDigitAlgorithm Modulus10_13 => _modulus10_13.Value;
+
+   /// <summary>
+   ///   Modulus11Decimal algorithm.
+   /// </summary>
+   public static IMaskedCheckDigitAlgorithm Modulus11Decimal => _modulus11Decimal.Value;
+
+   /// <summary>
+   ///   Modulus11Extended algorithm.
+   /// </summary>
+   public static IMaskedCheckDigitAlgorithm Modulus11Extended => _modulus11Extended.Value;
 
 }

--- a/CheckDigits.Net/Resources.Designer.cs
+++ b/CheckDigits.Net/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace CheckDigits.Net {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -606,6 +606,24 @@ namespace CheckDigits.Net {
         internal static string Modulus11AlgorithmName {
             get {
                 return ResourceManager.GetString("Modulus11AlgorithmName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Modulus 11 algorithm where every character is weighted by its position, starting from the right-most character. Generated check digit will be 0-9. Values that result in a check value of 10 are rejected.
+        /// </summary>
+        internal static string Modulus11DecimalAlgorithmDescription {
+            get {
+                return ResourceManager.GetString("Modulus11DecimalAlgorithmDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Modulus11Decimal.
+        /// </summary>
+        internal static string Modulus11DecimalAlgorithmName {
+            get {
+                return ResourceManager.GetString("Modulus11DecimalAlgorithmName", resourceCulture);
             }
         }
         

--- a/CheckDigits.Net/Resources.Designer.cs
+++ b/CheckDigits.Net/Resources.Designer.cs
@@ -628,6 +628,24 @@ namespace CheckDigits.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Modulus 11 algorithm where every character is weighted by its position, starting from the right-most character. Generated check digit will be 0-9 or X.
+        /// </summary>
+        internal static string Modulus11ExtendedAlgorithmDescription {
+            get {
+                return ResourceManager.GetString("Modulus11ExtendedAlgorithmDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Modulus11Extended.
+        /// </summary>
+        internal static string Modulus11ExtendedAlgorithmName {
+            get {
+                return ResourceManager.GetString("Modulus11ExtendedAlgorithmName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Modulus must be &gt;= 2.
         /// </summary>
         internal static string ModulusIntModulusOutOfRangeMessage {

--- a/CheckDigits.Net/Resources.resx
+++ b/CheckDigits.Net/Resources.resx
@@ -351,4 +351,10 @@
   <data name="Modulus11DecimalAlgorithmName" xml:space="preserve">
     <value>Modulus11Decimal</value>
   </data>
+  <data name="Modulus11ExtendedAlgorithmDescription" xml:space="preserve">
+    <value>Modulus 11 algorithm where every character is weighted by its position, starting from the right-most character. Generated check digit will be 0-9 or X</value>
+  </data>
+  <data name="Modulus11ExtendedAlgorithmName" xml:space="preserve">
+    <value>Modulus11Extended</value>
+  </data>
 </root>

--- a/CheckDigits.Net/Resources.resx
+++ b/CheckDigits.Net/Resources.resx
@@ -345,4 +345,10 @@
   <data name="VinAlgorithmName" xml:space="preserve">
     <value>VIN (Vehicle Identification Number)</value>
   </data>
+  <data name="Modulus11DecimalAlgorithmDescription" xml:space="preserve">
+    <value>Modulus 11 algorithm where every character is weighted by its position, starting from the right-most character. Generated check digit will be 0-9. Values that result in a check value of 10 are rejected</value>
+  </data>
+  <data name="Modulus11DecimalAlgorithmName" xml:space="preserve">
+    <value>Modulus11Decimal</value>
+  </data>
 </root>

--- a/CheckDigits.Net/Utility/ExtensionMethods.cs
+++ b/CheckDigits.Net/Utility/ExtensionMethods.cs
@@ -3,6 +3,28 @@
 public static class ExtensionMethods
 {
    /// <summary>
+   ///   Determines if the specified integer value (generally returned by 
+   ///   <see cref="ToIntegerDigit(Char)"/>) is not a valid single digit integer.
+   /// </summary>
+   /// <remarks>
+   ///   <see cref="ToIntegerDigit(Char)"/> converts a single character to an
+   ///   integer by subtracting the character zero ('0') from the character to 
+   ///   convert. If the character to convert is not '0' - '9', then the result
+   ///   will be less than 0 or greater than 9.
+   /// </remarks>
+   /// <param name="digit">
+   ///   The integer to evaluate for validity. Must be in the range 0 to 9 to be 
+   ///   considered valid.
+   /// </param>
+   /// <returns>
+   ///   <see langword="true"/> if the digit is less than 0 or greater than 9; 
+   ///   otherwise, <see langword="false"/>.
+   /// </returns>
+   [MethodImpl(MethodImplOptions.AggressiveInlining)]
+   public static Boolean IsInvalidDigit(this Int32 digit)
+      => digit < 0 || digit > 9;
+
+   /// <summary>
    ///   Get the equivalent ASCII digit character for an integer between 0-9;
    /// </summary>
    /// <param name="num">

--- a/CheckDigits.Net/Utility/ExtensionMethods.cs
+++ b/CheckDigits.Net/Utility/ExtensionMethods.cs
@@ -25,6 +25,22 @@ public static class ExtensionMethods
       => digit < 0 || digit > 9;
 
    /// <summary>
+   ///   Determines whether the specified integer value is an invalid extended 
+   ///   decimal check digit.
+   /// </summary>
+   /// <param name="value">
+   ///   The integer value to evaluate as an extended decimal check digit. Must 
+   ///   be in the range 0 to 10, inclusive.
+   /// </param>
+   /// <returns>
+   ///   <see langword="true"/> if the value is less than 0 or greater than 10; 
+   ///   otherwise, <see langword="false"/>.
+   /// </returns>
+   [MethodImpl(MethodImplOptions.AggressiveInlining)]
+   public static Boolean IsInvalidExtendedDecimalCheckDigit(this Int32 value)
+      => value < 0 || value > 10;
+
+   /// <summary>
    ///   Get the equivalent ASCII digit character for an integer between 0-9;
    /// </summary>
    /// <param name="num">
@@ -38,6 +54,28 @@ public static class ExtensionMethods
    ///   return an unexpected value
    /// </remarks>
    public static Char ToDigitChar(this Int32 num) => (Char)(Chars.DigitZero + num);
+
+   /// <summary>
+   ///   Converts the specified character to its extended decimal check digit 
+   ///   value, interpreting 'X' as 10 and numeric digits as their integer 
+   ///   equivalents.
+   /// </summary>
+   /// <param name="ch">
+   ///   The character to convert. Must be a numeric digit ('0'-'9') or the 
+   ///   uppercase letter 'X'.
+   /// </param>
+   /// <returns>
+   ///   An integer representing the extended check digit value. Returns 10 if 
+   ///   the character is 'X'; otherwise, returns the integer value of the 
+   ///   digit.
+   /// </returns>
+   /// <remarks>
+   ///   If <paramref name="ch"/> is not 'X' or '0'-'9' then this method will
+   ///   return an unexpected value
+   /// </remarks>
+   [MethodImpl(MethodImplOptions.AggressiveInlining)]
+   public static Int32 ToExtendedDecimalCheckDigit(this Char ch)
+      => ch == Chars.UpperCaseX ? 10 : ch - Chars.DigitZero;
 
    /// <summary>
    ///   Get the integer equivalent of an ASCII digit character.

--- a/CheckDigits.Net/ValueSpecificAlgorithms/NhsAlgorithm.cs
+++ b/CheckDigits.Net/ValueSpecificAlgorithms/NhsAlgorithm.cs
@@ -9,6 +9,22 @@ namespace CheckDigits.Net.ValueSpecificAlgorithms;
 /// </summary>
 /// <remarks>
 ///   <para>
+///   This algorithm is depreciated in favor of the 
+///   <see cref="Modulus11DecimalAlgorithm"/> algorithm. Modulus11DecimalAlgorithm
+///   is slightly more efficient and more flexibe than this algorithm and follows 
+///   the naming convention (Decimal/Extended) used for other modulus 11 
+///   algorithms in this library. Modulus11DecimalAlgorithm removes the fixed 10 
+///   character length requirement of NhsAlgorithm and instead allows values of
+///   length 2 to 10 characters for validation. To completly replicate the 
+///   behavior of NhsAlgorithm you will need to add your own length check to 
+///   ensure that the value being validated is exactly 10 characters long.
+///   </para>
+///   <para>
+///   While marked as obsolete, NhsAlgorithm is still available for use and
+///   will not be removed in a future major release because Modulus11DecimalAlgorithm
+///   is not a drop-in replacement for NhsAlgorithm.
+///   </para>
+///   <para>
 ///   Valid characters are decimal digits (0-9).
 ///   </para>
 ///   <para>
@@ -25,6 +41,7 @@ namespace CheckDigits.Net.ValueSpecificAlgorithms;
 ///   Value length is 10 characters.
 ///   </para>
 /// </remarks>
+[Obsolete("NhsAlgorithm is depreciated in favor of Modulus11DecimalAlgorithm.")]
 public sealed class NhsAlgorithm : ICheckDigitAlgorithm
 {
    private const Int32 _expectedLength = 10;

--- a/CheckDigits.Net/ValueSpecificAlgorithms/NhsAlgorithm.cs
+++ b/CheckDigits.Net/ValueSpecificAlgorithms/NhsAlgorithm.cs
@@ -9,13 +9,13 @@ namespace CheckDigits.Net.ValueSpecificAlgorithms;
 /// </summary>
 /// <remarks>
 ///   <para>
-///   This algorithm is depreciated in favor of the 
+///   This algorithm is deprecated in favor of the 
 ///   <see cref="Modulus11DecimalAlgorithm"/> algorithm. Modulus11DecimalAlgorithm
-///   is slightly more efficient and more flexibe than this algorithm and follows 
+///   is slightly more efficient and more flexible than this algorithm and follows 
 ///   the naming convention (Decimal/Extended) used for other modulus 11 
 ///   algorithms in this library. Modulus11DecimalAlgorithm removes the fixed 10 
 ///   character length requirement of NhsAlgorithm and instead allows values of
-///   length 2 to 10 characters for validation. To completly replicate the 
+///   length 2 to 10 characters for validation. To completely replicate the 
 ///   behavior of NhsAlgorithm you will need to add your own length check to 
 ///   ensure that the value being validated is exactly 10 characters long.
 ///   </para>
@@ -41,7 +41,7 @@ namespace CheckDigits.Net.ValueSpecificAlgorithms;
 ///   Value length is 10 characters.
 ///   </para>
 /// </remarks>
-[Obsolete("NhsAlgorithm is depreciated in favor of Modulus11DecimalAlgorithm.")]
+[Obsolete("NhsAlgorithm is deprecated in favor of Modulus11DecimalAlgorithm.")]
 public sealed class NhsAlgorithm : ICheckDigitAlgorithm
 {
    private const Int32 _expectedLength = 10;

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ let us know. Or contribute to the CheckDigits.Net repository: https://github.com
     * [Modulus10_13 Algorithm (UPC/EAN/ISBN-13/etc.)](#modulus10_13-algorithm)
     * [Modulus11 Algorithm (ISBN-10/ISSN/etc.)](#modulus11-algorithm)
     * [Modulus11Decimal Algorithm (NHS Number/etc.)](#modulus11decimal-algorithm)
-    * [Modulus11Extended Algorithm (ISBN-10/ISSN/etc.)](#modulus11Extended-algorithm)
+    * [Modulus11Extended Algorithm (ISBN-10/ISSN/etc.)](#modulus11extended-algorithm)
     * [NHS (UK National Health Service) Algorithm](#nhs-algorithm)
     * [NOID Check Digit Algorithm](#noid-check-digit-algorithm)
     * [NPI (US National Provider Identifier) Algorithm](#npi-algorithm)
@@ -164,7 +164,7 @@ The ISO/IEC 7064:2003 standard is available at https://www.iso.org/standard/3153
 * [Modulus10_13 Algorithm (UPC/EAN/ISBN-13/etc.)](#modulus10_13-algorithm)
 * [Modulus11 Algorithm (ISBN-10/ISSN/etc.)](#modulus11-algorithm)
 * [Modulus11Decimal Algorithm (NHS Number/etc.)](#modulus11decimal-algorithm)
-* [Modulus11Extended Algorithm (ISBN-10/ISSN/etc.)](#modulus11Extended-algorithm)
+* [Modulus11Extended Algorithm (ISBN-10/ISSN/etc.)](#modulus11extended-algorithm)
 * [NHS (UK National Health Service) Algorithm](#nhs-algorithm)
 * [NOID Check Digit Algorithm](#noid-check-digit-algorithm)
 * [NPI (US National Provider Identifier) Algorithm](#npi-algorithm)
@@ -198,7 +198,7 @@ The ISO/IEC 7064:2003 standard is available at https://www.iso.org/standard/3153
 | IMEI				                                     | [Luhn Algorithm](#luhn-algorithm) |
 | IMO Number                                             | [Modulus10_2 Algorithm](#modulus10_2-algorithm) |
 | ISAN                                                   | [ISAN Algorithm](#isan-algorithm) |
-| ISBN-10				                                 | [Modulus11Extended Algorithm](#modulus11Extended-algorithm) or [Modulus11 Algorithm](#modulus11-algorithm) |
+| ISBN-10				                                 | [Modulus11Extended Algorithm](#modulus11extended-algorithm) or [Modulus11 Algorithm](#modulus11-algorithm) |
 | ISBN-13				                                 | [Modulus10_13 Algorithm](#modulus10_13-algorithm) |
 | ISBT Donation Identification Number                    | [ISO/IEC 7064 MOD 37-2 Algorithm](#isoiec-7064-mod-37-2-algorithm) |
 | ISIN                                                   | [ISIN Algorithm](#isin-algorithm) |
@@ -1094,7 +1094,7 @@ Wikipedia:
 
 #### Description
 
-NOTE: This algorithm has been depreciated in favor of using the Modulus11Extended 
+NOTE: This algorithm has been deprecated in favor of using the Modulus11Extended 
 algorithm.
 
 The Modulus11 algorithm uses modulus 11 and each digit is weighted by its position
@@ -1190,7 +1190,7 @@ possible values must be rejected, or approximately 9.09% of all values.
 The Modulus11Extended algorithm takes the former approach and the `TryCalculateCheckDigit`
 and `Validate` allow values that 'X' as an extended check character.
 
-Modulus11Extended replaces the depreciated Modulus11 algorithm.
+Modulus11Extended replaces the deprecated Modulus11 algorithm.
 
 #### Details
 
@@ -1216,7 +1216,7 @@ Wikipedia:
 
 #### Description
 
-NOTE: This algorithm has been depreciated in favor of using the Modulus11Decimal 
+NOTE: This algorithm has been deprecated in favor of using the Modulus11Decimal 
 algorithm.
 
 UK National Health Service (NHS) identifiers use a variation of the Modulus 11 

--- a/README.md
+++ b/README.md
@@ -1657,12 +1657,16 @@ benchmarks do not cover lengths greater than 10.
 | Modulus10_2           | 1406625389                    | 4.048 ns  | 0.0270 ns | 0.0253 ns | -         |
 |                       |                               |           |           |           |           |
 | Modulus11             | 1406                          | 2.948 ns  | 0.0241 ns | 0.0214 ns | -         |
-| Modulus11             | 1406625                       | 4.062 ns  | 0.0213 ns | 0.0200 ns | -         |
+| Modulus11             | 1406620                       | 4.062 ns  | 0.0213 ns | 0.0200 ns | -         |
 | Modulus11             | 1406625388                    | 4.506 ns  | 0.0278 ns | 0.0247 ns | -         |
 |                       |                               |           |           |           |           |
 | Modulus11Decimal      | 1406                          | 1.892 ns  | 0.0528 ns | 0.0791 ns | -         |
-| Modulus11Decimal      | 1406625                       | 3.126 ns  | 0.0801 ns | 0.1403 ns | -         |
+| Modulus11Decimal      | 1406620                       | 3.126 ns  | 0.0801 ns | 0.1403 ns | -         |
 | Modulus11Decimal      | 1406625388                    | 4.123 ns  | 0.0335 ns | 0.0313 ns | -         |
+|                       |                               |           |           |           |           |
+| Modulus11Extended     | 1406                          | 2.316 ns  | 0.0099 ns | 0.0093 ns | -         |
+| Modulus11Extended     | 1406620                       | 3.931 ns  | 0.0054 ns | 0.0051 ns | -         |
+| Modulus11Extended     | 1406625388                    | 4.563 ns  | 0.0169 ns | 0.0158 ns | -         |
 |                       |                               |           |           |           |           |
 | Verhoeff              | 1401                          | 4.827 ns  | 0.0255 ns | 0.0239 ns | -         |
 | Verhoeff              | 1406625                       | 6.848 ns  | 0.0410 ns | 0.0383 ns | -         |
@@ -1856,8 +1860,12 @@ public class GroupsOfThreeCheckDigitMask : ICheckDigitMask
 | Modulus10_13          | 140 662 538 042 551 028 265 7 | 14.315 ns | 0.1808 ns | 0.1691 ns | -         |
 |                       |                               |           |           |           |           |
 | Modulus11Decimal      | 140 6                         |  4.200 ns | 0.0472 ns | 0.0442 ns | -         |
-| Modulus11Decimal      | 140 662 5                     |  5.134 ns | 0.0596 ns | 0.0529 ns | -         |
+| Modulus11Decimal      | 140 662 0                     |  5.134 ns | 0.0596 ns | 0.0529 ns | -         |
 | Modulus11Decimal      | 140 662 538 8                 |  6.342 ns | 0.0429 ns | 0.0401 ns | -         |
+|                       |                               |           |           |           |           |
+| Modulus11Extended     | 140 6                         |  4.317 ns | 0.0073 ns | 0.0068 ns | -         |
+| Modulus11Extended     | 140 662 0                     |  5.268 ns | 0.0358 ns | 0.0335 ns | -         |
+| Modulus11Extended     | 140 662 538 8                 |  6.603 ns | 0.0696 ns | 0.0651 ns | -         |
 
 # Release History/Release Notes
 

--- a/README.md
+++ b/README.md
@@ -1384,6 +1384,10 @@ benchmarks do not cover lengths greater than 10.
 | Modulus11             | 140662                | 3.323 ns  | 0.0300 ns | 0.0280 ns | -         |
 | Modulus11             | 140662538             | 4.341 ns  | 0.0301 ns | 0.0281 ns | -         |
 |                       |                       |           |           |           |           |
+| Modulus11Decimal      | 140                   | 2.322 ns  | 0.0348 ns | 0.0325 ns | -         |
+| Modulus11Decimal      | 140662                | 3.220 ns  | 0.0485 ns | 0.0453 ns | -         |
+| Modulus11Decimal      | 140662538             | 4.239 ns  | 0.0544 ns | 0.0509 ns | -         |
+|                       |                       |           |           |           |           |
 | Verhoeff              | 140                   | 4.250 ns  | 0.0312 ns | 0.0277 ns | -         |
 | Verhoeff              | 140662                | 6.399 ns  | 0.0542 ns | 0.0452 ns | -         |
 | Verhoeff              | 140662538             | 9.977 ns  | 0.0363 ns | 0.0340 ns | -         |
@@ -1561,6 +1565,10 @@ benchmarks do not cover lengths greater than 10.
 | Modulus11             | 1406                          | 2.948 ns  | 0.0241 ns | 0.0214 ns | -         |
 | Modulus11             | 1406625                       | 4.062 ns  | 0.0213 ns | 0.0200 ns | -         |
 | Modulus11             | 1406625388                    | 4.506 ns  | 0.0278 ns | 0.0247 ns | -         |
+|                       |                               |           |           |           |           |
+| Modulus11Decimal      | 1406                          | 1.892 ns  | 0.0528 ns | 0.0791 ns | -         |
+| Modulus11Decimal      | 1406625                       | 3.126 ns  | 0.0801 ns | 0.1403 ns | -         |
+| Modulus11Decimal      | 1406625388                    | 4.123 ns  | 0.0335 ns | 0.0313 ns | -         |
 |                       |                               |           |           |           |           |
 | Verhoeff              | 1401                          | 4.827 ns  | 0.0255 ns | 0.0239 ns | -         |
 | Verhoeff              | 1406625                       | 6.848 ns  | 0.0410 ns | 0.0383 ns | -         |
@@ -1744,6 +1752,18 @@ public class GroupsOfThreeCheckDigitMask : ICheckDigitMask
 | Luhn                  | 140 662 538 042 551 4         | 11.272 ns | 0.0564 ns | 0.0528 ns | -         |
 | Luhn                  | 140 662 538 042 551 028 5     | 13.034 ns | 0.0692 ns | 0.0613 ns | -         |
 | Luhn                  | 140 662 538 042 551 028 265 1 | 14.754 ns | 0.1212 ns | 0.1075 ns | -         |
+|                       |                               |           |           |           |           |
+| Modulus10_13          | 140 3                         |  4.536 ns | 0.0544 ns | 0.0509 ns | -         |
+| Modulus10_13          | 140 662 7                     |  5.908 ns | 0.1229 ns | 0.1090 ns | -         |
+| Modulus10_13          | 140 662 538 5                 |  7.526 ns | 0.0957 ns | 0.0895 ns | -         |
+| Modulus10_13          | 140 662 538 042 5             |  9.083 ns | 0.1075 ns | 0.0898 ns | -         |
+| Modulus10_13          | 140 662 538 042 551 8         | 10.977 ns | 0.1084 ns | 0.1014 ns | -         |
+| Modulus10_13          | 140 662 538 042 551 028 8     | 12.475 ns | 0.1031 ns | 0.0965 ns | -         |
+| Modulus10_13          | 140 662 538 042 551 028 265 7 | 14.315 ns | 0.1808 ns | 0.1691 ns | -         |
+|                       |                               |           |           |           |           |
+| Modulus11Decimal      | 140 6                         |  4.200 ns | 0.0472 ns | 0.0442 ns | -         |
+| Modulus11Decimal      | 140 662 5                     |  5.134 ns | 0.0596 ns | 0.0529 ns | -         |
+| Modulus11Decimal      | 140 662 538 8                 |  6.342 ns | 0.0429 ns | 0.0401 ns | -         |
 
 # Release History/Release Notes
 
@@ -1765,7 +1785,7 @@ Initial limited release. Included algorithms:
 
 ## v1.0.0
 
-Initial release. Additional included algorithms
+Initial release. Additional included algorithms:
 * ISO/IEC 7064 MOD 11,10
 * ISO/IEC 7064 MOD 11-2
 * ISO/IEC 7064 MOD 1271-36
@@ -1777,7 +1797,7 @@ Initial release. Additional included algorithms
 
 ## v1.1.0
 
-Additional included algorithms
+Additional included algorithms:
 * AlphanumericMod97_10Algorithm
 * IbanAlgorithm
 * IsanAlgorithm (including ValidateFormatted method)
@@ -1799,7 +1819,7 @@ Detailed benchmark results for .Net 7 vs .Net 8 located at https://github.com/Kn
 
 ## v2.1.0
 
-Additional included algorithms
+Additional included algorithms:
 * CUSIP Algorithm
 * ISO 6346 Algorithm
 * SEDOL Algorithm
@@ -1818,7 +1838,7 @@ Thanks to Steff Beckers for this addition
 
 ## v2.3.0
 
-Additional included algorithms
+Additional included algorithms:
 * FIGI Algorithm
 * ICAO Algorithm
 * ICAO 9303 Document Size TD1 Algorithm
@@ -1849,4 +1869,12 @@ Detailed benchmark results for .Net 8 vs .Net 10 located at https://github.com/K
 
 Added masked validation support for algorithms via ICheckDigitMask and IMaskedCheckDigitAlgorithm interfaces. Algorithms that implement IMaskedCheckDigitAlgorithm:
 * Luhn Algorithm
+* Modulus10_13 Algorithm
+
+## v3.1.0
+
+Additional included algorithms:
+* Modulus11Decimal
+
+Added masked validation support to the following algorithms:
 * Modulus10_13 Algorithm

--- a/README.md
+++ b/README.md
@@ -1094,6 +1094,9 @@ Wikipedia:
 
 #### Description
 
+NOTE: This algorithm has been depreciated in favor of using the Modulus11Extended 
+algorithm.
+
 The Modulus11 algorithm uses modulus 11 and each digit is weighted by its position
 in the value, starting from the right-most digit. Prior to the existence of the
 Verhoeff algorithm and the Damm algorithm it was popular because it was able to

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ let us know. Or contribute to the CheckDigits.Net repository: https://github.com
     * [Modulus10_13 Algorithm (UPC/EAN/ISBN-13/etc.)](#modulus10_13-algorithm)
     * [Modulus11 Algorithm (ISBN-10/ISSN/etc.)](#modulus11-algorithm)
     * [Modulus11Decimal Algorithm (NHS Number/etc.)](#modulus11decimal-algorithm)
+    * [Modulus11Extended Algorithm (ISBN-10/ISSN/etc.)](#modulus11Extended-algorithm)
     * [NHS (UK National Health Service) Algorithm](#nhs-algorithm)
     * [NOID Check Digit Algorithm](#noid-check-digit-algorithm)
     * [NPI (US National Provider Identifier) Algorithm](#npi-algorithm)
@@ -163,6 +164,7 @@ The ISO/IEC 7064:2003 standard is available at https://www.iso.org/standard/3153
 * [Modulus10_13 Algorithm (UPC/EAN/ISBN-13/etc.)](#modulus10_13-algorithm)
 * [Modulus11 Algorithm (ISBN-10/ISSN/etc.)](#modulus11-algorithm)
 * [Modulus11Decimal Algorithm (NHS Number/etc.)](#modulus11decimal-algorithm)
+* [Modulus11Extended Algorithm (ISBN-10/ISSN/etc.)](#modulus11Extended-algorithm)
 * [NHS (UK National Health Service) Algorithm](#nhs-algorithm)
 * [NOID Check Digit Algorithm](#noid-check-digit-algorithm)
 * [NPI (US National Provider Identifier) Algorithm](#npi-algorithm)
@@ -196,13 +198,13 @@ The ISO/IEC 7064:2003 standard is available at https://www.iso.org/standard/3153
 | IMEI				                                     | [Luhn Algorithm](#luhn-algorithm) |
 | IMO Number                                             | [Modulus10_2 Algorithm](#modulus10_2-algorithm) |
 | ISAN                                                   | [ISAN Algorithm](#isan-algorithm) |
-| ISBN-10				                                 | [Modulus11 Algorithm](#modulus11-algorithm) |
+| ISBN-10				                                 | [Modulus11Extended Algorithm](#modulus11Extended-algorithm) or [Modulus11 Algorithm](#modulus11-algorithm) |
 | ISBN-13				                                 | [Modulus10_13 Algorithm](#modulus10_13-algorithm) |
 | ISBT Donation Identification Number                    | [ISO/IEC 7064 MOD 37-2 Algorithm](#isoiec-7064-mod-37-2-algorithm) |
 | ISIN                                                   | [ISIN Algorithm](#isin-algorithm) |
 | ISMN					                                 | [Modulus10_13 Algorithm](#modulus10_13-algorithm) |
 | ISNI                                                   | [ISO/IEC 7064 MOD 11-2 Algorithm](#isoiec-7064-mod-11-2-algorithm) |
-| ISSN   				                                 | [Modulus11 Algorithm](#modulus11-algorithm) |
+| ISSN   				                                 | [Modulus11Extended Algorithm](#modulus11Extended-algorithm) or [Modulus11 Algorithm](#modulus11-algorithm) |
 | Legal Entity Identifier                                | [Alphanumeric MOD 97-10 Algorithm](#alphanumeric-mod-97-10-algorithm) |
 | NHS Number                                             | [Modulus11Decimal Algorithm](#modulus11decimal-algorithm) or [NHS (UK National Health Service) Algorithm](#nhs-algorithm) |
 | SEDOL					                                 | [SEDOL Algorithm](#sedol-algorithm) |
@@ -1163,6 +1165,49 @@ fixed 10 character length required by NhsAlgorithm.
 
 Wikipedia: 
 	https://en.wikipedia.org/wiki/NHS_number#Format,_number_ranges,_and_check_characters
+
+### Modulus11Extended Algorithm
+
+#### Description
+
+The Modulus11Extended algorithm uses modulus 11 and each digit is weighted by its 
+position in the value, starting from the right-most digit. Prior to the existence 
+of the Verhoeff algorithm and the Damm algorithm, modulus 11 algorithms were 
+popular because they were very capable of detecting two digit transposition errors 
+while using only a single check character. However, because it used modulus 11, 
+the check character could not be a single decimal digit. 
+
+There are two common solutions to this problem: use a non-digit character to 
+represent the 11th possible check value or reject any value that would require a
+non-digit check character. Using a non-digit check character (commonly 'X') means
+that the value is not an integer and must be stored as a string. Rejecting any
+value that could require a non-digit check character means that one out of eleven 
+possible values must be rejected, or approximately 9.09% of all values.
+
+The Modulus11Extended algorithm takes the former approach and the `TryCalculateCheckDigit`
+and `Validate` allow values that 'X' as an extended check character.
+
+Modulus11Extended replaces the depreciated Modulus11 algorithm.
+
+#### Details
+
+* Valid characters - decimal digits ('0' - '9')
+* Check digit size - one character
+* Check digit value - either decimal digit ('0' - '9') or an uppercase 'X'
+* Check digit location - assumed to be the trailing (right-most) character when validating
+* Max length - 9 characters when generating a check digit; 10 characters when validating
+* Class name - `Modulus11Extended`
+
+#### Common Applications
+
+* International Standard Book Number, prior to January 1, 2007 (ISBN-10)
+* International Standard Serial Number (ISSN)
+
+#### Links
+
+Wikipedia: 
+  https://en.wikipedia.org/wiki/ISBN#ISBN-10_check_digits
+  https://en.wikipedia.org/wiki/ISSN
 
 ### NHS Algorithm
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ let us know. Or contribute to the CheckDigits.Net repository: https://github.com
     * [Modulus10_2 Algorithm](#modulus10_2-algorithm)
     * [Modulus10_13 Algorithm (UPC/EAN/ISBN-13/etc.)](#modulus10_13-algorithm)
     * [Modulus11 Algorithm (ISBN-10/ISSN/etc.)](#modulus11-algorithm)
+    * [Modulus11Decimal Algorithm (NHS Number/etc.)](#modulus11decimal-algorithm)
     * [NHS (UK National Health Service) Algorithm](#nhs-algorithm)
     * [NOID Check Digit Algorithm](#noid-check-digit-algorithm)
     * [NPI (US National Provider Identifier) Algorithm](#npi-algorithm)
@@ -161,6 +162,7 @@ The ISO/IEC 7064:2003 standard is available at https://www.iso.org/standard/3153
 * [Modulus10_2 Algorithm](#modulus10_2-algorithm)
 * [Modulus10_13 Algorithm (UPC/EAN/ISBN-13/etc.)](#modulus10_13-algorithm)
 * [Modulus11 Algorithm (ISBN-10/ISSN/etc.)](#modulus11-algorithm)
+* [Modulus11Decimal Algorithm (NHS Number/etc.)](#modulus11decimal-algorithm)
 * [NHS (UK National Health Service) Algorithm](#nhs-algorithm)
 * [NOID Check Digit Algorithm](#noid-check-digit-algorithm)
 * [NPI (US National Provider Identifier) Algorithm](#npi-algorithm)
@@ -202,6 +204,7 @@ The ISO/IEC 7064:2003 standard is available at https://www.iso.org/standard/3153
 | ISNI                                                   | [ISO/IEC 7064 MOD 11-2 Algorithm](#isoiec-7064-mod-11-2-algorithm) |
 | ISSN   				                                 | [Modulus11 Algorithm](#modulus11-algorithm) |
 | Legal Entity Identifier                                | [Alphanumeric MOD 97-10 Algorithm](#alphanumeric-mod-97-10-algorithm) |
+| NHS Number                                             | [Modulus11Decimal Algorithm](#modulus11decimal-algorithm) or [NHS (UK National Health Service) Algorithm](#nhs-algorithm) |
 | SEDOL					                                 | [SEDOL Algorithm](#sedol-algorithm) |
 | Shipping Container Number                              | [ISO 6346 Algorithm](#iso-6346-algorithm) |
 | SSCC					                                 | [Modulus10_13 Algorithm](#modulus10_13-algorithm) |
@@ -1118,9 +1121,55 @@ Wikipedia:
   https://en.wikipedia.org/wiki/ISBN#ISBN-10_check_digits
   https://en.wikipedia.org/wiki/ISSN
 
+### Modulus11Decimal Algorithm
+
+#### Description
+
+The Modulus11Decimal algorithm uses modulus 11 and each digit is weighted by its 
+position in the value, starting from the right-most digit. Prior to the existence 
+of the Verhoeff algorithm and the Damm algorithm, modulus 11 algorithms were 
+popular because they were very capable of detecting two digit transposition errors 
+while using only a single check character. However, because it used modulus 11, 
+the check character could not be a single decimal digit. 
+
+There are two common solutions to this problem: use a non-digit character to 
+represent the 11th possible check value or reject any value that would require a
+non-digit check character. Using a non-digit check character (commonly 'X') means
+that the value is not an integer and must be stored as a string. Rejecting any
+value that could require a non-digit check character means that one out of eleven 
+possible values must be rejected, or approximately 9.09% of all values.
+
+The Modulus11Decimal algorithm takes the later approach and the `TryCalculateCheckDigit`
+and `Validate` methods return false if the value would require a non-digit check
+character.
+
+Modulus11Decimal is a generalized version of the NhsAlgorithm which drops the
+fixed 10 character length required by NhsAlgorithm.
+
+#### Details
+
+* Valid characters - decimal digits ('0' - '9')
+* Check digit size - one character
+* Check digit value - either decimal digit ('0' - '9')
+* Check digit location - assumed to be the trailing (right-most) character when validating
+* Max length - 9 characters when generating a check digit; 10 characters when validating
+* Class name - `Modulus11DecimalAlgorithm`
+
+#### Common Applications
+
+* UK National Health Service Number
+
+#### Links
+
+Wikipedia: 
+	https://en.wikipedia.org/wiki/NHS_number#Format,_number_ranges,_and_check_characters
+
 ### NHS Algorithm
 
 #### Description
+
+NOTE: This algorithm has been depreciated in favor of using the Modulus11Decimal 
+algorithm.
 
 UK National Health Service (NHS) identifiers use a variation of the Modulus 11 
 algorithm. However, instead of generating 11 possible values for the check digit,


### PR DESCRIPTION
This pull request introduces Modulus11 variations (Decimal and Extended), improves consistency in benchmark and unit tests, and updates usage of check digit masks. The main changes are grouped below by theme.

### Expanded Modulus11 Algorithm Coverage

* Added tests and benchmarks for `Modulus11DecimalAlgorithm` and `Modulus11ExtendedAlgorithm`, including property checks in `AlgorithmsTests`, new benchmark cases in `OptimizeBenchmarks`, and additional test values in `NumericAlgorithmBenchmarks` for both calculation and validation scenarios. [[1]](diffhunk://#diff-4bebe45cfbd0b094011faf3d282f048a3d1444f56a71fca363367a1ce1773d87R375-R411) [[2]](diffhunk://#diff-4bebe45cfbd0b094011faf3d282f048a3d1444f56a71fca363367a1ce1773d87R433-R441) [[3]](diffhunk://#diff-2c6d0e182a0dff7c05e9b053d9df3655c5be638b9c53942e636f8ddfda689c85R65-R77) [[4]](diffhunk://#diff-2c6d0e182a0dff7c05e9b053d9df3655c5be638b9c53942e636f8ddfda689c85R157-R172) [[5]](diffhunk://#diff-2c6d0e182a0dff7c05e9b053d9df3655c5be638b9c53942e636f8ddfda689c85R189-R205) [[6]](diffhunk://#diff-bcfbf601d72d5aba080771f01eb6949556d3dd51b2870219dae9f3f8b51be450L1-R15) [[7]](diffhunk://#diff-bcfbf601d72d5aba080771f01eb6949556d3dd51b2870219dae9f3f8b51be450L23-R87)

### Benchmark Improvements

* Enabled `OptimizeBenchmarks` in `Program.cs` and disabled obsolete algorithm warnings for relevant benchmarks, ensuring new algorithms are included in performance testing. [[1]](diffhunk://#diff-7687108d65e57c8ece664486c28509f07a7fe5f4617870bbbb743f3455783c9bL8-R10) [[2]](diffhunk://#diff-bcfbf601d72d5aba080771f01eb6949556d3dd51b2870219dae9f3f8b51be450L1-R15)
* Added new benchmark methods for validating NHS, Modulus11Decimal, and Modulus11Extended values.

### Unit Test Consistency

* Updated `LuhnAlgorithmTests` to include benchmark values for calculation and validation, moving masked value tests to appropriate locations and ensuring all relevant values are covered. [[1]](diffhunk://#diff-bddcee88a258df141c14d9333dc5ff47b8788fb4acf58eb70547efb170766434R143-R153) [[2]](diffhunk://#diff-bddcee88a258df141c14d9333dc5ff47b8788fb4acf58eb70547efb170766434L208-L218) [[3]](diffhunk://#diff-bddcee88a258df141c14d9333dc5ff47b8788fb4acf58eb70547efb170766434R256-R266) [[4]](diffhunk://#diff-bddcee88a258df141c14d9333dc5ff47b8788fb4acf58eb70547efb170766434L319-L329) [[5]](diffhunk://#diff-bddcee88a258df141c14d9333dc5ff47b8788fb4acf58eb70547efb170766434R367-R377)
* Corrected `Modulus10_13AlgorithmTests` to apply the `_groupsOfThreeMask` when validating masked values.

### Obsolete Algorithm Handling

* Added `#pragma warning disable CS0618`/`restore` blocks to suppress warnings for obsolete algorithms in benchmarks and unit tests, improving code clarity and maintainability. [[1]](diffhunk://#diff-2c6d0e182a0dff7c05e9b053d9df3655c5be638b9c53942e636f8ddfda689c85R65-R77) [[2]](diffhunk://#diff-2c6d0e182a0dff7c05e9b053d9df3655c5be638b9c53942e636f8ddfda689c85R157-R172) [[3]](diffhunk://#diff-d38793c8745252aed06ea4b2d7b8705f45081d8e8e90c2071274bb649b592d0bR96-R100) [[4]](diffhunk://#diff-233e719fa0d44ba74117ca8b39e245df473b90b0da9b8693ce34727b04562e73L1-R3)

### Miscellaneous

* Updated spelling ignore list in `AlgorithmsTests.cs` to include "Vin".