### PR TITLE
S0062 make icao9393 classes stateless

### DIFF
--- a/CheckDigits.Net.Tests.Benchmarks/OptimizeBenchmarks.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/OptimizeBenchmarks.cs
@@ -5,16 +5,12 @@ namespace CheckDigits.Net.Tests.Benchmarks;
 [MemoryDiagnoser]
 public class OptimizeBenchmarks
 {
-   private static readonly Modulus11_27DecimalAlgorithm _algorithm = new();
+   private static readonly Icao9303SizeTD2Algorithm _algorithm = new();
 
    [Benchmark(Baseline = true)]
-   [Arguments("1406")]
-   //[Arguments("1406620")]
-   //[Arguments("1406625385")]
-   [Arguments("1406625380421")]
-   //[Arguments("1406625380425510")]
-   //[Arguments("1406625380425510288")]
-   [Arguments("1406625380425510282650")]
+   [Arguments("I<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<D231458907UTO7408122F1204159<<<<<<<6")]
+   [Arguments("I<UTOQWERTY<<ASDF<<<<<<<<<<<<<<<<<<<\r\nD23145890<UTO7408122F1204159AB1124<4")]
+   [Arguments("I<UTOSKYWALKER<<LUKE<<<<<<<<<<<<<<<<\nSTARWARS45UTO7705256M2405252<<<<<<<4")]
    public void OriginalVersion(String value) => _ = _algorithm.Validate(value);
 
    //[Benchmark()]

--- a/CheckDigits.Net.Tests.Benchmarks/Program.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/Program.cs
@@ -1,5 +1,5 @@
 ﻿
-BenchmarkRunner.Run<NumericAlgorithmBenchmarks>();
+//BenchmarkRunner.Run<NumericAlgorithmBenchmarks>();
 
 //BenchmarkRunner.Run<AlphabeticAlgorithmsBenchmarks>();
 
@@ -7,4 +7,4 @@ BenchmarkRunner.Run<NumericAlgorithmBenchmarks>();
 
 //BenchmarkRunner.Run<ValueSpecificAlgorithmBenchmarks>();
 
-//BenchmarkRunner.Run<OptimizeBenchmarks>();
+BenchmarkRunner.Run<OptimizeBenchmarks>();

--- a/CheckDigits.Net.Tests.Benchmarks/Program.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/Program.cs
@@ -5,6 +5,6 @@
 
 //BenchmarkRunner.Run<AlphanumericAlgorithmBenchmarks>();
 
-//BenchmarkRunner.Run<ValueSpecificAlgorithmBenchmarks>();
+BenchmarkRunner.Run<ValueSpecificAlgorithmBenchmarks>();
 
-BenchmarkRunner.Run<OptimizeBenchmarks>();
+//BenchmarkRunner.Run<OptimizeBenchmarks>();

--- a/CheckDigits.Net.Tests.Benchmarks/ValueSpecificAlgorithmBenchmarks.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/ValueSpecificAlgorithmBenchmarks.cs
@@ -70,12 +70,12 @@ public class ValueSpecificAlgorithmBenchmarks
       yield return [Algorithms.Icao9303MachineReadableVisa, Algorithms.Icao9303MachineReadableVisa.AlgorithmName, "I<UTOSKYWALKER<<LUKE<<<<<<<<<<<<<<<<STARWARS45UTO7705256M2405252<<<<<<B<"];
 
       yield return [Algorithms.Icao9303SizeTD1, Algorithms.Icao9303SizeTD1.AlgorithmName, "I<UTOD231458907<<<<<<<<<<<<<<<7408122F1204159UTO<<<<<<<<<<<6ERIKSSON<<ANNA<MARIA<<<<<<<<A<"];
-      yield return [Algorithms.Icao9303SizeTD1, Algorithms.Icao9303SizeTD1.AlgorithmName, "I<UTOD23145890<AB112234566<<<<7408122F1204159UTO<<<<<<<<<<<4ERIKSSON<<ANNA<MARIA<<<<<<<<B<"];
-      yield return [Algorithms.Icao9303SizeTD1, Algorithms.Icao9303SizeTD1.AlgorithmName, "I<UTOSTARWARS45<<<<<<<<<<<<<<<7705256M2405252UTO<<<<<<<<<<<4SKYWALKER<<LUKE<<<<<<<<<<<<<C<"];
+      yield return [Algorithms.Icao9303SizeTD1, Algorithms.Icao9303SizeTD1.AlgorithmName, "I<UTOD23145890<AB112234566<<<<\r\n7408122F1204159UTO<<<<<<<<<<<4\r\nERIKSSON<<ANNA<MARIA<<<<<<<<B<"];
+      yield return [Algorithms.Icao9303SizeTD1, Algorithms.Icao9303SizeTD1.AlgorithmName, "I<UTOSTARWARS45<<<<<<<<<<<<<<<\n7705256M2405252UTO<<<<<<<<<<<4\nSKYWALKER<<LUKE<<<<<<<<<<<<<C<"];
 
       yield return [Algorithms.Icao9303SizeTD2, Algorithms.Icao9303SizeTD2.AlgorithmName, "I<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<D231458907UTO7408122F1204159<<<<<<<6"];
-      yield return [Algorithms.Icao9303SizeTD2, Algorithms.Icao9303SizeTD2.AlgorithmName, "I<UTOQWERTY<<ASDF<<<<<<<<<<<<<<<<<<<D23145890<UTO7408122F1204159AB1124<4"];
-      yield return [Algorithms.Icao9303SizeTD2, Algorithms.Icao9303SizeTD2.AlgorithmName, "I<UTOSKYWALKER<<LUKE<<<<<<<<<<<<<<<<STARWARS45UTO7705256M2405252<<<<<<<8"];
+      yield return [Algorithms.Icao9303SizeTD2, Algorithms.Icao9303SizeTD2.AlgorithmName, "I<UTOQWERTY<<ASDF<<<<<<<<<<<<<<<<<<<\r\nD23145890<UTO7408122F1204159AB1124<4"];
+      yield return [Algorithms.Icao9303SizeTD2, Algorithms.Icao9303SizeTD2.AlgorithmName, "I<UTOSKYWALKER<<LUKE<<<<<<<<<<<<<<<<\nSTARWARS45UTO7705256M2405252<<<<<<<4"];
 
       yield return [Algorithms.Icao9303SizeTD3, Algorithms.Icao9303SizeTD3.AlgorithmName, "P<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<L898902C36UTO7408122F1204159ZE184226B<<<<<10"];
       yield return [Algorithms.Icao9303SizeTD3, Algorithms.Icao9303SizeTD3.AlgorithmName, "P<UTOQWERTY<<ASDF<<<<<<<<<<<<<<<<<<<<<<<<<<<Q123987655UTO3311226F2010201<<<<<<<<<<<<<<06"];

--- a/CheckDigits.Net.Tests.Benchmarks/ValueSpecificAlgorithmBenchmarks.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/ValueSpecificAlgorithmBenchmarks.cs
@@ -19,17 +19,17 @@ public class ValueSpecificAlgorithmBenchmarks
       yield return [ Algorithms.Icao9303, Algorithms.Icao9303.AlgorithmName, "U7Y8SXRC0O3SC4IHYQ" ];
       yield return [ Algorithms.Icao9303, Algorithms.Icao9303.AlgorithmName, "U7Y8SXRC0O3SC4IHYQF4M" ];
 
-      yield return [Algorithms.Isin, Algorithms.Isin.AlgorithmName, "US037833100"];
-      yield return [Algorithms.Isin, Algorithms.Isin.AlgorithmName, "AU0000XVGZA"];
-      yield return [Algorithms.Isin, Algorithms.Isin.AlgorithmName, "GB000263494"];
+      //yield return [Algorithms.Isin, Algorithms.Isin.AlgorithmName, "US037833100"];
+      //yield return [Algorithms.Isin, Algorithms.Isin.AlgorithmName, "AU0000XVGZA"];
+      //yield return [Algorithms.Isin, Algorithms.Isin.AlgorithmName, "GB000263494"];
 
-      yield return [Algorithms.Iso6346, Algorithms.Iso6346.AlgorithmName, "CSQU305438"];
-      yield return [Algorithms.Iso6346, Algorithms.Iso6346.AlgorithmName, "TOLU473478"];
-      yield return [Algorithms.Iso6346, Algorithms.Iso6346.AlgorithmName, "MSKU907032"];
+      //yield return [Algorithms.Iso6346, Algorithms.Iso6346.AlgorithmName, "CSQU305438"];
+      //yield return [Algorithms.Iso6346, Algorithms.Iso6346.AlgorithmName, "TOLU473478"];
+      //yield return [Algorithms.Iso6346, Algorithms.Iso6346.AlgorithmName, "MSKU907032"];
 
-      yield return [Algorithms.Vin, Algorithms.Vin.AlgorithmName, "1M8GDM9A_KP042788"];
-      yield return [Algorithms.Vin, Algorithms.Vin.AlgorithmName, "1G8ZG127_WZ157259"];
-      yield return [Algorithms.Vin, Algorithms.Vin.AlgorithmName, "1HGEM212_2L047875"];
+      //yield return [Algorithms.Vin, Algorithms.Vin.AlgorithmName, "1M8GDM9A_KP042788"];
+      //yield return [Algorithms.Vin, Algorithms.Vin.AlgorithmName, "1G8ZG127_WZ157259"];
+      //yield return [Algorithms.Vin, Algorithms.Vin.AlgorithmName, "1HGEM212_2L047875"];
    }
 
    public static IEnumerable<Object[]> TryCalculateCheckDigitsArguments()
@@ -41,33 +41,33 @@ public class ValueSpecificAlgorithmBenchmarks
 
    public static IEnumerable<Object[]> ValidateArguments()
    {
-      yield return [Algorithms.AbaRtn, Algorithms.AbaRtn.AlgorithmName, "111000025"];
-      yield return [Algorithms.AbaRtn, Algorithms.AbaRtn.AlgorithmName, "122235821"];
-      yield return [Algorithms.AbaRtn, Algorithms.AbaRtn.AlgorithmName, "325081403"];
+      //yield return [Algorithms.AbaRtn, Algorithms.AbaRtn.AlgorithmName, "111000025"];
+      //yield return [Algorithms.AbaRtn, Algorithms.AbaRtn.AlgorithmName, "122235821"];
+      //yield return [Algorithms.AbaRtn, Algorithms.AbaRtn.AlgorithmName, "325081403"];
 
-      yield return [Algorithms.Cusip, Algorithms.Cusip.AlgorithmName, "037833100"];
-      yield return [Algorithms.Cusip, Algorithms.Cusip.AlgorithmName, "38143VAA7"];
-      yield return [Algorithms.Cusip, Algorithms.Cusip.AlgorithmName, "91282CJL6"];
+      //yield return [Algorithms.Cusip, Algorithms.Cusip.AlgorithmName, "037833100"];
+      //yield return [Algorithms.Cusip, Algorithms.Cusip.AlgorithmName, "38143VAA7"];
+      //yield return [Algorithms.Cusip, Algorithms.Cusip.AlgorithmName, "91282CJL6"];
 
-      yield return [Algorithms.Figi, Algorithms.Figi.AlgorithmName, "BBG000B9Y5X2"];
-      yield return [Algorithms.Figi, Algorithms.Figi.AlgorithmName, "BBG111111160"];
-      yield return [Algorithms.Figi, Algorithms.Figi.AlgorithmName, "BBGZYXWVTSR7"];
+      //yield return [Algorithms.Figi, Algorithms.Figi.AlgorithmName, "BBG000B9Y5X2"];
+      //yield return [Algorithms.Figi, Algorithms.Figi.AlgorithmName, "BBG111111160"];
+      //yield return [Algorithms.Figi, Algorithms.Figi.AlgorithmName, "BBGZYXWVTSR7"];
 
-      yield return [Algorithms.Iban, Algorithms.Iban.AlgorithmName, "BE71096123456769"];
-      yield return [Algorithms.Iban, Algorithms.Iban.AlgorithmName, "GB82WEST12345698765432"];
-      yield return [Algorithms.Iban, Algorithms.Iban.AlgorithmName, "SC74MCBL01031234567890123456USD"];
+      //yield return [Algorithms.Iban, Algorithms.Iban.AlgorithmName, "BE71096123456769"];
+      //yield return [Algorithms.Iban, Algorithms.Iban.AlgorithmName, "GB82WEST12345698765432"];
+      //yield return [Algorithms.Iban, Algorithms.Iban.AlgorithmName, "SC74MCBL01031234567890123456USD"];
 
-      yield return [ Algorithms.Icao9303, Algorithms.Icao9303.AlgorithmName, "U7Y5" ];
-      yield return [ Algorithms.Icao9303, Algorithms.Icao9303.AlgorithmName, "U7Y8SX8" ];
-      yield return [ Algorithms.Icao9303, Algorithms.Icao9303.AlgorithmName, "U7Y8SXRC03" ];
-      yield return [ Algorithms.Icao9303, Algorithms.Icao9303.AlgorithmName, "U7Y8SXRC0O3S8" ];
-      yield return [ Algorithms.Icao9303, Algorithms.Icao9303.AlgorithmName, "U7Y8SXRC0O3SC4I2" ];
-      yield return [ Algorithms.Icao9303, Algorithms.Icao9303.AlgorithmName, "U7Y8SXRC0O3SC4IHYQ9" ];
-      yield return [ Algorithms.Icao9303, Algorithms.Icao9303.AlgorithmName, "U7Y8SXRC0O3SC4IHYQF4M8" ];
+      yield return [Algorithms.Icao9303, Algorithms.Icao9303.AlgorithmName, "U7Y5"];
+      yield return [Algorithms.Icao9303, Algorithms.Icao9303.AlgorithmName, "U7Y8SX8"];
+      yield return [Algorithms.Icao9303, Algorithms.Icao9303.AlgorithmName, "U7Y8SXRC03"];
+      yield return [Algorithms.Icao9303, Algorithms.Icao9303.AlgorithmName, "U7Y8SXRC0O3S8"];
+      yield return [Algorithms.Icao9303, Algorithms.Icao9303.AlgorithmName, "U7Y8SXRC0O3SC4I2"];
+      yield return [Algorithms.Icao9303, Algorithms.Icao9303.AlgorithmName, "U7Y8SXRC0O3SC4IHYQ9"];
+      yield return [Algorithms.Icao9303, Algorithms.Icao9303.AlgorithmName, "U7Y8SXRC0O3SC4IHYQF4M8"];
 
       yield return [Algorithms.Icao9303MachineReadableVisa, Algorithms.Icao9303MachineReadableVisa.AlgorithmName, "I<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<D231458907UTO7408122F1204159<<<<<<A<"];
-      yield return [Algorithms.Icao9303MachineReadableVisa, Algorithms.Icao9303MachineReadableVisa.AlgorithmName, "V<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<L898902C<3UTO6908061F9406236ZE184226B<<<<<<<"];
-      yield return [Algorithms.Icao9303MachineReadableVisa, Algorithms.Icao9303MachineReadableVisa.AlgorithmName, "I<UTOSKYWALKER<<LUKE<<<<<<<<<<<<<<<<STARWARS45UTO7705256M2405252<<<<<<B<"];
+      yield return [Algorithms.Icao9303MachineReadableVisa, Algorithms.Icao9303MachineReadableVisa.AlgorithmName, "V<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<\r\nL898902C<3UTO6908061F9406236ZE184226B<<<<<<<"];
+      yield return [Algorithms.Icao9303MachineReadableVisa, Algorithms.Icao9303MachineReadableVisa.AlgorithmName, "I<UTOSKYWALKER<<LUKE<<<<<<<<<<<<<<<<\nSTARWARS45UTO7705256M2405252<<<<<<B<"];
 
       yield return [Algorithms.Icao9303SizeTD1, Algorithms.Icao9303SizeTD1.AlgorithmName, "I<UTOD231458907<<<<<<<<<<<<<<<7408122F1204159UTO<<<<<<<<<<<6ERIKSSON<<ANNA<MARIA<<<<<<<<A<"];
       yield return [Algorithms.Icao9303SizeTD1, Algorithms.Icao9303SizeTD1.AlgorithmName, "I<UTOD23145890<AB112234566<<<<\r\n7408122F1204159UTO<<<<<<<<<<<4\r\nERIKSSON<<ANNA<MARIA<<<<<<<<B<"];
@@ -78,38 +78,38 @@ public class ValueSpecificAlgorithmBenchmarks
       yield return [Algorithms.Icao9303SizeTD2, Algorithms.Icao9303SizeTD2.AlgorithmName, "I<UTOSKYWALKER<<LUKE<<<<<<<<<<<<<<<<\nSTARWARS45UTO7705256M2405252<<<<<<<4"];
 
       yield return [Algorithms.Icao9303SizeTD3, Algorithms.Icao9303SizeTD3.AlgorithmName, "P<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<L898902C36UTO7408122F1204159ZE184226B<<<<<10"];
-      yield return [Algorithms.Icao9303SizeTD3, Algorithms.Icao9303SizeTD3.AlgorithmName, "P<UTOQWERTY<<ASDF<<<<<<<<<<<<<<<<<<<<<<<<<<<Q123987655UTO3311226F2010201<<<<<<<<<<<<<<06"];
-      yield return [Algorithms.Icao9303SizeTD3, Algorithms.Icao9303SizeTD3.AlgorithmName, "P<UTOSKYWALKER<<LUKE<<<<<<<<<<<<<<<<<<<<<<<<STARWARS45UTO7705256M2405252HAN<SHOT<FIRST78"];
+      yield return [Algorithms.Icao9303SizeTD3, Algorithms.Icao9303SizeTD3.AlgorithmName, "P<UTOQWERTY<<ASDF<<<<<<<<<<<<<<<<<<<<<<<<<<<\r\nQ123987655UTO3311226F2010201<<<<<<<<<<<<<<06"];
+      yield return [Algorithms.Icao9303SizeTD3, Algorithms.Icao9303SizeTD3.AlgorithmName, "P<UTOSKYWALKER<<LUKE<<<<<<<<<<<<<<<<<<<<<<<<\nSTARWARS45UTO7705256M2405252HAN<SHOT<FIRST78"];
 
-      yield return [Algorithms.Isan, Algorithms.Isan.AlgorithmName, "D02C42E954183EE2Q1291C8AEO"];
-      yield return [Algorithms.Isan, Algorithms.Isan.AlgorithmName, "C594660A8B2E5D22X6DDA3272E"];
-      yield return [Algorithms.Isan, Algorithms.Isan.AlgorithmName, "E9530C32BC0EE83B269867B20F"];
+      //      yield return [Algorithms.Isan, Algorithms.Isan.AlgorithmName, "D02C42E954183EE2Q1291C8AEO"];
+      //      yield return [Algorithms.Isan, Algorithms.Isan.AlgorithmName, "C594660A8B2E5D22X6DDA3272E"];
+      //      yield return [Algorithms.Isan, Algorithms.Isan.AlgorithmName, "E9530C32BC0EE83B269867B20F"];
 
-      yield return [Algorithms.Iso6346, Algorithms.Iso6346.AlgorithmName, "CSQU3054383"];
-      yield return [Algorithms.Iso6346, Algorithms.Iso6346.AlgorithmName, "TOLU4734787"];
-      yield return [Algorithms.Iso6346, Algorithms.Iso6346.AlgorithmName, "MSKU9070323"];
+      //      yield return [Algorithms.Iso6346, Algorithms.Iso6346.AlgorithmName, "CSQU3054383"];
+      //      yield return [Algorithms.Iso6346, Algorithms.Iso6346.AlgorithmName, "TOLU4734787"];
+      //      yield return [Algorithms.Iso6346, Algorithms.Iso6346.AlgorithmName, "MSKU9070323"];
 
-      yield return [Algorithms.Isin, Algorithms.Isin.AlgorithmName, "US0378331005"];
-      yield return [Algorithms.Isin, Algorithms.Isin.AlgorithmName, "AU0000XVGZA3"];
-      yield return [Algorithms.Isin, Algorithms.Isin.AlgorithmName, "GB0002634946"];
+      //      yield return [Algorithms.Isin, Algorithms.Isin.AlgorithmName, "US0378331005"];
+      //      yield return [Algorithms.Isin, Algorithms.Isin.AlgorithmName, "AU0000XVGZA3"];
+      //      yield return [Algorithms.Isin, Algorithms.Isin.AlgorithmName, "GB0002634946"];
 
-#pragma warning disable CS0618 // Type or member is obsolete
-      yield return [Algorithms.Nhs, Algorithms.Nhs.AlgorithmName, "9434765919"];
-      yield return [Algorithms.Nhs, Algorithms.Nhs.AlgorithmName, "4505577104"];
-      yield return [Algorithms.Nhs, Algorithms.Nhs.AlgorithmName, "5301194917"];
-#pragma warning restore CS0618 // Type or member is obsolete
+      //#pragma warning disable CS0618 // Type or member is obsolete
+      //      yield return [Algorithms.Nhs, Algorithms.Nhs.AlgorithmName, "9434765919"];
+      //      yield return [Algorithms.Nhs, Algorithms.Nhs.AlgorithmName, "4505577104"];
+      //      yield return [Algorithms.Nhs, Algorithms.Nhs.AlgorithmName, "5301194917"];
+      //#pragma warning restore CS0618 // Type or member is obsolete
 
-      yield return [Algorithms.Npi, Algorithms.Npi.AlgorithmName, "1234567893"];
-      yield return [Algorithms.Npi, Algorithms.Npi.AlgorithmName, "1245319599"];
-      yield return [Algorithms.Npi, Algorithms.Npi.AlgorithmName, "1122337797"];
+      //      yield return [Algorithms.Npi, Algorithms.Npi.AlgorithmName, "1234567893"];
+      //      yield return [Algorithms.Npi, Algorithms.Npi.AlgorithmName, "1245319599"];
+      //      yield return [Algorithms.Npi, Algorithms.Npi.AlgorithmName, "1122337797"];
 
-      yield return [Algorithms.Sedol, Algorithms.Sedol.AlgorithmName, "3134865"];
-      yield return [Algorithms.Sedol, Algorithms.Sedol.AlgorithmName, "B0YQ5W0"];
-      yield return [Algorithms.Sedol, Algorithms.Sedol.AlgorithmName, "BRDVMH9"];
+      //      yield return [Algorithms.Sedol, Algorithms.Sedol.AlgorithmName, "3134865"];
+      //      yield return [Algorithms.Sedol, Algorithms.Sedol.AlgorithmName, "B0YQ5W0"];
+      //      yield return [Algorithms.Sedol, Algorithms.Sedol.AlgorithmName, "BRDVMH9"];
 
-      yield return [Algorithms.Vin, Algorithms.Vin.AlgorithmName, "1M8GDM9AXKP042788"];
-      yield return [Algorithms.Vin, Algorithms.Vin.AlgorithmName, "1G8ZG127XWZ157259"];
-      yield return [Algorithms.Vin, Algorithms.Vin.AlgorithmName, "1HGEM21292L047875"];
+      //      yield return [Algorithms.Vin, Algorithms.Vin.AlgorithmName, "1M8GDM9AXKP042788"];
+      //      yield return [Algorithms.Vin, Algorithms.Vin.AlgorithmName, "1G8ZG127XWZ157259"];
+      //      yield return [Algorithms.Vin, Algorithms.Vin.AlgorithmName, "1HGEM21292L047875"];
    }
 
    public static IEnumerable<Object[]> ValidateFormattedArguments()
@@ -129,12 +129,12 @@ public class ValueSpecificAlgorithmBenchmarks
       algorithm.TryCalculateCheckDigit(value, out var checkDigit);
    }
 
-   [Benchmark]
-   [ArgumentsSource(nameof(TryCalculateCheckDigitsArguments))]
-   public void TryCalculateCheckDigits(IDoubleCheckDigitAlgorithm algorithm, String name, String value)
-   {
-      algorithm.TryCalculateCheckDigits(value, out var first, out var second);
-   }
+   //[Benchmark]
+   //[ArgumentsSource(nameof(TryCalculateCheckDigitsArguments))]
+   //public void TryCalculateCheckDigits(IDoubleCheckDigitAlgorithm algorithm, String name, String value)
+   //{
+   //   algorithm.TryCalculateCheckDigits(value, out var first, out var second);
+   //}
 
    [Benchmark]
    [ArgumentsSource(nameof(ValidateArguments))]
@@ -143,10 +143,10 @@ public class ValueSpecificAlgorithmBenchmarks
       algorithm.Validate(value);
    }
 
-   [Benchmark]
-   [ArgumentsSource(nameof(ValidateFormattedArguments))]
-   public void ValidateFormatted(IsanAlgorithm algorithm, String name, String value)
-   {
-      algorithm.ValidateFormatted(value);
-   }
+   //[Benchmark]
+   //[ArgumentsSource(nameof(ValidateFormattedArguments))]
+   //public void ValidateFormatted(IsanAlgorithm algorithm, String name, String value)
+   //{
+   //   algorithm.ValidateFormatted(value);
+   //}
 }

--- a/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303AlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303AlgorithmTests.cs
@@ -26,64 +26,6 @@ public class Icao9303AlgorithmTests
 
    #endregion
 
-   #region MapCharacter Tests
-   // ==========================================================================
-   // ==========================================================================
-
-   [Theory]
-   [InlineData('\0', -1)]
-   [InlineData('/', -1)]
-   [InlineData('0', 0)]
-   [InlineData('1', 1)]
-   [InlineData('2', 2)]
-   [InlineData('3', 3)]
-   [InlineData('4', 4)]
-   [InlineData('5', 5)]
-   [InlineData('6', 6)]
-   [InlineData('7', 7)]
-   [InlineData('8', 8)]
-   [InlineData('9', 9)]
-   [InlineData(':', -1)]
-   [InlineData(';', -1)]
-   [InlineData('<', 0)]
-   [InlineData('=', -1)]
-   [InlineData('>', -1)]
-   [InlineData('?', -1)]
-   [InlineData('@', -1)]
-   [InlineData('A', 10)]
-   [InlineData('B', 11)]
-   [InlineData('C', 12)]
-   [InlineData('D', 13)]
-   [InlineData('E', 14)]
-   [InlineData('F', 15)]
-   [InlineData('G', 16)]
-   [InlineData('H', 17)]
-   [InlineData('I', 18)]
-   [InlineData('J', 19)]
-   [InlineData('K', 20)]
-   [InlineData('L', 21)]
-   [InlineData('M', 22)]
-   [InlineData('N', 23)]
-   [InlineData('O', 24)]
-   [InlineData('P', 25)]
-   [InlineData('Q', 26)]
-   [InlineData('R', 27)]
-   [InlineData('S', 28)]
-   [InlineData('T', 29)]
-   [InlineData('U', 30)]
-   [InlineData('V', 31)]
-   [InlineData('W', 32)]
-   [InlineData('X', 33)]
-   [InlineData('Y', 34)]
-   [InlineData('Z', 35)]
-   [InlineData('[', -1)]
-   public void Icao9303Algorithm_MapCharacter_ShouldReturnExpectedValue(
-      Char ch,
-      Int32 expected)
-      => Icao9303Algorithm.MapCharacter(ch).Should().Be(expected);
-
-   #endregion
-
    #region TryCalculateCheckDigit Tests
    // ==========================================================================
    // ==========================================================================

--- a/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303HelpersTests.cs
+++ b/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303HelpersTests.cs
@@ -1,0 +1,63 @@
+﻿namespace CheckDigits.Net.Tests.Unit.ValueSpecificAlgorithms;
+
+public class Icao9303HelpersTests
+{
+   #region MapCharacter Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [InlineData('\0', -1)]
+   [InlineData('/', -1)]
+   [InlineData('0', 0)]
+   [InlineData('1', 1)]
+   [InlineData('2', 2)]
+   [InlineData('3', 3)]
+   [InlineData('4', 4)]
+   [InlineData('5', 5)]
+   [InlineData('6', 6)]
+   [InlineData('7', 7)]
+   [InlineData('8', 8)]
+   [InlineData('9', 9)]
+   [InlineData(':', -1)]
+   [InlineData(';', -1)]
+   [InlineData('<', 0)]
+   [InlineData('=', -1)]
+   [InlineData('>', -1)]
+   [InlineData('?', -1)]
+   [InlineData('@', -1)]
+   [InlineData('A', 10)]
+   [InlineData('B', 11)]
+   [InlineData('C', 12)]
+   [InlineData('D', 13)]
+   [InlineData('E', 14)]
+   [InlineData('F', 15)]
+   [InlineData('G', 16)]
+   [InlineData('H', 17)]
+   [InlineData('I', 18)]
+   [InlineData('J', 19)]
+   [InlineData('K', 20)]
+   [InlineData('L', 21)]
+   [InlineData('M', 22)]
+   [InlineData('N', 23)]
+   [InlineData('O', 24)]
+   [InlineData('P', 25)]
+   [InlineData('Q', 26)]
+   [InlineData('R', 27)]
+   [InlineData('S', 28)]
+   [InlineData('T', 29)]
+   [InlineData('U', 30)]
+   [InlineData('V', 31)]
+   [InlineData('W', 32)]
+   [InlineData('X', 33)]
+   [InlineData('Y', 34)]
+   [InlineData('Z', 35)]
+   [InlineData('[', -1)]
+   public void Icao9303Algorithm_MapCharacter_ShouldReturnExpectedValue(
+      Char ch,
+      Int32 expected)
+      => Icao9303Helpers.MapCharacter(ch).Should().Be(expected);
+
+   #endregion
+
+}

--- a/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303MachineReadableVisaAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303MachineReadableVisaAlgorithmTests.cs
@@ -11,40 +11,63 @@ public class Icao9303MachineReadableVisaAlgorithmTests
    private const String _fmtAMrzSecondLine = "L898902C<3UTO6908061F9406236ZE184226B<<<<<<<";
    private const String _fmtBMrzFirstLine = "V<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<";
    private const String _fmtBMrzSecondLine = "L898902C<3UTO6908061F9406236ZE184226";
-   private const String _emptySeparator = "";
-   private const String _crlf = "\r\n";
-   private const String _lf = "\n";
+
+   private const String _fmtANameField = "ERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<";
+   private const String _fmtBNameField = "ERIKSSON<<ANNA<MARIA<<<<<<<<<<<";
+
+   private const String _fmtAOptionalDataField = "ZE184226B<<<<<<<";
+   private const String _fmtBOptionalDataField = "ZE184226";
+
+   private const String _lineSeparatorNone = "";
+   private const String _lineSeparatorCrlf = "\r\n";
+   private const String _lineSeparatorLf = "\n";
 
    public enum MrzFormat { A, B }
 
+#pragma warning disable CS8524 // The switch expression does not handle some values of its input type (it is not exhaustive) involving an unnamed enum value.
+   private static String GetNameField(MrzFormat format)
+      => format switch
+      {
+         MrzFormat.A => _fmtANameField,
+         MrzFormat.B => _fmtBNameField,
+      };
+
+   private static String GetOptionalDataField(MrzFormat format)
+      => format switch
+      {
+         MrzFormat.A => _fmtAOptionalDataField,
+         MrzFormat.B => _fmtBOptionalDataField,
+      };
+#pragma warning restore CS8524 // The switch expression does not handle some values of its input type (it is not exhaustive) involving an unnamed enum value.
+
+   private static String GetTestValue(
+      String documentType = "V<",
+      String issuingState = "UTO",
+      String name = _fmtANameField,
+      String lineSeparator = _lineSeparatorNone,
+      String documentNumber = "D231458907",              // 9 alphanumeric characters + 1 check digit
+      String nationality = "UTO",
+      String dateOfBirth = "7408122",                    // 6 digit characters + 1 check digit
+      String sex = "F",
+      String dateOfExpiry = "1204159",                   // 6 digit characters + 1 check digit
+      String optionalData = _fmtAOptionalDataField)
+      => $"{documentType}{issuingState}{name}" +
+         lineSeparator +
+         $"{documentNumber}{nationality}{dateOfBirth}{sex}{dateOfExpiry}{optionalData}";
+
    private static String GetTestValue(
       MrzFormat format = MrzFormat.A,
-      String separatorChars = _emptySeparator,
-#if !NET48
-      String? firstLine = null,
-      String? secondLine = null)
-#else
-      String firstLine = null,
-      String secondLine = null)
-#endif
-      => (firstLine ?? MrzFirstLine(format))
-         + separatorChars + (secondLine ?? MrzSecondLine(format));
-
-   private static String MrzFirstLine(MrzFormat format)
-      => format switch
-      {
-         MrzFormat.A => _fmtAMrzFirstLine,
-         MrzFormat.B => _fmtBMrzFirstLine,
-         _ => throw new ArgumentOutOfRangeException(),
-      };
-
-   private static String MrzSecondLine(MrzFormat format)
-      => format switch
-      {
-         MrzFormat.A => _fmtAMrzSecondLine,
-         MrzFormat.B => _fmtBMrzSecondLine,
-         _ => throw new ArgumentOutOfRangeException(),
-      };
+      String documentType = "V<",
+      String issuingState = "UTO",
+      String lineSeparator = _lineSeparatorNone,
+      String documentNumber = "D231458907",              // 9 alphanumeric characters + 1 check digit
+      String nationality = "UTO",
+      String dateOfBirth = "7408122",                    // 6 digit characters + 1 check digit
+      String sex = "F",
+      String dateOfExpiry = "1204159")                   // 6 digit characters + 1 check digit
+      => $"{documentType}{issuingState}{GetNameField(format)}" +
+         lineSeparator +
+         $"{documentNumber}{nationality}{dateOfBirth}{sex}{dateOfExpiry}{GetOptionalDataField(format)}";
 
    #region AlgorithmDescription Property Tests
    // ==========================================================================
@@ -78,163 +101,193 @@ public class Icao9303MachineReadableVisaAlgorithmTests
    public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnFalse_WhenInputIsEmpty()
       => _sut.Validate(String.Empty).Should().BeFalse();
 
-   public static TheoryData<MrzFormat, String, String, String> InvalidLengthData => new()
-   {
-      { MrzFormat.A, _emptySeparator, _fmtAMrzFirstLine[..35], _fmtBMrzSecondLine },
-      { MrzFormat.A, _crlf,           _fmtAMrzFirstLine[..35], "<" + _fmtBMrzSecondLine },
-      { MrzFormat.B, _emptySeparator, _fmtBMrzFirstLine + "<<", _fmtBMrzSecondLine },
-      { MrzFormat.B, _crlf,           _fmtBMrzFirstLine + "<<", _fmtBMrzSecondLine },
-      { MrzFormat.B, _lf,             _fmtBMrzFirstLine + "<<", _fmtBMrzSecondLine },
-   };
-
    [Theory]
-   [MemberData(nameof(InvalidLengthData))]
-   public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnFalse_WhenValueIsInvalidLength(
-      MrzFormat format,
+   [InlineData("ERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<", _lineSeparatorNone, _fmtAOptionalDataField)]      // Name -1 char and default line separator = total length 87
+   [InlineData("ERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<<", _lineSeparatorNone, _fmtAOptionalDataField)]    // Name -1 char and default line separator = total length 91
+   [InlineData("ERIKSSON<<ANNA<MARIA<<<<<<<<<<", _lineSeparatorNone, _fmtBOptionalDataField)]              // Name -1 char and default line separator = total length 71
+   [InlineData("ERIKSSON<<ANNA<MARIA<<<<<<<<<<<<", _lineSeparatorNone, _fmtBOptionalDataField)]            // Name -1 char and default line separator = total length 95
+   public void Icao93033MachineReadableVisaAlgorithm_Validate_ShouldReturnFalse_WhenValueIsInvalidLength(
+      String name,
       String lineSeparator,
-      String firstLine,
-      String secondLine)
+      String optionalData)
    {
       // Arrange.
-      var value = GetTestValue(format, lineSeparator, firstLine, secondLine);
+      var value = GetTestValue(name: name, lineSeparator: lineSeparator, optionalData: optionalData);
 
       // Act/assert.
       _sut.Validate(value).Should().BeFalse();
    }
 
    [Theory]
-   [InlineData(_fmtAMrzFirstLine + "X\n" + _fmtAMrzSecondLine)]  // 'X' instead of \r
-   [InlineData(_fmtBMrzFirstLine + " \n" + _fmtBMrzSecondLine)]  // Space instead of \r
-   [InlineData(_fmtAMrzFirstLine + "\r " + _fmtAMrzSecondLine)]  // Space instead of \n
-   [InlineData(_fmtBMrzFirstLine + "\n\r" + _fmtBMrzSecondLine)] // \n\r instead of \r\n
-   public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnFalse_WhenSeparatorCharactersAreInvalid(String value)
-      => _sut.Validate(value).Should().BeFalse();
-
-   /// <summary>
-   ///   Test data for edge cases where separator validation cannot detect certain 
-   ///   issues due to length ambiguity. For example, when the first line is 
-   ///   shortened by exactly one character, a CRLF separator's LF character falls 
-   ///   at the position where an LF-only separator would be expected, making the 
-   ///   error undetectable by length validation alone.
-   /// </summary>
-   public static TheoryData<MrzFormat, String, String, String> UndetectableSeparatorIssuesData => new()
+   [InlineData(MrzFormat.A, _lineSeparatorNone)]
+   [InlineData(MrzFormat.A, _lineSeparatorCrlf)]
+   [InlineData(MrzFormat.A, _lineSeparatorLf)]
+   [InlineData(MrzFormat.B, _lineSeparatorNone)]
+   [InlineData(MrzFormat.B, _lineSeparatorCrlf)]
+   [InlineData(MrzFormat.B, _lineSeparatorLf)]
+   public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnTrue_WhenLineSeparatorIsValid(
+      MrzFormat format,
+      String lineSeparator)
    {
-      { MrzFormat.A, _crlf, _fmtAMrzFirstLine[..44], _fmtAMrzSecondLine },      // Length indicates Lf only and Lf falls in correct position
-      { MrzFormat.A, _lf,   _fmtAMrzFirstLine[..44], _fmtAMrzSecondLine },      // Length indicates no separator so separator chars not checked
-      { MrzFormat.A, _crlf, _fmtBMrzFirstLine[..35], _fmtBMrzSecondLine },      // Length indicates Lf only and Lf falls in correct position
-      { MrzFormat.B, _lf,   _fmtBMrzFirstLine[..35], _fmtBMrzSecondLine },      // Length indicates no separator so separator chars not checked
-   };
+      // Arrange.
+      var value = GetTestValue(format: format, lineSeparator: lineSeparator);
+
+      // Act/assert.
+      _sut.Validate(value).Should().BeTrue();
+   }
 
    [Theory]
-   [InlineData(71)]  // One character short of MRV-B with no separator
-   [InlineData(73)]  // One character over MRV-B with no separator
-   [InlineData(87)]  // One character short of MRV-A with no separator
-   [InlineData(89)]  // One character over MRV-A with no separator
-   public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnFalse_WhenLengthIsNearButInvalid(Int32 length)
+   [InlineData(MrzFormat.A, "X\n")]     // 'X' instead of \r
+   [InlineData(MrzFormat.A, " \n")]     // Space instead of \r
+   [InlineData(MrzFormat.A, "\r ")]     // Space instead of \n
+   [InlineData(MrzFormat.A, "\n\r")]    // \n\r instead of \r\n
+   [InlineData(MrzFormat.B, "X\n")]     // 'X' instead of \r
+   [InlineData(MrzFormat.B, " \n")]     // Space instead of \r
+   [InlineData(MrzFormat.B, "\r ")]     // Space instead of \n
+   [InlineData(MrzFormat.B, "\n\r")]    // \n\r instead of \r\n
+   public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnFalse_WhenLineSeparatorIsInvalid(
+      MrzFormat format,
+      String lineSeparator)
    {
-      var value = new String('0', length);
+      // Arrange.
+      var value = GetTestValue(format: format, lineSeparator: lineSeparator);
+
+      // Act/assert.
       _sut.Validate(value).Should().BeFalse();
    }
 
    [Theory]
-   [MemberData(nameof(UndetectableSeparatorIssuesData))]
+   // Test data for edge cases where separator validation cannot detect certain 
+   // issues due to length ambiguity. For example, when the first line is 
+   // shortened by exactly one character, a CRLF separator's LF character falls 
+   // at the position where an LF-only separator would be expected, making the 
+   // error undetectable by length validation alone.
+   [InlineData("ERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<", _lineSeparatorCrlf, _fmtAOptionalDataField)]      // Length indicates Lf only and Lf falls in correct position
+   [InlineData("ERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<", _lineSeparatorLf, _fmtAOptionalDataField)]        // Length indicates no separator so separator chars not checked
+   [InlineData("ERIKSSON<<ANNA<MARIA<<<<<<<<<<", _lineSeparatorCrlf, _fmtBOptionalDataField)]              // Length indicates Lf only and Lf falls in correct position
+   [InlineData("ERIKSSON<<ANNA<MARIA<<<<<<<<<<", _lineSeparatorLf, _fmtBOptionalDataField)]                // Length indicates no separator so separator chars not checked
    public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnTrue_WhenUndetectableInvalidSeparator(
-      MrzFormat format,
+      String name,
       String lineSeparator,
-      String firstLine,
-      String secondLine)
+      String optionalData)
    {
       // Arrange.
-      var value = GetTestValue(format, lineSeparator, firstLine, secondLine);
+      var value = GetTestValue(name: name, lineSeparator: lineSeparator, optionalData: optionalData);
 
       // Act/assert.
       _sut.Validate(value).Should().BeTrue();
    }
 
    [Theory]
-   [InlineData(MrzFormat.B, _emptySeparator, "0000000000UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _emptySeparator, "0010000001UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _emptySeparator, "0020000002UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _emptySeparator, "0030000003UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _emptySeparator, "0040000004UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _emptySeparator, "0050000005UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _emptySeparator, "0060000006UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _emptySeparator, "0070000007UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _emptySeparator, "0080000008UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _emptySeparator, "0090000009UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _crlf, "00A0000000UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _crlf, "00B0000001UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _crlf, "00C0000002UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _crlf, "00D0000003UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _crlf, "00E0000004UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _crlf, "00F0000005UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _crlf, "00G0000006UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _crlf, "00H0000007UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _crlf, "00I0000008UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _crlf, "00J0000009UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _lf, "00K0000000UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _lf, "00L0000001UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _lf, "00M0000002UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _lf, "00N0000003UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _lf, "00O0000004UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _lf, "00P0000005UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _lf, "00Q0000006UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _lf, "00R0000007UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _lf, "00S0000008UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _lf, "00T0000009UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.A, _emptySeparator, "00U0000000UTO0000000F0000000<<<<<<<<<<<<<<<<")]
-   [InlineData(MrzFormat.A, _emptySeparator, "00V0000001UTO0000000F0000000<<<<<<<<<<<<<<<<")]
-   [InlineData(MrzFormat.A, _emptySeparator, "00W0000002UTO0000000F0000000<<<<<<<<<<<<<<<<")]
-   [InlineData(MrzFormat.A, _emptySeparator, "00X0000003UTO0000000F0000000<<<<<<<<<<<<<<<<")]
-   [InlineData(MrzFormat.A, _emptySeparator, "00Y0000004UTO0000000F0000000<<<<<<<<<<<<<<<<")]
-   [InlineData(MrzFormat.A, _emptySeparator, "00Z0000005UTO0000000F0000000<<<<<<<<<<<<<<<<")]
-   [InlineData(MrzFormat.A, _emptySeparator, "00<0000000UTO0000000F0000000<<<<<<<<<<<<<<<<")]
-   public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldCorrectlyMapFieldCharacterValues(
+   // Third posiition has weight = 1, so easier to calculate field check digit
+   [InlineData(MrzFormat.A, "0000000000")]
+   [InlineData(MrzFormat.A, "0010000001")]
+   [InlineData(MrzFormat.A, "0020000002")]
+   [InlineData(MrzFormat.A, "0030000003")]
+   [InlineData(MrzFormat.A, "0040000004")]
+   [InlineData(MrzFormat.A, "0050000005")]
+   [InlineData(MrzFormat.A, "0060000006")]
+   [InlineData(MrzFormat.A, "0070000007")]
+   [InlineData(MrzFormat.A, "0080000008")]
+   [InlineData(MrzFormat.A, "0090000009")]
+   [InlineData(MrzFormat.A, "00A0000000")]
+   [InlineData(MrzFormat.A, "00B0000001")]
+   [InlineData(MrzFormat.A, "00C0000002")]
+   [InlineData(MrzFormat.A, "00D0000003")]
+   [InlineData(MrzFormat.A, "00E0000004")]
+   [InlineData(MrzFormat.A, "00F0000005")]
+   [InlineData(MrzFormat.A, "00G0000006")]
+   [InlineData(MrzFormat.A, "00H0000007")]
+   [InlineData(MrzFormat.A, "00I0000008")]
+   [InlineData(MrzFormat.B, "00J0000009")]
+   [InlineData(MrzFormat.B, "00K0000000")]
+   [InlineData(MrzFormat.B, "00L0000001")]
+   [InlineData(MrzFormat.B, "00M0000002")]
+   [InlineData(MrzFormat.B, "00N0000003")]
+   [InlineData(MrzFormat.B, "00O0000004")]
+   [InlineData(MrzFormat.B, "00P0000005")]
+   [InlineData(MrzFormat.B, "00Q0000006")]
+   [InlineData(MrzFormat.B, "00R0000007")]
+   [InlineData(MrzFormat.B, "00S0000008")]
+   [InlineData(MrzFormat.B, "00T0000009")]
+   [InlineData(MrzFormat.B, "00U0000000")]
+   [InlineData(MrzFormat.B, "00V0000001")]
+   [InlineData(MrzFormat.B, "00W0000002")]
+   [InlineData(MrzFormat.B, "00X0000003")]
+   [InlineData(MrzFormat.B, "00Y0000004")]
+   [InlineData(MrzFormat.B, "00Z0000005")]
+   [InlineData(MrzFormat.B, "00<0000000")]
+   public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldCorrectlyMapCharactersToIntegerEquivalents(
       MrzFormat format,
-      String lineSeparator,
-      String mrzSecondLine)
+      String documentNumber)
    {
       // Arrange.
-      var value = GetTestValue(format, lineSeparator, null, mrzSecondLine);
+      var value = GetTestValue(
+         format: format,
+         lineSeparator: _lineSeparatorCrlf,
+         documentNumber: documentNumber);
 
       // Act/assert.
       _sut.Validate(value).Should().BeTrue();
    }
 
    [Theory]
-   [InlineData(MrzFormat.B, _crlf, "00a0000000UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _crlf, "00b0000001UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _crlf, "00c0000002UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _crlf, "00d0000003UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _crlf, "00e0000004UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _crlf, "00f0000005UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _crlf, "00g0000006UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _crlf, "00h0000007UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _crlf, "00i0000008UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _crlf, "00j0000009UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _lf, "00k0000000UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _lf, "00l0000001UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _lf, "00m0000002UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _lf, "00n0000003UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _lf, "00o0000004UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _lf, "00p0000005UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _lf, "00q0000006UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _lf, "00r0000007UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _lf, "00s0000008UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _lf, "00t0000009UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.A, _emptySeparator, "00u0000000UTO0000000F0000000<<<<<<<<<<<<<<<<")]
-   [InlineData(MrzFormat.A, _emptySeparator, "00v0000001UTO0000000F0000000<<<<<<<<<<<<<<<<")]
-   [InlineData(MrzFormat.A, _emptySeparator, "00w0000002UTO0000000F0000000<<<<<<<<<<<<<<<<")]
-   [InlineData(MrzFormat.A, _emptySeparator, "00x0000003UTO0000000F0000000<<<<<<<<<<<<<<<<")]
-   [InlineData(MrzFormat.A, _emptySeparator, "00y0000004UTO0000000F0000000<<<<<<<<<<<<<<<<")]
-   [InlineData(MrzFormat.A, _emptySeparator, "00z0000005UTO0000000F0000000<<<<<<<<<<<<<<<<")]
+   // Check digits are accurate, if equivalent uppercase character
+   [InlineData(MrzFormat.A, "00a0000000")]
+   [InlineData(MrzFormat.A, "00b0000001")]
+   [InlineData(MrzFormat.A, "00c0000002")]
+   [InlineData(MrzFormat.A, "00d0000003")]
+   [InlineData(MrzFormat.A, "00e0000004")]
+   [InlineData(MrzFormat.A, "00f0000005")]
+   [InlineData(MrzFormat.A, "00g0000006")]
+   [InlineData(MrzFormat.A, "00h0000007")]
+   [InlineData(MrzFormat.A, "00i0000008")]
+   [InlineData(MrzFormat.B, "00j0000009")]
+   [InlineData(MrzFormat.B, "00k0000000")]
+   [InlineData(MrzFormat.B, "00l0000001")]
+   [InlineData(MrzFormat.B, "00m0000002")]
+   [InlineData(MrzFormat.B, "00n0000003")]
+   [InlineData(MrzFormat.B, "00o0000004")]
+   [InlineData(MrzFormat.B, "00p0000005")]
+   [InlineData(MrzFormat.B, "00q0000006")]
+   [InlineData(MrzFormat.B, "00r0000007")]
+   [InlineData(MrzFormat.B, "00s0000008")]
+   [InlineData(MrzFormat.B, "00t0000009")]
+   [InlineData(MrzFormat.B, "00u0000000")]
+   [InlineData(MrzFormat.B, "00v0000001")]
+   [InlineData(MrzFormat.B, "00w0000002")]
+   [InlineData(MrzFormat.B, "00x0000003")]
+   [InlineData(MrzFormat.B, "00y0000004")]
+   [InlineData(MrzFormat.B, "00z0000005")]
    public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnFalse_WhenLowerCaseAlphabeticCharacterEncountered(
       MrzFormat format,
-      String lineSeparator,
-      String mrzSecondLine)
+      String documentNumber)
    {
       // Arrange.
-      var value = GetTestValue(format, lineSeparator, null, mrzSecondLine);
+      var value = GetTestValue(
+         format: format,
+         lineSeparator: _lineSeparatorCrlf,
+         documentNumber: documentNumber);
+
+      // Act/assert.
+      _sut.Validate(value).Should().BeFalse();
+   }
+
+   [Theory]
+   // Check digits would be correct if alpha characters allowed
+   [InlineData("00A0000", "0000000")]
+   [InlineData("00a0000", "0000000")]
+   [InlineData("0000000", "00A0000")]
+   [InlineData("0000000", "00a0000")]
+   public void Icao93033MachineReadableVisaAlgorithm_Validate_ShouldReturnFalse_NumericFieldContainsAlphabeticCharacter(
+      String dateOfBirth,
+      String dateOfExpiry)
+   {
+      // Arrange.
+      var value = GetTestValue(
+         format: MrzFormat.A,
+         dateOfBirth: dateOfBirth,
+         dateOfExpiry: dateOfExpiry);
 
       // Act/assert.
       _sut.Validate(value).Should().BeFalse();
@@ -242,93 +295,127 @@ public class Icao9303MachineReadableVisaAlgorithmTests
 
    [Theory]
    // Document number field
-   [InlineData(MrzFormat.A, _emptySeparator, "1000000007UTO0000000F0000000<<<<<<<<<<<<<<<<")]
-   [InlineData(MrzFormat.A, _emptySeparator, "0100000003UTO0000000F0000000<<<<<<<<<<<<<<<<")]
-   [InlineData(MrzFormat.A, _emptySeparator, "0010000001UTO0000000F0000000<<<<<<<<<<<<<<<<")]
-   [InlineData(MrzFormat.A, _emptySeparator, "0001000007UTO0000000F0000000<<<<<<<<<<<<<<<<")]
-   [InlineData(MrzFormat.A, _emptySeparator, "0000100003UTO0000000F0000000<<<<<<<<<<<<<<<<")]
-   [InlineData(MrzFormat.B, _emptySeparator, "0000010001UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _emptySeparator, "0000001007UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _emptySeparator, "0000000103UTO0000000F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _emptySeparator, "0000000011UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.A, _lineSeparatorNone, "1000000007", "0000000", "0000000")]
+   [InlineData(MrzFormat.A, _lineSeparatorNone, "0100000003", "0000000", "0000000")]
+   [InlineData(MrzFormat.A, _lineSeparatorNone, "0010000001", "0000000", "0000000")]
+   [InlineData(MrzFormat.A, _lineSeparatorNone, "0001000007", "0000000", "0000000")]
+   [InlineData(MrzFormat.A, _lineSeparatorNone, "0000100003", "0000000", "0000000")]
+   [InlineData(MrzFormat.B, _lineSeparatorNone, "0000010001", "0000000", "0000000")]  
+   [InlineData(MrzFormat.B, _lineSeparatorNone, "0000001007", "0000000", "0000000")]  
+   [InlineData(MrzFormat.B, _lineSeparatorNone, "0000000103", "0000000", "0000000")]  
+   [InlineData(MrzFormat.B, _lineSeparatorNone, "0000000011", "0000000", "0000000")]  
    // Date of birth field
-   [InlineData(MrzFormat.A, _crlf, "0000000000UTO1000007F0000000<<<<<<<<<<<<<<<<")]
-   [InlineData(MrzFormat.A, _crlf, "0000000000UTO0100003F0000000<<<<<<<<<<<<<<<<")]
-   [InlineData(MrzFormat.A, _crlf, "0000000000UTO0010001F0000000<<<<<<<<<<<<<<<<")]
-   [InlineData(MrzFormat.B, _crlf, "0000000000UTO0001007F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _crlf, "0000000000UTO0000103F0000000<<<<<<<<")]
-   [InlineData(MrzFormat.B, _crlf, "0000000000UTO0000011F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.A, _lineSeparatorCrlf, "0000000000", "1000007", "0000000")]
+   [InlineData(MrzFormat.A, _lineSeparatorCrlf, "0000000000", "0100003", "0000000")]
+   [InlineData(MrzFormat.A, _lineSeparatorCrlf, "0000000000", "0010001", "0000000")]
+   [InlineData(MrzFormat.B, _lineSeparatorCrlf, "0000000000", "0001007", "0000000")]
+   [InlineData(MrzFormat.B, _lineSeparatorCrlf, "0000000000", "0000103", "0000000")]
+   [InlineData(MrzFormat.B, _lineSeparatorCrlf, "0000000000", "0000011", "0000000")]
    // Date of expiry field
-   [InlineData(MrzFormat.A, _lf, "0000000000UTO0000000F1000007<<<<<<<<<<<<<<<<")]
-   [InlineData(MrzFormat.A, _lf, "0000000000UTO0000000F0100003<<<<<<<<<<<<<<<<")]
-   [InlineData(MrzFormat.A, _lf, "0000000000UTO0000000F0010001<<<<<<<<<<<<<<<<")]
-   [InlineData(MrzFormat.B, _lf, "0000000000UTO0000000F0001007<<<<<<<<")]
-   [InlineData(MrzFormat.B, _lf, "0000000000UTO0000000F0000103<<<<<<<<")]
-   [InlineData(MrzFormat.B, _lf, "0000000000UTO0000000F0000011<<<<<<<<")]
+   [InlineData(MrzFormat.A, _lineSeparatorLf,   "0000000000", "0000000", "1000007")]
+   [InlineData(MrzFormat.A, _lineSeparatorLf,   "0000000000", "0000000", "0100003")]
+   [InlineData(MrzFormat.A, _lineSeparatorLf,   "0000000000", "0000000", "0010001")]
+   [InlineData(MrzFormat.B, _lineSeparatorLf,   "0000000000", "0000000", "0001007")]
+   [InlineData(MrzFormat.B, _lineSeparatorLf,   "0000000000", "0000000", "0000103")]
+   [InlineData(MrzFormat.B, _lineSeparatorLf,   "0000000000", "0000000", "0000011")]
    public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldCorrectlyWeightByCharacterPosition(
       MrzFormat format,
       String lineSeparator,
-      String mrzSecondLine)
+      String documentNumber,
+      String dateOfBirth,
+      String dateOfExpiry)
    {
       // Arrange.
-      var value = GetTestValue(format, lineSeparator, null, mrzSecondLine);
+      var value = GetTestValue(
+         format: format, 
+         lineSeparator: lineSeparator,
+         documentNumber: documentNumber,
+         dateOfBirth: dateOfBirth,
+         dateOfExpiry: dateOfExpiry);
 
       // Act/assert.
       _sut.Validate(value).Should().BeTrue();
    }
 
    [Theory]
-   [InlineData(MrzFormat.A, _emptySeparator)]
-   [InlineData(MrzFormat.A, _crlf)]
-   [InlineData(MrzFormat.A, _lf)]
-   [InlineData(MrzFormat.B, _emptySeparator)]
-   [InlineData(MrzFormat.B, _crlf)]
-   [InlineData(MrzFormat.B, _lf)]
+   [InlineData(MrzFormat.A, _lineSeparatorNone, "D231458907", "7408122", "1204159")]
+   [InlineData(MrzFormat.A, _lineSeparatorCrlf, "L898902C<3", "6908061", "9406236")]
+   [InlineData(MrzFormat.A, _lineSeparatorLf,   "STARWARS45", "7705256", "2405252")]
+   [InlineData(MrzFormat.B, _lineSeparatorNone, "D231458907", "7408122", "1204159")]
+   [InlineData(MrzFormat.B, _lineSeparatorCrlf, "L898902C<3", "6908061", "9406236")]
+   [InlineData(MrzFormat.B, _lineSeparatorLf,   "STARWARS45", "7705256", "2405252")]
    public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnTrue_WhenValueContainsValidCheckDigits(
       MrzFormat format,
-      String lineSeparator)
+      String lineSeparator,
+      String documentNumber,
+      String dateOfBirth,
+      String dateOfExpiry)
    {
       // Arrange.
-      var value = GetTestValue(format, lineSeparator);
+      var value = GetTestValue(
+         format: format, 
+         lineSeparator: lineSeparator,
+         documentNumber: documentNumber,
+         dateOfBirth: dateOfBirth,
+         dateOfExpiry: dateOfExpiry);
 
       // Act/assert.
       _sut.Validate(value).Should().BeTrue();
    }
 
    [Theory]
-   [InlineData(MrzFormat.A, _emptySeparator, "D2314589A7UTO7408122F1204159<<<<<<<<<<<<<<<<")]   // D231458907 with single char transcription error (0 -> A) with delta 10   
-   [InlineData(MrzFormat.B, _crlf, "N231458907UTO7408122F1204159<<<<<<<<")]           // D231458907 with single char transcription error (D -> N) with delta 10
-   [InlineData(MrzFormat.B, _lf,   "L89890C236UTO7408122F1204159<<<<<<<<")]           // L898902C36 with two char transposition error (2C -> C2) with delta 10
-   [InlineData(MrzFormat.B, _emptySeparator, "0000000000UTO8812728F0000000<<<<<<<<")]           // 8812278 with two char transposition error (27 -> 72) with delta 5
-   [InlineData(MrzFormat.A, _crlf, "0000000000UTO0000000F8812728<<<<<<<<<<<<<<<<")]   // 8812278 with two char transposition error (27 -> 72) with delta 5
+   [InlineData(MrzFormat.A, _lineSeparatorNone, "D2314589A7", "7408122", "1204159")]   // Document number D231458907 with single char transcription error (0 -> A) with delta 10   
+   [InlineData(MrzFormat.A, _lineSeparatorCrlf, "N231458907", "7408122", "1204159")]   // Document number D231458907 with single char transcription error (D -> N) with delta 10
+   [InlineData(MrzFormat.A, _lineSeparatorLf,   "L89890C236", "7408122", "1204159")]   // Document number L898902C36 with two char transposition error (2C -> C2) with delta 10
+   [InlineData(MrzFormat.A, _lineSeparatorNone, "0000000000", "8812728", "0000000")]   // Date of birth 8812278 with two char transposition error (27 -> 72) with delta 5
+   [InlineData(MrzFormat.A, _lineSeparatorCrlf, "0000000000", "0000000", "8812728")]   // Date of expiry 8812278 with two char transposition error (27 -> 72) with delta 5
+   [InlineData(MrzFormat.B, _lineSeparatorNone, "D2314589A7", "7408122", "1204159")]   // Document number D231458907 with single char transcription error (0 -> A) with delta 10   
+   [InlineData(MrzFormat.B, _lineSeparatorCrlf, "N231458907", "7408122", "1204159")]   // Document number D231458907 with single char transcription error (D -> N) with delta 10
+   [InlineData(MrzFormat.B, _lineSeparatorLf,   "L89890C236", "7408122", "1204159")]   // Document number L898902C36 with two char transposition error (2C -> C2) with delta 10
+   [InlineData(MrzFormat.B, _lineSeparatorNone, "0000000000", "8812728", "0000000")]   // Date of birth 8812278 with two char transposition error (27 -> 72) with delta 5
+   [InlineData(MrzFormat.B, _lineSeparatorCrlf, "0000000000", "0000000", "8812728")]   // Date of expiry 8812278 with two char transposition error (27 -> 72) with delta 5
    public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnTrue_WhenValueContainsUndetectableError(
       MrzFormat format,
       String lineSeparator,
-      String mrzSecondLine)
+      String documentNumber,
+      String dateOfBirth,
+      String dateOfExpiry)
    {
       // Arrange.
-      var value = GetTestValue(format, lineSeparator, null, mrzSecondLine);
+      var value = GetTestValue(
+         format: format, 
+         lineSeparator: lineSeparator,
+         documentNumber: documentNumber,
+         dateOfBirth: dateOfBirth,
+         dateOfExpiry: dateOfExpiry);
 
       // Act/assert.
       _sut.Validate(value).Should().BeTrue();
    }
 
    [Theory]
-   [InlineData(MrzFormat.A, _emptySeparator, "E231458907UTO7408122F1204159<<<<<<<<<<<<<<<<")]   // D231458907 with single character transcription error (D -> E)
-   [InlineData(MrzFormat.A, _crlf, "D241458907UTO7408122F1204159<<<<<<<<<<<<<<<<")]   // D231458907 with single digit transcription error (3 -> 4)
-   [InlineData(MrzFormat.A, _lf,   "D231458907UTO7409122F1204159<<<<<<<<<<<<<<<<")]   // 7408122 with single digit transcription error (8 -> 9)
-   [InlineData(MrzFormat.A, _emptySeparator, "D231458907UTO7408122F1203159<<<<<<<<<<<<<<<<")]   // 1204159 with single digit transcription error (4 -> 3)
-   [InlineData(MrzFormat.B, _crlf, "2D31458907UTO7408122F1204159<<<<<<<<")]           // D231458907 with two character transposition error (D2 -> 2D)
-   [InlineData(MrzFormat.B, _lf,   "D231548907UTO7408122F1204159<<<<<<<<")]           // D231458907 with two digit transposition error (45 -> 54)
-   [InlineData(MrzFormat.B, _emptySeparator, "D231458907UTO7408212F1204159<<<<<<<<")]           // 7408122 with two digit transposition error (12 -> 21)
-   [InlineData(MrzFormat.B, _crlf, "D231458907UTO7409122F1201459<<<<<<<<")]           // 1204159 with two digit transposition error (41 -> 14)
+   [InlineData(MrzFormat.A, _lineSeparatorNone, "E231458907", "7408122", "1204159")]   // Document number D231458907 with single character transcription error (D -> E)
+   [InlineData(MrzFormat.A, _lineSeparatorCrlf, "D241458907", "7408122", "1204159")]   // Document number D231458907 with single digit transcription error (3 -> 4)
+   [InlineData(MrzFormat.A, _lineSeparatorLf,   "D231458907", "7409122", "1204159")]   // Date of birth 7408122 with single digit transcription error (8 -> 9)
+   [InlineData(MrzFormat.A, _lineSeparatorNone, "D231458907", "7408122", "1203159")]   // Date of expiry 1204159 with single digit transcription error (4 -> 3)
+   [InlineData(MrzFormat.B, _lineSeparatorCrlf, "2D31458907", "7408122", "1204159")]   // Document number D231458907 with two character transposition error (D2 -> 2D)
+   [InlineData(MrzFormat.B, _lineSeparatorLf,   "D231548907", "7408122", "1204159")]   // Document number D231458907 with two digit transposition error (45 -> 54)
+   [InlineData(MrzFormat.B, _lineSeparatorNone, "D231458907", "7408212", "1204159")]   // Date of birth 7408122 with two digit transposition error (12 -> 21)
+   [InlineData(MrzFormat.B, _lineSeparatorCrlf, "D231458907", "7409122", "1201459")]   // Date of expiry 1204159 with two digit transposition error (41 -> 14)
    public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnFalse_WhenValueContainsDetectableError(
       MrzFormat format,
       String lineSeparator,
-      String mrzSecondLine)
+      String documentNumber,
+      String dateOfBirth,
+      String dateOfExpiry)
    {
       // Arrange.
-      var value = GetTestValue(format, lineSeparator, null, mrzSecondLine);
+      var value = GetTestValue(
+         format: format, 
+         lineSeparator: lineSeparator,
+         documentNumber: documentNumber,
+         dateOfBirth: dateOfBirth,
+         dateOfExpiry: dateOfExpiry);
 
       // Act/assert.
       _sut.Validate(value).Should().BeFalse();
@@ -339,85 +426,121 @@ public class Icao9303MachineReadableVisaAlgorithmTests
    {
       // Arrange.
       var value = GetTestValue(
-         MrzFormat.A,
-         _emptySeparator,
-         null,
-         "D23145890!UTO740812@F120415#<<<<<<<<<<<<<<<<");
+         MrzFormat.B,
+         documentNumber: "D23145890!",
+         dateOfBirth: "740812@",
+         dateOfExpiry: "120415#");
 
       // Act/assert.
       _sut.Validate(value).Should().BeFalse();
    }
 
    [Theory]
-   [InlineData(MrzFormat.A, _emptySeparator, "0000000000UTO0000000F0000000<<<<<<<<<<<<<<<<")]
-   [InlineData(MrzFormat.B, _crlf, "0000000000UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.A, _lineSeparatorNone, "0000000000", "0000000", "0000000")]
+   [InlineData(MrzFormat.B, _lineSeparatorCrlf, "0000000000", "0000000", "0000000")]
    public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnTrue_WhenFieldsAreAllZeros(
       MrzFormat format,
       String lineSeparator,
-      String mrzSecondLine)
+      String documentNumber,
+      String dateOfBirth,
+      String dateOfExpiry)
    {
       // Arrange.
-      var value = GetTestValue(format, lineSeparator, null, mrzSecondLine);
+      var value = GetTestValue(
+         format: format, 
+         lineSeparator: lineSeparator,
+         documentNumber: documentNumber,
+         dateOfBirth: dateOfBirth,
+         dateOfExpiry: dateOfExpiry);
 
       // Act/assert.
       _sut.Validate(value).Should().BeTrue();
    }
 
    [Theory]
-   [InlineData(MrzFormat.A, _emptySeparator, "<<<<<<<<<0UTO<<<<<<0F<<<<<<0<<<<<<<<<<<<<<<<")]
-   [InlineData(MrzFormat.B, _crlf, "<<<<<<<<<0UTO<<<<<<0F<<<<<<0<<<<<<<<")]
+   [InlineData(MrzFormat.A, _lineSeparatorLf,   "<<<<<<<<<0", "<<<<<<0", "<<<<<<0")]
+   [InlineData(MrzFormat.B, _lineSeparatorNone, "<<<<<<<<<0", "<<<<<<0", "<<<<<<0")]
    public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnTrue_WhenFieldsAreAllFillerCharacters(
       MrzFormat format,
       String lineSeparator,
-      String mrzSecondLine)
+      String documentNumber,
+      String dateOfBirth,
+      String dateOfExpiry)
    {
       // Arrange.
-      var value = GetTestValue(format, lineSeparator, null, mrzSecondLine);
+      var value = GetTestValue(
+         format: format, 
+         lineSeparator: lineSeparator,
+         documentNumber: documentNumber,
+         dateOfBirth: dateOfBirth,
+         dateOfExpiry: dateOfExpiry);
 
       // Act/assert.
       _sut.Validate(value).Should().BeTrue();
    }
 
    [Theory]
-   [InlineData(MrzFormat.A, _emptySeparator, "b231458907UTO7408122F1204159<<<<<<<<<<<<<<<<")]   // D231458907 with D replaced with character 30 positions later in ASCII table
-   [InlineData(MrzFormat.A, _crlf, "D2314589&7UTO7408122F1204159<<<<<<<<<<<<<<<<")]   // D231458907 with 0 replaced with character 10 positions before in ASCII table
-   [InlineData(MrzFormat.B, _lf,   "D2314589:7UTO7408122F1204159<<<<<<<<")]           // D231458907 with 0 replaced with character 10 positions later in ASCII table
-   [InlineData(MrzFormat.B, _emptySeparator, "D231458907UTO7>08122F1204159<<<<<<<<")]           // 7408122 with 4 replaced with character 10 positions later in ASCII table
+   [InlineData(MrzFormat.A, _lineSeparatorNone, "b231458907", "7408122", "1204159")]   // Document number D231458907 with D replaced with character 30 positions later in ASCII table
+   [InlineData(MrzFormat.A, _lineSeparatorCrlf, "D2314589&7", "7408122", "1204159")]   // Document number D231458907 with 0 replaced with character 10 positions before in ASCII table
+   [InlineData(MrzFormat.B, _lineSeparatorLf,   "D2314589:7", "7408122", "1204159")]   // Document number D231458907 with 0 replaced with character 10 positions later in ASCII table
+   [InlineData(MrzFormat.B, _lineSeparatorNone, "D231458907", "7>08122", "1204159")]   // Date of birth 7408122 with 4 replaced with character 10 positions later in ASCII table
+   [InlineData(MrzFormat.B, _lineSeparatorNone, "D231458907", "7408122", "120>159")]   // Date of expiry 1204159 with 4 replaced with character 10 positions later in ASCII table
    public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnFalse_WhenFieldContainsInvalidCharacter(
       MrzFormat format,
       String lineSeparator,
-      String mrzSecondLine)
+      String documentNumber,
+      String dateOfBirth,
+      String dateOfExpiry)
    {
       // Arrange.
-      var value = GetTestValue(format, lineSeparator, null, mrzSecondLine);
+      var value = GetTestValue(
+         format: format, 
+         lineSeparator: lineSeparator,
+         documentNumber: documentNumber,
+         dateOfBirth: dateOfBirth,
+         dateOfExpiry: dateOfExpiry);
 
       // Act/assert.
       _sut.Validate(value).Should().BeFalse();
    }
 
    [Theory]
-   [InlineData(MrzFormat.A, _emptySeparator, "D23145890AUTO7408122F1204159<<<<<<<<<<<<<<<<")]   // Document number check digit is invalid character
-   [InlineData(MrzFormat.A, _emptySeparator, "D23145890&UTO7408122F1204159<<<<<<<<<<<<<<<<")]   // Document number check digit is invalid character
-   [InlineData(MrzFormat.A, _emptySeparator, "D23145890:UTO7408122F1204159<<<<<<<<<<<<<<<<")]   // Document number check digit is invalid character
-   [InlineData(MrzFormat.A, _crlf, "D231458907UTO740812AF1204159<<<<<<<<<<<<<<<<")]   // Date of birth check digit is invalid character
-   [InlineData(MrzFormat.A, _crlf, "D231458907UTO740812&F1204159<<<<<<<<<<<<<<<<")]   // Date of birth check digit is invalid character
-   [InlineData(MrzFormat.A, _crlf, "D231458907UTO740812<F1204159<<<<<<<<<<<<<<<<")]   // Date of birth check digit is invalid character
-   [InlineData(MrzFormat.A, _crlf, "D231458907UTO740812[F1204159<<<<<<<<<<<<<<<<")]   // Date of birth check digit is invalid character
-   [InlineData(MrzFormat.B, _lf,   "D231458907UTO7408122F120415A<<<<<<<<")]           // Date of expiry check digit is invalid character
-   [InlineData(MrzFormat.B, _lf,   "D231458907UTO7408122F120415&<<<<<<<<")]           // Date of expiry check digit is invalid character
-   [InlineData(MrzFormat.B, _lf,   "D231458907UTO7408122F120415<<<<<<<<<")]           // Date of expiry check digit is invalid character
-   [InlineData(MrzFormat.B, _lf,   "D231458907UTO7408122F120415[<<<<<<<<")]           // Date of expiry check digit is invalid character
+   [InlineData(MrzFormat.A, _lineSeparatorNone, "D23145890A", "7408122", "1204159")]   // Document number check digit is invalid character
+   [InlineData(MrzFormat.A, _lineSeparatorCrlf, "D23145890&", "7408122", "1204159")]   // Document number check digit is invalid character
+   [InlineData(MrzFormat.A, _lineSeparatorLf,   "D23145890:", "7408122", "1204159")]   // Document number check digit is invalid character
+   [InlineData(MrzFormat.A, _lineSeparatorNone, "D231458907", "740812A", "1204159")]   // Date of birth check digit is invalid character
+   [InlineData(MrzFormat.A, _lineSeparatorCrlf, "D231458907", "740812&", "1204159")]   // Date of birth check digit is invalid character
+   [InlineData(MrzFormat.A, _lineSeparatorLf,   "D231458907", "740812<", "1204159")]   // Date of birth check digit is invalid character
+   [InlineData(MrzFormat.A, _lineSeparatorNone, "D231458907", "740812[", "1204159")]   // Date of birth check digit is invalid character
+   [InlineData(MrzFormat.B, _lineSeparatorCrlf, "D231458907", "7408122", "120415A")]   // Date of expiry check digit is invalid character
+   [InlineData(MrzFormat.B, _lineSeparatorLf,   "D231458907", "7408122", "120415&")]   // Date of expiry check digit is invalid character
+   [InlineData(MrzFormat.B, _lineSeparatorNone, "D231458907", "7408122", "120415<")]   // Date of expiry check digit is invalid character
+   [InlineData(MrzFormat.B, _lineSeparatorCrlf, "D231458907", "7408122", "120415[")]   // Date of expiry check digit is invalid character
    public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnFalse_WhenRequiredFieldCheckDigitContainsNonDigitCharacter(
       MrzFormat format,
       String lineSeparator,
-      String mrzSecondLine)
+      String documentNumber,
+      String dateOfBirth,
+      String dateOfExpiry)
    {
       // Arrange.
-      var value = GetTestValue(format, lineSeparator, null, mrzSecondLine);
+      var value = GetTestValue(
+         format: format, 
+         lineSeparator: lineSeparator,
+         documentNumber: documentNumber,
+         dateOfBirth: dateOfBirth,
+         dateOfExpiry: dateOfExpiry);
 
       // Act/assert.
       _sut.Validate(value).Should().BeFalse();
    }
+
+   [Theory]
+   [InlineData("I<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<D231458907UTO7408122F1204159<<<<<<A<")]
+   [InlineData("V<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<\r\nL898902C<3UTO6908061F9406236ZE184226B<<<<<<<")]
+   [InlineData("I<UTOSKYWALKER<<LUKE<<<<<<<<<<<<<<<<\nSTARWARS45UTO7705256M2405252<<<<<<B<")]
+   public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnTrue_ForBenchmarkValues(String value)
+      => _sut.Validate(value).Should().BeTrue();
 
    #endregion
 }

--- a/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303MachineReadableVisaAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303MachineReadableVisaAlgorithmTests.cs
@@ -106,7 +106,7 @@ public class Icao9303MachineReadableVisaAlgorithmTests
    [InlineData("ERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<<", _lineSeparatorNone, _fmtAOptionalDataField)]    // Name -1 char and default line separator = total length 91
    [InlineData("ERIKSSON<<ANNA<MARIA<<<<<<<<<<", _lineSeparatorNone, _fmtBOptionalDataField)]              // Name -1 char and default line separator = total length 71
    [InlineData("ERIKSSON<<ANNA<MARIA<<<<<<<<<<<<", _lineSeparatorNone, _fmtBOptionalDataField)]            // Name -1 char and default line separator = total length 95
-   public void Icao93033MachineReadableVisaAlgorithm_Validate_ShouldReturnFalse_WhenValueIsInvalidLength(
+   public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnFalse_WhenValueIsInvalidLength(
       String name,
       String lineSeparator,
       String optionalData)
@@ -279,7 +279,7 @@ public class Icao9303MachineReadableVisaAlgorithmTests
    [InlineData("00a0000", "0000000")]
    [InlineData("0000000", "00A0000")]
    [InlineData("0000000", "00a0000")]
-   public void Icao93033MachineReadableVisaAlgorithm_Validate_ShouldReturnFalse_NumericFieldContainsAlphabeticCharacter(
+   public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnFalse_NumericFieldContainsAlphabeticCharacter(
       String dateOfBirth,
       String dateOfExpiry)
    {

--- a/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303MachineReadableVisaAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303MachineReadableVisaAlgorithmTests.cs
@@ -119,10 +119,10 @@ public class Icao9303MachineReadableVisaAlgorithmTests
    /// </summary>
    public static TheoryData<MrzFormat, String, String, String> UndetectableSeparatorIssuesData => new()
    {
-      { MrzFormat.A, _crlf,           _fmtAMrzFirstLine[..44], _fmtAMrzSecondLine },      // Length indicates Lf only and Lf falls in correct position
-      { MrzFormat.A, _lf,             _fmtAMrzFirstLine[..44], _fmtAMrzSecondLine },      // Length indicates no separator so separator chars not checked
-      { MrzFormat.A, _crlf,           _fmtBMrzFirstLine[..35], _fmtBMrzSecondLine },      // Length indicates Lf only and Lf falls in correct position
-      { MrzFormat.B, _lf,             _fmtBMrzFirstLine[..35], _fmtBMrzSecondLine },      // Length indicates no separator so separator chars not checked
+      { MrzFormat.A, _crlf, _fmtAMrzFirstLine[..44], _fmtAMrzSecondLine },      // Length indicates Lf only and Lf falls in correct position
+      { MrzFormat.A, _lf,   _fmtAMrzFirstLine[..44], _fmtAMrzSecondLine },      // Length indicates no separator so separator chars not checked
+      { MrzFormat.A, _crlf, _fmtBMrzFirstLine[..35], _fmtBMrzSecondLine },      // Length indicates Lf only and Lf falls in correct position
+      { MrzFormat.B, _lf,   _fmtBMrzFirstLine[..35], _fmtBMrzSecondLine },      // Length indicates no separator so separator chars not checked
    };
 
    [Theory]
@@ -199,6 +199,45 @@ public class Icao9303MachineReadableVisaAlgorithmTests
 
       // Act/assert.
       _sut.Validate(value).Should().BeTrue();
+   }
+
+   [Theory]
+   [InlineData(MrzFormat.B, _crlf, "00a0000000UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, _crlf, "00b0000001UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, _crlf, "00c0000002UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, _crlf, "00d0000003UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, _crlf, "00e0000004UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, _crlf, "00f0000005UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, _crlf, "00g0000006UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, _crlf, "00h0000007UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, _crlf, "00i0000008UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, _crlf, "00j0000009UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, _lf, "00k0000000UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, _lf, "00l0000001UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, _lf, "00m0000002UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, _lf, "00n0000003UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, _lf, "00o0000004UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, _lf, "00p0000005UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, _lf, "00q0000006UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, _lf, "00r0000007UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, _lf, "00s0000008UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.B, _lf, "00t0000009UTO0000000F0000000<<<<<<<<")]
+   [InlineData(MrzFormat.A, _emptySeparator, "00u0000000UTO0000000F0000000<<<<<<<<<<<<<<<<")]
+   [InlineData(MrzFormat.A, _emptySeparator, "00v0000001UTO0000000F0000000<<<<<<<<<<<<<<<<")]
+   [InlineData(MrzFormat.A, _emptySeparator, "00w0000002UTO0000000F0000000<<<<<<<<<<<<<<<<")]
+   [InlineData(MrzFormat.A, _emptySeparator, "00x0000003UTO0000000F0000000<<<<<<<<<<<<<<<<")]
+   [InlineData(MrzFormat.A, _emptySeparator, "00y0000004UTO0000000F0000000<<<<<<<<<<<<<<<<")]
+   [InlineData(MrzFormat.A, _emptySeparator, "00z0000005UTO0000000F0000000<<<<<<<<<<<<<<<<")]
+   public void Icao9303MachineReadableVisaAlgorithm_Validate_ShouldReturnFalse_WhenLowerCaseAlphabeticCharacterEncountered(
+      MrzFormat format,
+      String lineSeparator,
+      String mrzSecondLine)
+   {
+      // Arrange.
+      var value = GetTestValue(format, lineSeparator, null, mrzSecondLine);
+
+      // Act/assert.
+      _sut.Validate(value).Should().BeFalse();
    }
 
    [Theory]

--- a/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303SizeTD1AlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303SizeTD1AlgorithmTests.cs
@@ -10,10 +10,13 @@ public class Icao9303SizeTD1AlgorithmTests
    private const String _mrzFirstLine = "I<UTOD231458907<<<<<<<<<<<<<<<";
    private const String _mrzSecondLine = "7408122F1204159UTO<<<<<<<<<<<6";
    private const String _mrzThirdLine = "ERIKSSON<<ANNA<MARIA<<<<<<<<<<";
+   private const String _emptySeparator = "";
+   private const String _crlf = "\r\n";
+   private const String _lf = "\n";
 
    private static String GetTestValue(
-      LineSeparator lineSeparator = LineSeparator.None,
-#if !NET48
+      String separatorChars = _emptySeparator,
+      #if !NET48
       String? firstLine = null,
       String? secondLine = null,
       String? thirdLine = null)
@@ -22,18 +25,9 @@ public class Icao9303SizeTD1AlgorithmTests
       String secondLine = null,
       String thirdLine = null)
 #endif
-   {
-      var separatorChars = lineSeparator switch
-      {
-         LineSeparator.Crlf => "\r\n",
-         LineSeparator.Lf => "\n",
-         _ => String.Empty,
-      };
-
-      return (firstLine ?? _mrzFirstLine) 
+      => (firstLine ?? _mrzFirstLine) 
          + separatorChars + (secondLine ?? _mrzSecondLine)
          + separatorChars + (thirdLine ?? _mrzThirdLine);
-   }
 
    #region AlgorithmDescription Property Tests
    // ==========================================================================
@@ -55,63 +49,6 @@ public class Icao9303SizeTD1AlgorithmTests
 
    #endregion
 
-   #region LineSeparator Property Tests
-   // ==========================================================================
-   // ==========================================================================
-
-   public static TheoryData<LineSeparator> LineSeparatorValues
-   {
-      get
-      {
-         var data = new TheoryData<LineSeparator>();
-         foreach (var value in Enum.GetValues(typeof(LineSeparator)))
-         {
-            data.Add((LineSeparator)value);
-         }
-
-         return data;
-      }
-   }
-
-   [Theory]
-   [MemberData(nameof(LineSeparatorValues))]
-   public void Icao9302SizeTD1Algorithm_LineSeparator_ShouldNotThrow_ValueIsValid(LineSeparator lineSeparator)
-   {
-      // Arrange.
-      var act = () => _sut.LineSeparator = lineSeparator;
-
-      // Act/assert.
-      act.Should().NotThrow();
-   }
-
-   [Theory]
-   [MemberData(nameof(LineSeparatorValues))]
-   public void Icao9303SizeTD1Algorithm_LineSeparator_ShouldReturnExpectedValueAfterSetting(LineSeparator lineSeparator)
-   {
-      // Arrange.
-      var sut = new Icao9303SizeTD1Algorithm() { LineSeparator = lineSeparator };
-
-      // Act/assert.
-      sut.LineSeparator.Should().Be(lineSeparator);
-   }
-
-   [Fact]
-   public void Icao9302SizeTD1Algorithm_LineSeparator_ShouldThrowArgumentOutOfRangeException_ValueIsInvalid()
-   {
-      // Arrange.
-      var value = (LineSeparator)(-1);
-      var act = () => _sut.LineSeparator = value;
-      var expectedMessage = Resources.LineSeparatorInvalidValueMessage;
-
-      // Act/assert.
-      act.Should().ThrowExactly<ArgumentOutOfRangeException>()
-         .WithParameterName(nameof(value))
-         .WithMessage(expectedMessage + "*")
-         .And.ActualValue.Should().Be(value);
-   }
-
-   #endregion
-
    #region Validate Tests
    // ==========================================================================
    // ==========================================================================
@@ -124,267 +61,292 @@ public class Icao9303SizeTD1AlgorithmTests
    public void Icao9303SizeTD1Algorithm_Validate_ShouldReturnFalse_WhenInputIsEmpty()
       => _sut.Validate(String.Empty).Should().BeFalse();
 
-   public static TheoryData<LineSeparator, String> InvalidLengthData => new()
+   public static TheoryData<String> InvalidLengthData => new()
    {
-      { LineSeparator.None, GetTestValue(LineSeparator.None, _mrzFirstLine[..29]) },
-      { LineSeparator.Crlf, GetTestValue(LineSeparator.Crlf, _mrzFirstLine[..29]) },
-      { LineSeparator.Lf,   GetTestValue(LineSeparator.Lf,   _mrzFirstLine[..29]) },
-      { LineSeparator.None, GetTestValue(LineSeparator.None, _mrzFirstLine + "<<") },
-      { LineSeparator.Crlf, GetTestValue(LineSeparator.Crlf, _mrzFirstLine + "<<") },
-      { LineSeparator.Lf,   GetTestValue(LineSeparator.Lf,   _mrzFirstLine + "<<") },
+      { GetTestValue(_emptySeparator, _mrzFirstLine[..29]) },
+      { GetTestValue(_crlf, _mrzFirstLine[..29]) },
+      { GetTestValue(_lf,   _mrzFirstLine[..29]) },
+      { GetTestValue(_emptySeparator, _mrzFirstLine + "<<") },
+      { GetTestValue(_crlf, _mrzFirstLine + "<<") },
+      { GetTestValue(_lf,   _mrzFirstLine + "<<") },
+
    };
 
    [Theory]
    [MemberData(nameof(InvalidLengthData))]
-   public void Icao9303SizeTD1Algorithm_Validate_ShouldReturnFalse_WhenValueIsInvalidLength(
-      LineSeparator lineSeparator,
-      String value)
-   {
-      // Arrange.
-      var sut = new Icao9303SizeTD1Algorithm()
-      {
-         LineSeparator = lineSeparator,
-      };
-
-      // Act/assert.
-      sut.Validate(value).Should().BeFalse();
-   }
+   public void Icao9303SizeTD1Algorithm_Validate_ShouldReturnFalse_WhenValueIsInvalidLength(String value)
+      => _sut.Validate(value).Should().BeFalse();
 
    [Theory]
-   [InlineData(LineSeparator.None, "I<UTO0000000000<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
-   [InlineData(LineSeparator.None, "I<UTO0010000001<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<8")]
-   [InlineData(LineSeparator.None, "I<UTO0020000002<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<6")]
-   [InlineData(LineSeparator.None, "I<UTO0030000003<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<4")]
-   [InlineData(LineSeparator.None, "I<UTO0040000004<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<2")]
-   [InlineData(LineSeparator.None, "I<UTO0050000005<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
-   [InlineData(LineSeparator.None, "I<UTO0060000006<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<8")]
-   [InlineData(LineSeparator.None, "I<UTO0070000007<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<6")]
-   [InlineData(LineSeparator.None, "I<UTO0080000008<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<4")]
-   [InlineData(LineSeparator.None, "I<UTO0090000009<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<2")]
-   [InlineData(LineSeparator.Crlf, "I<UTO00A0000000<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
-   [InlineData(LineSeparator.Crlf, "I<UTO00B0000001<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<8")]
-   [InlineData(LineSeparator.Crlf, "I<UTO00C0000002<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<6")]
-   [InlineData(LineSeparator.Crlf, "I<UTO00D0000003<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<4")]
-   [InlineData(LineSeparator.Crlf, "I<UTO00E0000004<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<2")]
-   [InlineData(LineSeparator.Crlf, "I<UTO00F0000005<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
-   [InlineData(LineSeparator.Crlf, "I<UTO00G0000006<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<8")]
-   [InlineData(LineSeparator.Crlf, "I<UTO00H0000007<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<6")]
-   [InlineData(LineSeparator.Crlf, "I<UTO00I0000008<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<4")]
-   [InlineData(LineSeparator.Crlf, "I<UTO00J0000009<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<2")]
-   [InlineData(LineSeparator.Lf,   "I<UTO00K0000000<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
-   [InlineData(LineSeparator.Lf,   "I<UTO00L0000001<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<8")]
-   [InlineData(LineSeparator.Lf,   "I<UTO00M0000002<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<6")]
-   [InlineData(LineSeparator.Lf,   "I<UTO00N0000003<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<4")]
-   [InlineData(LineSeparator.Lf,   "I<UTO00O0000004<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<2")]
-   [InlineData(LineSeparator.Lf,   "I<UTO00P0000005<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
-   [InlineData(LineSeparator.Lf,   "I<UTO00Q0000006<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<8")]
-   [InlineData(LineSeparator.Lf,   "I<UTO00R0000007<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<6")]
-   [InlineData(LineSeparator.Lf,   "I<UTO00S0000008<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<4")]
-   [InlineData(LineSeparator.Lf,   "I<UTO00T0000009<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<2")]
-   [InlineData(LineSeparator.None, "I<UTO00U0000000<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
-   [InlineData(LineSeparator.None, "I<UTO00V0000001<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<8")]
-   [InlineData(LineSeparator.None, "I<UTO00W0000002<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<6")]
-   [InlineData(LineSeparator.None, "I<UTO00X0000003<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<4")]
-   [InlineData(LineSeparator.None, "I<UTO00Y0000004<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<2")]
-   [InlineData(LineSeparator.None, "I<UTO00Z0000005<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
-   [InlineData(LineSeparator.None, "I<UTO00<0000000<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
+   [InlineData(_mrzFirstLine + "X\n" + _mrzSecondLine + _crlf + _mrzThirdLine)]        // 'X' instead of \r
+   [InlineData(_mrzFirstLine + _crlf + _mrzSecondLine + "X\n" + _mrzThirdLine)]        // 'X' instead of \r
+   [InlineData(_mrzFirstLine + " \n" + _mrzSecondLine + _crlf + _mrzThirdLine)]        // Space instead of \r
+   [InlineData(_mrzFirstLine + _crlf + _mrzSecondLine + " \n" + _mrzThirdLine)]        // Space instead of \r
+   [InlineData(_mrzFirstLine + "\r " + _mrzSecondLine + _crlf + _mrzThirdLine)]        // Space instead of \n
+   [InlineData(_mrzFirstLine + _crlf + _mrzSecondLine + "\r " + _mrzThirdLine)]        // Space instead of \n
+   [InlineData(_mrzFirstLine + "\n\r" + _mrzSecondLine + _crlf + _mrzThirdLine)]       // \n\r instead of \r\n
+   [InlineData(_mrzFirstLine + _crlf + _mrzSecondLine + "\n\r" + _mrzThirdLine)]       // \n\r instead of \r\n
+   [InlineData(_mrzFirstLine + " " + _mrzSecondLine + _lf + _mrzThirdLine)]            // Space instead of \n
+   [InlineData(_mrzFirstLine + _lf + _mrzSecondLine + " " + _mrzThirdLine)]            // Space instead of \n
+   public void Icao9303SizeTD1Algorithm_Validate_ShouldReturnFalse_WhenSeparatorCharactersAreInvalid(String value)
+      => _sut.Validate(value).Should().BeFalse();
+
+   [Theory]
+   [InlineData(_emptySeparator, "I<UTO0000000000<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
+   [InlineData(_emptySeparator, "I<UTO0010000001<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<8")]
+   [InlineData(_emptySeparator, "I<UTO0020000002<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<6")]
+   [InlineData(_emptySeparator, "I<UTO0030000003<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<4")]
+   [InlineData(_emptySeparator, "I<UTO0040000004<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<2")]
+   [InlineData(_emptySeparator, "I<UTO0050000005<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
+   [InlineData(_emptySeparator, "I<UTO0060000006<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<8")]
+   [InlineData(_emptySeparator, "I<UTO0070000007<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<6")]
+   [InlineData(_emptySeparator, "I<UTO0080000008<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<4")]
+   [InlineData(_emptySeparator, "I<UTO0090000009<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<2")]
+   [InlineData(_crlf, "I<UTO00A0000000<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
+   [InlineData(_crlf, "I<UTO00B0000001<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<8")]
+   [InlineData(_crlf, "I<UTO00C0000002<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<6")]
+   [InlineData(_crlf, "I<UTO00D0000003<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<4")]
+   [InlineData(_crlf, "I<UTO00E0000004<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<2")]
+   [InlineData(_crlf, "I<UTO00F0000005<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
+   [InlineData(_crlf, "I<UTO00G0000006<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<8")]
+   [InlineData(_crlf, "I<UTO00H0000007<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<6")]
+   [InlineData(_crlf, "I<UTO00I0000008<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<4")]
+   [InlineData(_crlf, "I<UTO00J0000009<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<2")]
+   [InlineData(_lf,   "I<UTO00K0000000<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
+   [InlineData(_lf,   "I<UTO00L0000001<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<8")]
+   [InlineData(_lf,   "I<UTO00M0000002<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<6")]
+   [InlineData(_lf,   "I<UTO00N0000003<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<4")]
+   [InlineData(_lf,   "I<UTO00O0000004<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<2")]
+   [InlineData(_lf,   "I<UTO00P0000005<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
+   [InlineData(_lf,   "I<UTO00Q0000006<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<8")]
+   [InlineData(_lf,   "I<UTO00R0000007<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<6")]
+   [InlineData(_lf,   "I<UTO00S0000008<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<4")]
+   [InlineData(_lf,   "I<UTO00T0000009<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<2")]
+   [InlineData(_emptySeparator, "I<UTO00U0000000<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
+   [InlineData(_emptySeparator, "I<UTO00V0000001<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<8")]
+   [InlineData(_emptySeparator, "I<UTO00W0000002<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<6")]
+   [InlineData(_emptySeparator, "I<UTO00X0000003<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<4")]
+   [InlineData(_emptySeparator, "I<UTO00Y0000004<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<2")]
+   [InlineData(_emptySeparator, "I<UTO00Z0000005<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
+   [InlineData(_emptySeparator, "I<UTO00<0000000<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
    public void Icao9303SizeTD1Algorithm_Validate_ShouldCorrectlyMapFieldCharacterValues(
-      LineSeparator lineSeparator,
+      String lineSeparator,
       String mrzFirstLine,
       String mrzSecondLine)
    {
       // Arrange.
-      var sut = new Icao9303SizeTD1Algorithm()
-      {
-         LineSeparator = lineSeparator,
-      };
       var value = GetTestValue(lineSeparator, mrzFirstLine, mrzSecondLine);
 
       // Act/assert.
-      sut.Validate(value).Should().BeTrue();
+      _sut.Validate(value).Should().BeTrue();
+   }
+
+   [Theory]
+   [InlineData(_crlf, "I<UTO00a0000000<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
+   [InlineData(_crlf, "I<UTO00b0000001<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<8")]
+   [InlineData(_crlf, "I<UTO00c0000002<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<6")]
+   [InlineData(_crlf, "I<UTO00d0000003<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<4")]
+   [InlineData(_crlf, "I<UTO00e0000004<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<2")]
+   [InlineData(_crlf, "I<UTO00f0000005<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
+   [InlineData(_crlf, "I<UTO00g0000006<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<8")]
+   [InlineData(_crlf, "I<UTO00h0000007<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<6")]
+   [InlineData(_crlf, "I<UTO00i0000008<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<4")]
+   [InlineData(_crlf, "I<UTO00j0000009<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<2")]
+   [InlineData(_lf, "I<UTO00k0000000<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
+   [InlineData(_lf, "I<UTO00l0000001<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<8")]
+   [InlineData(_lf, "I<UTO00m0000002<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<6")]
+   [InlineData(_lf, "I<UTO00n0000003<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<4")]
+   [InlineData(_lf, "I<UTO00o0000004<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<2")]
+   [InlineData(_lf, "I<UTO00p0000005<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
+   [InlineData(_lf, "I<UTO00q0000006<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<8")]
+   [InlineData(_lf, "I<UTO00r0000007<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<6")]
+   [InlineData(_lf, "I<UTO00s0000008<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<4")]
+   [InlineData(_lf, "I<UTO00t0000009<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<2")]
+   [InlineData(_emptySeparator, "I<UTO00u0000000<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
+   [InlineData(_emptySeparator, "I<UTO00v0000001<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<8")]
+   [InlineData(_emptySeparator, "I<UTO00w0000002<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<6")]
+   [InlineData(_emptySeparator, "I<UTO00x0000003<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<4")]
+   [InlineData(_emptySeparator, "I<UTO00y0000004<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<2")]
+   [InlineData(_emptySeparator, "I<UTO00z0000005<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
+   public void Icao9303SizeTD1Algorithm_Validate_ShouldReturnFalse_WhenLowerCaseAlphabeticCharacterEncountered(
+      String lineSeparator,
+      String mrzFirstLine,
+      String mrzSecondLine)
+   {
+      // Arrange.
+      var value = GetTestValue(lineSeparator, mrzFirstLine, mrzSecondLine);
+
+      // Act/assert.
+      _sut.Validate(value).Should().BeFalse();
    }
 
    [Theory]
    // Document number field
-   [InlineData(LineSeparator.None, "I<UTO1000000007<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<6")]
-   [InlineData(LineSeparator.None, "I<UTO0100000003<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<4")]
-   [InlineData(LineSeparator.None, "I<UTO0010000001<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<8")]
-   [InlineData(LineSeparator.None, "I<UTO0001000007<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<6")]
-   [InlineData(LineSeparator.None, "I<UTO0000100003<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<4")]
-   [InlineData(LineSeparator.None, "I<UTO0000010001<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<8")]
-   [InlineData(LineSeparator.None, "I<UTO0000001007<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<6")]
-   [InlineData(LineSeparator.None, "I<UTO0000000103<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<4")]
-   [InlineData(LineSeparator.None, "I<UTO0000000011<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<8")]
+   [InlineData(_emptySeparator, "I<UTO1000000007<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<6")]
+   [InlineData(_emptySeparator, "I<UTO0100000003<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<4")]
+   [InlineData(_emptySeparator, "I<UTO0010000001<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<8")]
+   [InlineData(_emptySeparator, "I<UTO0001000007<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<6")]
+   [InlineData(_emptySeparator, "I<UTO0000100003<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<4")]
+   [InlineData(_emptySeparator, "I<UTO0000010001<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<8")]
+   [InlineData(_emptySeparator, "I<UTO0000001007<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<6")]
+   [InlineData(_emptySeparator, "I<UTO0000000103<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<4")]
+   [InlineData(_emptySeparator, "I<UTO0000000011<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<8")]
    // Extended document number
-   [InlineData(LineSeparator.None, "I<UTO000000000<10000000000007<", "0000000F0000000UTO<<<<<<<<<<<8")]
-   [InlineData(LineSeparator.None, "I<UTO000000000<01000000000003<", "0000000F0000000UTO<<<<<<<<<<<2")]
-   [InlineData(LineSeparator.None, "I<UTO000000000<00100000000001<", "0000000F0000000UTO<<<<<<<<<<<4")]
-   [InlineData(LineSeparator.None, "I<UTO000000000<00010000000007<", "0000000F0000000UTO<<<<<<<<<<<8")]
-   [InlineData(LineSeparator.None, "I<UTO000000000<00001000000003<", "0000000F0000000UTO<<<<<<<<<<<2")]
-   [InlineData(LineSeparator.None, "I<UTO000000000<00000100000001<", "0000000F0000000UTO<<<<<<<<<<<4")]
-   [InlineData(LineSeparator.None, "I<UTO000000000<00000010000007<", "0000000F0000000UTO<<<<<<<<<<<8")]
-   [InlineData(LineSeparator.None, "I<UTO000000000<00000001000003<", "0000000F0000000UTO<<<<<<<<<<<2")]
-   [InlineData(LineSeparator.None, "I<UTO000000000<00000000100001<", "0000000F0000000UTO<<<<<<<<<<<4")]
-   [InlineData(LineSeparator.None, "I<UTO000000000<00000000010007<", "0000000F0000000UTO<<<<<<<<<<<8")]
-   [InlineData(LineSeparator.None, "I<UTO000000000<00000000001003<", "0000000F0000000UTO<<<<<<<<<<<2")]
-   [InlineData(LineSeparator.None, "I<UTO000000000<00000000000101<", "0000000F0000000UTO<<<<<<<<<<<4")]
-   [InlineData(LineSeparator.None, "I<UTO000000000<00000000000017<", "0000000F0000000UTO<<<<<<<<<<<8")]
+   [InlineData(_emptySeparator, "I<UTO000000000<10000000000007<", "0000000F0000000UTO<<<<<<<<<<<8")]
+   [InlineData(_emptySeparator, "I<UTO000000000<01000000000003<", "0000000F0000000UTO<<<<<<<<<<<2")]
+   [InlineData(_emptySeparator, "I<UTO000000000<00100000000001<", "0000000F0000000UTO<<<<<<<<<<<4")]
+   [InlineData(_emptySeparator, "I<UTO000000000<00010000000007<", "0000000F0000000UTO<<<<<<<<<<<8")]
+   [InlineData(_emptySeparator, "I<UTO000000000<00001000000003<", "0000000F0000000UTO<<<<<<<<<<<2")]
+   [InlineData(_emptySeparator, "I<UTO000000000<00000100000001<", "0000000F0000000UTO<<<<<<<<<<<4")]
+   [InlineData(_emptySeparator, "I<UTO000000000<00000010000007<", "0000000F0000000UTO<<<<<<<<<<<8")]
+   [InlineData(_emptySeparator, "I<UTO000000000<00000001000003<", "0000000F0000000UTO<<<<<<<<<<<2")]
+   [InlineData(_emptySeparator, "I<UTO000000000<00000000100001<", "0000000F0000000UTO<<<<<<<<<<<4")]
+   [InlineData(_emptySeparator, "I<UTO000000000<00000000010007<", "0000000F0000000UTO<<<<<<<<<<<8")]
+   [InlineData(_emptySeparator, "I<UTO000000000<00000000001003<", "0000000F0000000UTO<<<<<<<<<<<2")]
+   [InlineData(_emptySeparator, "I<UTO000000000<00000000000101<", "0000000F0000000UTO<<<<<<<<<<<4")]
+   [InlineData(_emptySeparator, "I<UTO000000000<00000000000017<", "0000000F0000000UTO<<<<<<<<<<<8")]
    // Date of birth field
-   [InlineData(LineSeparator.Crlf, "I<UTO0000000000<<<<<<<<<<<<<<<", "1000007F0000000UTO<<<<<<<<<<<4")]
-   [InlineData(LineSeparator.Crlf, "I<UTO0000000000<<<<<<<<<<<<<<<", "0100003F0000000UTO<<<<<<<<<<<0")]
-   [InlineData(LineSeparator.Crlf, "I<UTO0000000000<<<<<<<<<<<<<<<", "0010001F0000000UTO<<<<<<<<<<<0")]
-   [InlineData(LineSeparator.Crlf, "I<UTO0000000000<<<<<<<<<<<<<<<", "0001007F0000000UTO<<<<<<<<<<<4")]
-   [InlineData(LineSeparator.Crlf, "I<UTO0000000000<<<<<<<<<<<<<<<", "0000103F0000000UTO<<<<<<<<<<<0")]
-   [InlineData(LineSeparator.Crlf, "I<UTO0000000000<<<<<<<<<<<<<<<", "0000011F0000000UTO<<<<<<<<<<<0")]
+   [InlineData(_crlf, "I<UTO0000000000<<<<<<<<<<<<<<<", "1000007F0000000UTO<<<<<<<<<<<4")]
+   [InlineData(_crlf, "I<UTO0000000000<<<<<<<<<<<<<<<", "0100003F0000000UTO<<<<<<<<<<<0")]
+   [InlineData(_crlf, "I<UTO0000000000<<<<<<<<<<<<<<<", "0010001F0000000UTO<<<<<<<<<<<0")]
+   [InlineData(_crlf, "I<UTO0000000000<<<<<<<<<<<<<<<", "0001007F0000000UTO<<<<<<<<<<<4")]
+   [InlineData(_crlf, "I<UTO0000000000<<<<<<<<<<<<<<<", "0000103F0000000UTO<<<<<<<<<<<0")]
+   [InlineData(_crlf, "I<UTO0000000000<<<<<<<<<<<<<<<", "0000011F0000000UTO<<<<<<<<<<<0")]
    // Date of expiry field
-   [InlineData(LineSeparator.Lf,   "I<UTO0000000000<<<<<<<<<<<<<<<", "0000000F1000007UTO<<<<<<<<<<<8")]
-   [InlineData(LineSeparator.Lf,   "I<UTO0000000000<<<<<<<<<<<<<<<", "0000000F0100003UTO<<<<<<<<<<<0")]
-   [InlineData(LineSeparator.Lf,   "I<UTO0000000000<<<<<<<<<<<<<<<", "0000000F0010001UTO<<<<<<<<<<<4")]
-   [InlineData(LineSeparator.Lf,   "I<UTO0000000000<<<<<<<<<<<<<<<", "0000000F0001007UTO<<<<<<<<<<<8")]
-   [InlineData(LineSeparator.Lf,   "I<UTO0000000000<<<<<<<<<<<<<<<", "0000000F0000103UTO<<<<<<<<<<<0")]
-   [InlineData(LineSeparator.Lf,   "I<UTO0000000000<<<<<<<<<<<<<<<", "0000000F0000011UTO<<<<<<<<<<<4")]
+   [InlineData(_lf,   "I<UTO0000000000<<<<<<<<<<<<<<<", "0000000F1000007UTO<<<<<<<<<<<8")]
+   [InlineData(_lf,   "I<UTO0000000000<<<<<<<<<<<<<<<", "0000000F0100003UTO<<<<<<<<<<<0")]
+   [InlineData(_lf,   "I<UTO0000000000<<<<<<<<<<<<<<<", "0000000F0010001UTO<<<<<<<<<<<4")]
+   [InlineData(_lf,   "I<UTO0000000000<<<<<<<<<<<<<<<", "0000000F0001007UTO<<<<<<<<<<<8")]
+   [InlineData(_lf,   "I<UTO0000000000<<<<<<<<<<<<<<<", "0000000F0000103UTO<<<<<<<<<<<0")]
+   [InlineData(_lf,   "I<UTO0000000000<<<<<<<<<<<<<<<", "0000000F0000011UTO<<<<<<<<<<<4")]
    public void Icao9303SizeTD1Algorithm_Validate_ShouldCorrectlyWeightByCharacterPosition(
-      LineSeparator lineSeparator,
+      String lineSeparator,
       String mrzFirstLine,
       String mrzSecondLine)
    {
       // Arrange.
-      var sut = new Icao9303SizeTD1Algorithm()
-      {
-         LineSeparator = lineSeparator,
-      };
       var value = GetTestValue(lineSeparator, mrzFirstLine, mrzSecondLine);
 
       // Act/assert.
-      sut.Validate(value).Should().BeTrue();
+      _sut.Validate(value).Should().BeTrue();
    }
 
    [Theory]
-   [InlineData(LineSeparator.None, "I<UTOD231458907<<<<<<<<<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<6")]
-   [InlineData(LineSeparator.Crlf, "I<UTOD231458907<<<<<<<<<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<6")]
-   [InlineData(LineSeparator.Lf,   "I<UTOD231458907<<<<<<<<<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<6")]
-   [InlineData(LineSeparator.None, "I<UTOD23145890<AB112234566<<<<", "7408122F1204159UTO<<<<<<<<<<<4")]
-   [InlineData(LineSeparator.Crlf, "I<UTOD23145890<AB112234566<<<<", "7408122F1204159UTO<<<<<<<<<<<4")]
-   [InlineData(LineSeparator.Lf,   "I<UTOD23145890<AB112234566<<<<", "7408122F1204159UTO<<<<<<<<<<<4")]
+   [InlineData(_emptySeparator, "I<UTOD231458907<<<<<<<<<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<6")]
+   [InlineData(_crlf,           "I<UTOD231458907<<<<<<<<<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<6")]
+   [InlineData(_lf,             "I<UTOD231458907<<<<<<<<<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<6")]
+   [InlineData(_emptySeparator, "I<UTOD23145890<AB112234566<<<<", "7408122F1204159UTO<<<<<<<<<<<4")]
+   [InlineData(_crlf,           "I<UTOD23145890<AB112234566<<<<", "7408122F1204159UTO<<<<<<<<<<<4")]
+   [InlineData(_lf,             "I<UTOD23145890<AB112234566<<<<", "7408122F1204159UTO<<<<<<<<<<<4")]
    public void Icao9303SizeTD1Algorithm_Validate_ShouldReturnTrue_WhenValueContainsValidCheckDigits(
-      LineSeparator lineSeparator,
+      String lineSeparator,
       String mrzFirstLine,
       String mrzSecondLine)
    {
       // Arrange.
-      var sut = new Icao9303SizeTD1Algorithm()
-      {
-         LineSeparator = lineSeparator,
-      };
       var value = GetTestValue(lineSeparator, mrzFirstLine, mrzSecondLine);
 
       // Act/assert.
-      sut.Validate(value).Should().BeTrue();
+      _sut.Validate(value).Should().BeTrue();
    }
 
    [Theory]
-   [InlineData(LineSeparator.None, "I<UTOD23145890<00000000000007<", "7408122F1204159UTO<<<<<<<<<<<8")]
-   [InlineData(LineSeparator.Crlf, "I<UTOD23145890<0000000000007<<", "7408122F1204159UTO<<<<<<<<<<<6")]
-   [InlineData(LineSeparator.Lf,   "I<UTOD23145890<000000000007<<<", "7408122F1204159UTO<<<<<<<<<<<0")]
-   [InlineData(LineSeparator.None, "I<UTOD23145890<00000000007<<<<", "7408122F1204159UTO<<<<<<<<<<<8")]
-   [InlineData(LineSeparator.Crlf, "I<UTOD23145890<0000000007<<<<<", "7408122F1204159UTO<<<<<<<<<<<6")]
-   [InlineData(LineSeparator.Lf,   "I<UTOD23145890<000000007<<<<<<", "7408122F1204159UTO<<<<<<<<<<<0")]
-   [InlineData(LineSeparator.None, "I<UTOD23145890<00000007<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<8")]
-   [InlineData(LineSeparator.Crlf, "I<UTOD23145890<0000007<<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<6")]
-   [InlineData(LineSeparator.Lf,   "I<UTOD23145890<000007<<<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<0")]
-   [InlineData(LineSeparator.None, "I<UTOD23145890<00007<<<<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<8")]
-   [InlineData(LineSeparator.Crlf, "I<UTOD23145890<0007<<<<<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<6")]
-   [InlineData(LineSeparator.Lf,   "I<UTOD23145890<007<<<<<<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<0")]
-   [InlineData(LineSeparator.None, "I<UTOD23145890<07<<<<<<<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<8")]
-   [InlineData(LineSeparator.None, "I<UTOD23145890<AB112234566<<<<", "7408122F1204159UTO<<<<<<<<<<<4")]
+   [InlineData(_emptySeparator, "I<UTOD23145890<00000000000007<", "7408122F1204159UTO<<<<<<<<<<<8")]
+   [InlineData(_crlf,           "I<UTOD23145890<0000000000007<<", "7408122F1204159UTO<<<<<<<<<<<6")]
+   [InlineData(_lf,             "I<UTOD23145890<000000000007<<<", "7408122F1204159UTO<<<<<<<<<<<0")]
+   [InlineData(_emptySeparator, "I<UTOD23145890<00000000007<<<<", "7408122F1204159UTO<<<<<<<<<<<8")]
+   [InlineData(_crlf,           "I<UTOD23145890<0000000007<<<<<", "7408122F1204159UTO<<<<<<<<<<<6")]
+   [InlineData(_lf,             "I<UTOD23145890<000000007<<<<<<", "7408122F1204159UTO<<<<<<<<<<<0")]
+   [InlineData(_emptySeparator, "I<UTOD23145890<00000007<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<8")]
+   [InlineData(_crlf,           "I<UTOD23145890<0000007<<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<6")]
+   [InlineData(_lf,             "I<UTOD23145890<000007<<<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<0")]
+   [InlineData(_emptySeparator, "I<UTOD23145890<00007<<<<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<8")]
+   [InlineData(_crlf,           "I<UTOD23145890<0007<<<<<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<6")]
+   [InlineData(_lf,             "I<UTOD23145890<007<<<<<<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<0")]
+   [InlineData(_emptySeparator, "I<UTOD23145890<07<<<<<<<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<8")]
+   [InlineData(_emptySeparator, "I<UTOD23145890<AB112234566<<<<", "7408122F1204159UTO<<<<<<<<<<<4")]
    public void Icao9303SizeTD1Algorithm_Validate_ShouldReturnTrue_WhenValueContainsExtendedDocumentNumberWithValidCheckDigits(
-      LineSeparator lineSeparator,
+      String lineSeparator,
       String mrzFirstLine,
       String mrzSecondLine)
    {
       // Arrange.
-      var sut = new Icao9303SizeTD1Algorithm()
-      {
-         LineSeparator = lineSeparator,
-      };
       var value = GetTestValue(lineSeparator, mrzFirstLine, mrzSecondLine);
 
       // Act/assert.
-      sut.Validate(value).Should().BeTrue();
+      _sut.Validate(value).Should().BeTrue();
    }
 
    [Theory]
-   [InlineData(LineSeparator.None, "I<UTOD2314589A7<<<<<<<<<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<6")]  // D231458907 with single char transcription error (0 -> A) with delta 10
-   [InlineData(LineSeparator.Crlf, "I<UTON2314589A7<<<<<<<<<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<6")]  // D231458907 with single char transcription error (D -> N) with delta 10
-   [InlineData(LineSeparator.None, "I<UTOL89890C236<<<<<<<<<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<8")]  // L898902C36 with two char transposition error (2C -> C2) with delta 10
-   [InlineData(LineSeparator.Lf,   "I<UTO0000000000<<<<<<<<<<<<<<<", "8812728F0000000UTO<<<<<<<<<<<0")]  // 8812278 with two char transposition error (27 -> 72) with delta 5
-   [InlineData(LineSeparator.None, "I<UTO0000000000<<<<<<<<<<<<<<<", "0000000F8812728UTO<<<<<<<<<<<2")]  // 8812278 with two char transposition error (27 -> 72) with delta 5
-   [InlineData(LineSeparator.Crlf, "I<UTOD23145890<0B112234566<<<<", "7408122F1204159UTO<<<<<<<<<<<4")]  // Extended document number AB112234566 with single char transcription error (A -> 0) with delta 10
-   [InlineData(LineSeparator.Lf,   "I<UTOD23145890<AB112283568<<<<", "7408122F1204159UTO<<<<<<<<<<<2")]  // Extended document number AB112238568 with two char transposition error (38 -> 83) with delta 5
+   [InlineData(_emptySeparator, "I<UTOD2314589A7<<<<<<<<<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<6")]  // D231458907 with single char transcription error (0 -> A) with delta 10
+   [InlineData(_crlf, "I<UTON2314589A7<<<<<<<<<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<6")]  // D231458907 with single char transcription error (D -> N) with delta 10
+   [InlineData(_emptySeparator, "I<UTOL89890C236<<<<<<<<<<<<<<<", "7408122F1204159UTO<<<<<<<<<<<8")]  // L898902C36 with two char transposition error (2C -> C2) with delta 10
+   [InlineData(_lf,   "I<UTO0000000000<<<<<<<<<<<<<<<", "8812728F0000000UTO<<<<<<<<<<<0")]  // 8812278 with two char transposition error (27 -> 72) with delta 5
+   [InlineData(_emptySeparator, "I<UTO0000000000<<<<<<<<<<<<<<<", "0000000F8812728UTO<<<<<<<<<<<2")]  // 8812278 with two char transposition error (27 -> 72) with delta 5
+   [InlineData(_crlf, "I<UTOD23145890<0B112234566<<<<", "7408122F1204159UTO<<<<<<<<<<<4")]  // Extended document number AB112234566 with single char transcription error (A -> 0) with delta 10
+   [InlineData(_lf,   "I<UTOD23145890<AB112283568<<<<", "7408122F1204159UTO<<<<<<<<<<<2")]  // Extended document number AB112238568 with two char transposition error (38 -> 83) with delta 5
    public void Icao9303SizeTD1Algorithm_Validate_ShouldReturnTrue_WhenValueContainsUndetectableError(
-      LineSeparator lineSeparator,
+      String lineSeparator,
       String mrzFirstLine,
       String mrzSecondLine)
    {
       // Arrange.
-      var sut = new Icao9303SizeTD1Algorithm()
-      {
-         LineSeparator = lineSeparator,
-      };
       var value = GetTestValue(lineSeparator, mrzFirstLine, mrzSecondLine);
 
       // Act/assert.
-      sut.Validate(value).Should().BeTrue();
+      _sut.Validate(value).Should().BeTrue();
    }
 
-   public static TheoryData<LineSeparator, String, String> DetectableErrorData = new()
+   public static TheoryData<String, String, String> DetectableErrorData = new()
    {
-      { LineSeparator.None, "I<UTOE231458907<<<<<<<<<<<<<<<", _mrzSecondLine },     // D231458907 with single character transcription error (D -> E)
-      { LineSeparator.None, "I<UTOD241458907<<<<<<<<<<<<<<<", _mrzSecondLine },     // D231458907 with single digit transcription error (3 -> 4)
-      { LineSeparator.Crlf, _mrzFirstLine, "7409122F1204159UTO<<<<<<<<<<<6" },      // 7408122 with single digit transcription error (8 -> 9)
-      { LineSeparator.Crlf, _mrzFirstLine, "7409122F1203159UTO<<<<<<<<<<<6" },      // 1204159 with single digit transcription error (4 -> 3)
-      { LineSeparator.None, "I<UTO2D31458907<<<<<<<<<<<<<<<", _mrzSecondLine },     // D231458907 with two character transposition error (D2 -> 2D)
-      { LineSeparator.None, "I<UTOD231548907<<<<<<<<<<<<<<<", _mrzSecondLine },     // D231458907 with two digit transposition error (45 -> 54)
-      { LineSeparator.Crlf, _mrzFirstLine, "7408212F1204159UTO<<<<<<<<<<<6" },      // 7408122 with two digit transposition error (12 -> 21)
-      { LineSeparator.Crlf, _mrzFirstLine, "7409122F1201459UTO<<<<<<<<<<<6" },      // 1204159 with two digit transposition error (41 -> 14)
-      { LineSeparator.None, "I<UTOD23145890<AC112234566<<<<", "7408122F1204159UTO<<<<<<<<<<<4" },     // Extended document number AB112234566 with single character transcription error (B -> C)
+      { _emptySeparator, "I<UTOE231458907<<<<<<<<<<<<<<<", _mrzSecondLine },     // D231458907 with single character transcription error (D -> E)
+      { _emptySeparator, "I<UTOD241458907<<<<<<<<<<<<<<<", _mrzSecondLine },     // D231458907 with single digit transcription error (3 -> 4)
+      { _crlf,           _mrzFirstLine, "7409122F1204159UTO<<<<<<<<<<<6" },      // 7408122 with single digit transcription error (8 -> 9)
+      { _crlf,           _mrzFirstLine, "7409122F1203159UTO<<<<<<<<<<<6" },      // 1204159 with single digit transcription error (4 -> 3)
+      { _emptySeparator, "I<UTO2D31458907<<<<<<<<<<<<<<<", _mrzSecondLine },     // D231458907 with two character transposition error (D2 -> 2D)
+      { _emptySeparator, "I<UTOD231548907<<<<<<<<<<<<<<<", _mrzSecondLine },     // D231458907 with two digit transposition error (45 -> 54)
+      { _crlf,           _mrzFirstLine, "7408212F1204159UTO<<<<<<<<<<<6" },      // 7408122 with two digit transposition error (12 -> 21)
+      { _crlf,           _mrzFirstLine, "7409122F1201459UTO<<<<<<<<<<<6" },      // 1204159 with two digit transposition error (41 -> 14)
+      { _emptySeparator, "I<UTOD23145890<AC112234566<<<<", "7408122F1204159UTO<<<<<<<<<<<4" },     // Extended document number AB112234566 with single character transcription error (B -> C)
    };
 
    [Theory]
    [MemberData(nameof(DetectableErrorData))]
    public void Icao9303SizeTD1Algorithm_Validate_ShouldReturnFalse_WhenValueContainsDetectableError(
-      LineSeparator lineSeparator,
+      String lineSeparator,
       String mrzFirstLine,
       String mrzSecondLine)
    {
       // Arrange.
-      var sut = new Icao9303SizeTD1Algorithm()
-      {
-         LineSeparator = lineSeparator,
-      };
       var value = GetTestValue(lineSeparator, mrzFirstLine, mrzSecondLine);
 
       // Act/assert.
-      sut.Validate(value).Should().BeFalse();
+      _sut.Validate(value).Should().BeFalse();
+   }
+
+   [Fact]
+   public void Icao9303SizeTD1Algorithm_Validate_ShouldReturnFalse_WhenFieldCheckDigitsAreValidButCompositeCheckDigitIsNotValid()
+   {
+      // Arrange.
+      var value = _mrzThirdLine + _mrzSecondLine[..29] + "8" + _mrzThirdLine;
+
+      // Act/assert.
+      _sut.Validate(value).Should().BeFalse();
    }
 
    [Theory]
-   [InlineData(LineSeparator.None, "I<UTO0000000000<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
-   [InlineData(LineSeparator.Crlf, "I<UTO000000000<00000000000000<", "0000000F0000000UTO<<<<<<<<<<<0")]
+   [InlineData(_emptySeparator, "I<UTO0000000000<<<<<<<<<<<<<<<", "0000000F0000000UTO<<<<<<<<<<<0")]
+   [InlineData(_crlf,           "I<UTO000000000<00000000000000<", "0000000F0000000UTO<<<<<<<<<<<0")]
    public void Icao9303SizeTD1Algorithm_Validate_ShouldReturnTrue_WhenFieldsAreAllZeros(
-      LineSeparator lineSeparator,
+      String lineSeparator,
       String mrzFirstLine,
       String mrzSecondLine)
    {
       // Arrange.
-      var sut = new Icao9303SizeTD1Algorithm()
-      {
-         LineSeparator = lineSeparator,
-      };
       var value = GetTestValue(lineSeparator, mrzFirstLine, mrzSecondLine);
 
       // Act/assert.
-      sut.Validate(value).Should().BeTrue();
+      _sut.Validate(value).Should().BeTrue();
    }
 
    [Fact]
@@ -392,7 +354,7 @@ public class Icao9303SizeTD1AlgorithmTests
    {
       // Arrange.
       var value = GetTestValue(
-         LineSeparator.None,
+         _emptySeparator,
          "I<UTO<<<<<<<<<0<<<<<<<<<<<<<<<",
          "<<<<<<0F<<<<<<0UTO<<<<<<<<<<<0");
 
@@ -400,70 +362,76 @@ public class Icao9303SizeTD1AlgorithmTests
       _sut.Validate(value).Should().BeTrue();
    }
 
-   public static TheoryData<LineSeparator, String, String> InvalidCharacterData = new()
+   public static TheoryData<String, String, String> InvalidCharacterData = new()
    {
-      { LineSeparator.None, "I<UTOb231458907<<<<<<<<<<<<<<<", _mrzSecondLine },     // D231458907 with D replaced with character 30 positions later in ASCII table
-      { LineSeparator.Crlf, "I<UTOD2314589&7<<<<<<<<<<<<<<<", _mrzSecondLine },     // D231458907 with 0 replaced with character 10 positions before in ASCII table
-      { LineSeparator.Lf,   "I<UTOD2314589:7<<<<<<<<<<<<<<<", _mrzSecondLine },     // D231458907 with 0 replaced with character 10 positions later in ASCII table
-      { LineSeparator.None, _mrzFirstLine, "7>08122F1204159UTO<<<<<<<<<<<6" },      // 7408122 with 4 replaced with character 10 positions later in ASCII table
-      { LineSeparator.None, "I<UTOD23145890<A&112234566<<<<", "7408122F1204159UTO<<<<<<<<<<<4" },     // Extended document number AB112234566 with B replaced by invalid character
-      { LineSeparator.None, "I<UTOD23145890<A:112234566<<<<", "7408122F1204159UTO<<<<<<<<<<<4" },     // Extended document number AB112234566 with B replaced by invalid character
-      { LineSeparator.None, "I<UTOD23145890<A[112234566<<<<", "7408122F1204159UTO<<<<<<<<<<<4" },     // Extended document number AB112234566 with B replaced by invalid character
+      { _emptySeparator, "I<UTOb231458907<<<<<<<<<<<<<<<", _mrzSecondLine },     // D231458907 with D replaced with character 30 positions later in ASCII table
+      { _crlf,           "I<UTOD2314589&7<<<<<<<<<<<<<<<", _mrzSecondLine },     // D231458907 with 0 replaced with character 10 positions before in ASCII table
+      { _lf,             "I<UTOD2314589:7<<<<<<<<<<<<<<<", _mrzSecondLine },     // D231458907 with 0 replaced with character 10 positions later in ASCII table
+      { _emptySeparator, _mrzFirstLine, "7>08122F1204159UTO<<<<<<<<<<<6" },      // 7408122 with 4 replaced with character 10 positions later in ASCII table
+      { _emptySeparator, "I<UTOD23145890<A&112234566<<<<", "7408122F1204159UTO<<<<<<<<<<<4" },     // Extended document number AB112234566 with B replaced by invalid character
+      { _emptySeparator, "I<UTOD23145890<A:112234566<<<<", "7408122F1204159UTO<<<<<<<<<<<4" },     // Extended document number AB112234566 with B replaced by invalid character
+      { _emptySeparator, "I<UTOD23145890<A[112234566<<<<", "7408122F1204159UTO<<<<<<<<<<<4" },     // Extended document number AB112234566 with B replaced by invalid character
    };
 
    [Theory]
    [MemberData(nameof(InvalidCharacterData))]
    public void Icao9303SizeTD1Algorithm_Validate_ShouldReturnFalse_WhenFieldContainsInvalidCharacter(
-      LineSeparator lineSeparator,
+      String lineSeparator,
       String mrzFirstLine,
       String mrzSecondLine)
    {
       // Arrange.
-      var sut = new Icao9303SizeTD1Algorithm()
-      {
-         LineSeparator = lineSeparator,
-      };
       var value = GetTestValue(lineSeparator, mrzFirstLine, mrzSecondLine);
 
       // Act/assert.
-      sut.Validate(value).Should().BeFalse();
+      _sut.Validate(value).Should().BeFalse();
    }
 
-   public static TheoryData<LineSeparator, String, String> InvalidCheckDigitCharacterData = new()
+   public static TheoryData<String, String, String> InvalidCheckDigitCharacterData = new()
    {
-      { LineSeparator.None, "I<UTOD23145890A<<<<<<<<<<<<<<<", _mrzSecondLine },     // Document number check digit is invalid character 
-      { LineSeparator.None, "I<UTOD23145890&<<<<<<<<<<<<<<<", _mrzSecondLine },     // Document number check digit is invalid character
-      { LineSeparator.None, "I<UTOD23145890:<<<<<<<<<<<<<<<", _mrzSecondLine },     // Document number check digit is invalid character
-      { LineSeparator.Crlf, _mrzFirstLine, "740812AF1204159UTO<<<<<<<<<<<6" },      // Date of birth check digit is invalid character
-      { LineSeparator.Crlf, _mrzFirstLine, "740812&F1204159UTO<<<<<<<<<<<6" },      // Date of birth check digit is invalid character
-      { LineSeparator.Crlf, _mrzFirstLine, "740812<F1204159UTO<<<<<<<<<<<6" },      // Date of birth check digit is invalid character
-      { LineSeparator.Crlf, _mrzFirstLine, "740812[F1204159UTO<<<<<<<<<<<6" },      // Date of birth check digit is invalid character
-      { LineSeparator.Lf,   _mrzFirstLine, "7408122F120415AUTO<<<<<<<<<<<6" },      // Date of expiry check digit is invalid character
-      { LineSeparator.Lf,   _mrzFirstLine, "7408122F120415&UTO<<<<<<<<<<<6" },      // Date of expiry check digit is invalid character
-      { LineSeparator.Lf,   _mrzFirstLine, "7408122F120415<UTO<<<<<<<<<<<6" },      // Date of expiry check digit is invalid character
-      { LineSeparator.Lf,   _mrzFirstLine, "7408122F120415[UTO<<<<<<<<<<<6" },      // Date of expiry check digit is invalid character
-      { LineSeparator.None, "I<UTOD23145890<AB11223456A<<<<", "7408122F1204159UTO<<<<<<<<<<<4" },     // Extended document number check digit with invalid character
-      { LineSeparator.None, "I<UTOD23145890<AB11223456&<<<<", "7408122F1204159UTO<<<<<<<<<<<4" },     // Extended document number check digit with invalid character
-      { LineSeparator.None, "I<UTOD23145890<AB11223456<<<<<", "7408122F1204159UTO<<<<<<<<<<<4" },     // Extended document number check digit with invalid character
-      { LineSeparator.None, "I<UTOD23145890<AB11223456[<<<<", "7408122F1204159UTO<<<<<<<<<<<4" },     // Extended document number check digit with invalid character
+      { _emptySeparator, "I<UTOD23145890A<<<<<<<<<<<<<<<", _mrzSecondLine },     // Document number check digit is invalid character 
+      { _emptySeparator, "I<UTOD23145890&<<<<<<<<<<<<<<<", _mrzSecondLine },     // Document number check digit is invalid character
+      { _emptySeparator, "I<UTOD23145890:<<<<<<<<<<<<<<<", _mrzSecondLine },     // Document number check digit is invalid character
+      { _crlf,           _mrzFirstLine, "740812AF1204159UTO<<<<<<<<<<<6" },      // Date of birth check digit is invalid character
+      { _crlf,           _mrzFirstLine, "740812&F1204159UTO<<<<<<<<<<<6" },      // Date of birth check digit is invalid character
+      { _crlf,           _mrzFirstLine, "740812<F1204159UTO<<<<<<<<<<<6" },      // Date of birth check digit is invalid character
+      { _crlf,           _mrzFirstLine, "740812[F1204159UTO<<<<<<<<<<<6" },      // Date of birth check digit is invalid character
+      { _lf,             _mrzFirstLine, "7408122F120415AUTO<<<<<<<<<<<6" },      // Date of expiry check digit is invalid character
+      { _lf,             _mrzFirstLine, "7408122F120415&UTO<<<<<<<<<<<6" },      // Date of expiry check digit is invalid character
+      { _lf,             _mrzFirstLine, "7408122F120415<UTO<<<<<<<<<<<6" },      // Date of expiry check digit is invalid character
+      { _lf,             _mrzFirstLine, "7408122F120415[UTO<<<<<<<<<<<6" },      // Date of expiry check digit is invalid character
+      { _emptySeparator, "I<UTOD23145890<AB11223456A<<<<", "7408122F1204159UTO<<<<<<<<<<<4" },     // Extended document number check digit with invalid character
+      { _emptySeparator, "I<UTOD23145890<AB11223456&<<<<", "7408122F1204159UTO<<<<<<<<<<<4" },     // Extended document number check digit with invalid character
+      { _emptySeparator, "I<UTOD23145890<AB11223456<<<<<", "7408122F1204159UTO<<<<<<<<<<<4" },     // Extended document number check digit with invalid character
+      { _emptySeparator, "I<UTOD23145890<AB11223456[<<<<", "7408122F1204159UTO<<<<<<<<<<<4" },     // Extended document number check digit with invalid character
    };
 
    [Theory]
    [MemberData(nameof(InvalidCheckDigitCharacterData))]
    public void Icao9303SizeTD1Algorithm_Validate_ShouldReturnFalse_WhenRequiredFieldCheckDigitContainsNonDigitCharacter(
-      LineSeparator lineSeparator,
+      String lineSeparator,
       String mrzFirstLine,
       String mrzSecondLine)
    {
       // Arrange.
-      var sut = new Icao9303SizeTD1Algorithm()
-      {
-         LineSeparator = lineSeparator,
-      };
       var value = GetTestValue(lineSeparator, mrzFirstLine, mrzSecondLine);
 
       // Act/assert.
-      sut.Validate(value).Should().BeFalse();
+      _sut.Validate(value).Should().BeFalse();
+   }
+
+   [Theory]
+   [InlineData("A")]
+   [InlineData("&")]
+   [InlineData("<")]
+   [InlineData("[")]
+   public void Icao9303SizeTD1Algorithm_Validate_ShouldReturnFalse_WhenExtendedCheckDigitContainsNonDigitCharacter(String extendedCheckDigit)
+   {
+      // Arrange.
+      var value = _mrzFirstLine + _mrzSecondLine[..29] + extendedCheckDigit + _mrzThirdLine;
+
+      // Act/assert.
+      _sut.Validate(value).Should().BeFalse();
    }
 
    #endregion

--- a/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303SizeTD2AlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303SizeTD2AlgorithmTests.cs
@@ -158,7 +158,7 @@ public class Icao9303SizeTD2AlgorithmTests
    }
 
    [Theory]
-   // Third posiition has weight = 1, so easier to calculate field check digit and composite check digit
+   // Check digits are accurate, if equivalent uppercase character
    [InlineData("00a0000000", "0")]
    [InlineData("00b0000001", "8")]
    [InlineData("00c0000002", "6")]
@@ -376,7 +376,7 @@ public class Icao9303SizeTD2AlgorithmTests
    }
 
    [Fact]
-   public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnFalse_WhenValueContainsContainsInvalidCompositeCheckDigit()
+   public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnFalse_WhenFieldCheckDigitsAreValidButCompositeCheckDigitIsNotValid()
    {
       // Arrange.
       var value = GetTestValue(compositeCheckDigit: "7");   // Composite check digit should be '6' for the default test value

--- a/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303SizeTD2AlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303SizeTD2AlgorithmTests.cs
@@ -10,26 +10,25 @@ public class Icao9303SizeTD2AlgorithmTests
    private const String _mrzFirstLine = "I<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<";
    private const String _mrzSecondLine = "D231458907UTO7408122F1204159<<<<<<<6";
 
-   private static String GetTestValue(
-      LineSeparator lineSeparator = LineSeparator.None,
-#if !NET48
-      String? firstLine = null,
-      String? secondLine = null)
-#else
-      String firstLine = null,
-      String secondLine = null)
-#endif
-   {
-      var separatorChars = lineSeparator switch
-      {
-         LineSeparator.Crlf => "\r\n",
-         LineSeparator.Lf => "\n",
-         _ => String.Empty,
-      };
+   private const String _lineSeparatorNone = "";
+   private const String _lineSeparatorCrlf = "\r\n";
+   private const String _lineSeparatorLf = "\n";
 
-      return (firstLine ?? _mrzFirstLine)
-         + separatorChars + (secondLine ?? _mrzSecondLine);
-   }
+   private static String GetTestValue(
+      String documentCode = "I<",
+      String issuingState = "UTO",
+      String name = "ERIKSSON<<ANNA<MARIA<<<<<<<<<<<",
+      String lineSeparator = _lineSeparatorNone,
+      String documentNumber = "D231458907",              // 9 alphanumeric characters + 1 check digit
+      String nationality = "UTO",
+      String dateOfBirth = "7408122",                    // 6 digit characters + 1 check digit
+      String sex = "F",
+      String dateOfExpiry = "1204159",                   // 6 digit characters + 1 check digit
+      String optionalData = "<<<<<<<",                   // possible extended document number
+      String compositeCheckDigit = "6")
+      => $"{documentCode}{issuingState}{name}" + 
+         lineSeparator +
+         $"{documentNumber}{nationality}{dateOfBirth}{sex}{dateOfExpiry}{optionalData}{compositeCheckDigit}";
 
    #region AlgorithmDescription Property Tests
    // ==========================================================================
@@ -51,63 +50,6 @@ public class Icao9303SizeTD2AlgorithmTests
 
    #endregion
 
-   #region LineSeparator Property Tests
-   // ==========================================================================
-   // ==========================================================================
-
-   public static TheoryData<LineSeparator> LineSeparatorValues
-   {
-      get
-      {
-         var data = new TheoryData<LineSeparator>();
-         foreach (var value in Enum.GetValues(typeof(LineSeparator)))
-         {
-            data.Add((LineSeparator)value);
-         }
-
-         return data;
-      }
-   }
-
-   [Theory]
-   [MemberData(nameof(LineSeparatorValues))]
-   public void Icao9302SizeTD2Algorithm_LineSeparator_ShouldNotThrow_ValueIsValid(LineSeparator lineSeparator)
-   {
-      // Arrange.
-      var act = () => _sut.LineSeparator = lineSeparator;
-
-      // Act/assert.
-      act.Should().NotThrow();
-   }
-
-   [Theory]
-   [MemberData(nameof(LineSeparatorValues))]
-   public void Icao9303SizeTD2Algorithm_LineSeparator_ShouldReturnExpectedValueAfterSetting(LineSeparator lineSeparator)
-   {
-      // Arrange.
-      var sut = new Icao9303SizeTD2Algorithm() { LineSeparator = lineSeparator };
-
-      // Act/assert.
-      sut.LineSeparator.Should().Be(lineSeparator);
-   }
-
-   [Fact]
-   public void Icao9302SizeTD2Algorithm_LineSeparator_ShouldThrowArgumentOutOfRangeException_ValueIsInvalid()
-   {
-      // Arrange.
-      var value = (LineSeparator)(-1);
-      var act = () => _sut.LineSeparator = value;
-      var expectedMessage = Resources.LineSeparatorInvalidValueMessage;
-
-      // Act/assert.
-      act.Should().ThrowExactly<ArgumentOutOfRangeException>()
-         .WithParameterName(nameof(value))
-         .WithMessage(expectedMessage + "*")
-         .And.ActualValue.Should().Be(value);
-   }
-
-   #endregion
-
    #region Validate Tests
    // ==========================================================================
    // ==========================================================================
@@ -120,284 +62,423 @@ public class Icao9303SizeTD2AlgorithmTests
    public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnFalse_WhenInputIsEmpty()
       => _sut.Validate(String.Empty).Should().BeFalse();
 
-   public static TheoryData<LineSeparator, String> InvalidLengthData => new()
-   {
-      { LineSeparator.None, GetTestValue(LineSeparator.None, _mrzFirstLine[..35]) },
-      { LineSeparator.Crlf, GetTestValue(LineSeparator.Crlf, _mrzFirstLine[..35]) },
-      { LineSeparator.Lf,   GetTestValue(LineSeparator.Lf,   _mrzFirstLine[..35]) },
-      { LineSeparator.None, GetTestValue(LineSeparator.None, _mrzFirstLine + "<<") },
-      { LineSeparator.Crlf, GetTestValue(LineSeparator.Crlf, _mrzFirstLine + "<<") },
-      { LineSeparator.Lf,   GetTestValue(LineSeparator.Lf,   _mrzFirstLine + "<<") },
-   };
-
    [Theory]
-   [MemberData(nameof(InvalidLengthData))]
+   [InlineData("ERIKSSON<<ANNA<MARIA<<<<<<<<<<", _lineSeparatorNone)]      // Name -1 char and default line separator = total length 71
+   [InlineData("ERIKSSON<<ANNA<MARIA<<<<<<<<<<<<", _lineSeparatorCrlf)]    // Name + 1 char and CRLF separator = total length 75
    public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnFalse_WhenValueIsInvalidLength(
-      LineSeparator lineSeparator,
-      String value)
+      String name,
+      String lineSeparator)
    {
       // Arrange.
-      var sut = new Icao9303SizeTD2Algorithm()
-      {
-         LineSeparator = lineSeparator,
-      };
+      var value = GetTestValue(name: name, lineSeparator: lineSeparator);
 
       // Act/assert.
-      sut.Validate(value).Should().BeFalse();
+      _sut.Validate(value).Should().BeFalse();
    }
 
    [Theory]
-   [InlineData(LineSeparator.None, "0000000000UTO0000000F0000000<<<<<<<0")]
-   [InlineData(LineSeparator.None, "0010000001UTO0000000F0000000<<<<<<<8")]
-   [InlineData(LineSeparator.None, "0020000002UTO0000000F0000000<<<<<<<6")]
-   [InlineData(LineSeparator.None, "0030000003UTO0000000F0000000<<<<<<<4")]
-   [InlineData(LineSeparator.None, "0040000004UTO0000000F0000000<<<<<<<2")]
-   [InlineData(LineSeparator.None, "0050000005UTO0000000F0000000<<<<<<<0")]
-   [InlineData(LineSeparator.None, "0060000006UTO0000000F0000000<<<<<<<8")]
-   [InlineData(LineSeparator.None, "0070000007UTO0000000F0000000<<<<<<<6")]
-   [InlineData(LineSeparator.None, "0080000008UTO0000000F0000000<<<<<<<4")]
-   [InlineData(LineSeparator.None, "0090000009UTO0000000F0000000<<<<<<<2")]
-   [InlineData(LineSeparator.Crlf, "00A0000000UTO0000000F0000000<<<<<<<0")]
-   [InlineData(LineSeparator.Crlf, "00B0000001UTO0000000F0000000<<<<<<<8")]
-   [InlineData(LineSeparator.Crlf, "00C0000002UTO0000000F0000000<<<<<<<6")]
-   [InlineData(LineSeparator.Crlf, "00D0000003UTO0000000F0000000<<<<<<<4")]
-   [InlineData(LineSeparator.Crlf, "00E0000004UTO0000000F0000000<<<<<<<2")]
-   [InlineData(LineSeparator.Crlf, "00F0000005UTO0000000F0000000<<<<<<<0")]
-   [InlineData(LineSeparator.Crlf, "00G0000006UTO0000000F0000000<<<<<<<8")]
-   [InlineData(LineSeparator.Crlf, "00H0000007UTO0000000F0000000<<<<<<<6")]
-   [InlineData(LineSeparator.Crlf, "00I0000008UTO0000000F0000000<<<<<<<4")]
-   [InlineData(LineSeparator.Crlf, "00J0000009UTO0000000F0000000<<<<<<<2")]
-   [InlineData(LineSeparator.Lf,   "00K0000000UTO0000000F0000000<<<<<<<0")]
-   [InlineData(LineSeparator.Lf,   "00L0000001UTO0000000F0000000<<<<<<<8")]
-   [InlineData(LineSeparator.Lf,   "00M0000002UTO0000000F0000000<<<<<<<6")]
-   [InlineData(LineSeparator.Lf,   "00N0000003UTO0000000F0000000<<<<<<<4")]
-   [InlineData(LineSeparator.Lf,   "00O0000004UTO0000000F0000000<<<<<<<2")]
-   [InlineData(LineSeparator.Lf,   "00P0000005UTO0000000F0000000<<<<<<<0")]
-   [InlineData(LineSeparator.Lf,   "00Q0000006UTO0000000F0000000<<<<<<<8")]
-   [InlineData(LineSeparator.Lf,   "00R0000007UTO0000000F0000000<<<<<<<6")]
-   [InlineData(LineSeparator.Lf,   "00S0000008UTO0000000F0000000<<<<<<<4")]
-   [InlineData(LineSeparator.Lf,   "00T0000009UTO0000000F0000000<<<<<<<2")]
-   [InlineData(LineSeparator.None, "00U0000000UTO0000000F0000000<<<<<<<0")]
-   [InlineData(LineSeparator.None, "00V0000001UTO0000000F0000000<<<<<<<8")]
-   [InlineData(LineSeparator.None, "00W0000002UTO0000000F0000000<<<<<<<6")]
-   [InlineData(LineSeparator.None, "00X0000003UTO0000000F0000000<<<<<<<4")]
-   [InlineData(LineSeparator.None, "00Y0000004UTO0000000F0000000<<<<<<<2")]
-   [InlineData(LineSeparator.None, "00Z0000005UTO0000000F0000000<<<<<<<0")]
-   [InlineData(LineSeparator.None, "00<0000000UTO0000000F0000000<<<<<<<0")]
-   public void Icao9303SizeTD2Algorithm_Validate_ShouldCorrectlyMapFieldCharacterValues(
-      LineSeparator lineSeparator,
-      String mrzSecondLine)
+   [InlineData(_lineSeparatorNone)]
+   [InlineData(_lineSeparatorCrlf)]
+   [InlineData(_lineSeparatorLf)]
+   public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnTrue_WhenLineSeparatorIsValid(String lineSeparator)
    {
       // Arrange.
-      var sut = new Icao9303SizeTD2Algorithm()
-      {
-         LineSeparator = lineSeparator,
-      };
-      var value = GetTestValue(lineSeparator, _mrzFirstLine, mrzSecondLine);
-
-      // Act/assert.
-      sut.Validate(value).Should().BeTrue();
-   }
-
-   [Theory]
-   // Document number field
-   [InlineData(LineSeparator.None, "1000000007UTO0000000F0000000<<<<<<<6")]
-   [InlineData(LineSeparator.None, "0100000003UTO0000000F0000000<<<<<<<4")]
-   [InlineData(LineSeparator.None, "0010000001UTO0000000F0000000<<<<<<<8")]
-   [InlineData(LineSeparator.None, "0001000007UTO0000000F0000000<<<<<<<6")]
-   [InlineData(LineSeparator.None, "0000100003UTO0000000F0000000<<<<<<<4")]
-   [InlineData(LineSeparator.None, "0000010001UTO0000000F0000000<<<<<<<8")]
-   [InlineData(LineSeparator.None, "0000001007UTO0000000F0000000<<<<<<<6")]
-   [InlineData(LineSeparator.None, "0000000103UTO0000000F0000000<<<<<<<4")]
-   [InlineData(LineSeparator.None, "0000000011UTO0000000F0000000<<<<<<<8")]
-   // Extended document number
-   [InlineData(LineSeparator.None, "000000000<UTO0000000F0000000100007<4")]
-   [InlineData(LineSeparator.None, "000000000<UTO0000000F0000000010003<6")]
-   [InlineData(LineSeparator.None, "000000000<UTO0000000F0000000001001<2")]
-   [InlineData(LineSeparator.None, "000000000<UTO0000000F0000000000107<4")]
-   [InlineData(LineSeparator.None, "000000000<UTO0000000F0000000000013<6")]
-   // Date of birth field
-   [InlineData(LineSeparator.Crlf, "0000000000UTO1000007F0000000<<<<<<<4")]
-   [InlineData(LineSeparator.Crlf, "0000000000UTO0100003F0000000<<<<<<<0")]
-   [InlineData(LineSeparator.Crlf, "0000000000UTO0010001F0000000<<<<<<<0")]
-   [InlineData(LineSeparator.Crlf, "0000000000UTO0001007F0000000<<<<<<<4")]
-   [InlineData(LineSeparator.Crlf, "0000000000UTO0000103F0000000<<<<<<<0")]
-   [InlineData(LineSeparator.Crlf, "0000000000UTO0000011F0000000<<<<<<<0")]
-   // Date of expiry field
-   [InlineData(LineSeparator.Lf,   "0000000000UTO0000000F1000007<<<<<<<8")]
-   [InlineData(LineSeparator.Lf,   "0000000000UTO0000000F0100003<<<<<<<0")]
-   [InlineData(LineSeparator.Lf,   "0000000000UTO0000000F0010001<<<<<<<4")]
-   [InlineData(LineSeparator.Lf,   "0000000000UTO0000000F0001007<<<<<<<8")]
-   [InlineData(LineSeparator.Lf,   "0000000000UTO0000000F0000103<<<<<<<0")]
-   [InlineData(LineSeparator.Lf,   "0000000000UTO0000000F0000011<<<<<<<4")]
-   public void Icao9303SizeTD2Algorithm_Validate_ShouldCorrectlyWeightByCharacterPosition(
-      LineSeparator lineSeparator,
-      String mrzSecondLine)
-   {
-      // Arrange.
-      var sut = new Icao9303SizeTD2Algorithm()
-      {
-         LineSeparator = lineSeparator,
-      };
-      var value = GetTestValue(lineSeparator, _mrzFirstLine, mrzSecondLine);
-
-      // Act/assert.
-      sut.Validate(value).Should().BeTrue();
-   }
-
-   [Theory]
-   [InlineData(LineSeparator.None, "D231458907UTO7408122F1204159<<<<<<<6")]
-   [InlineData(LineSeparator.Crlf, "D231458907UTO7408122F1204159<<<<<<<6")]
-   [InlineData(LineSeparator.Lf,   "D231458907UTO7408122F1204159<<<<<<<6")]
-   [InlineData(LineSeparator.None, "D23145890<UTO7408122F1204159AB1124<4")]
-   [InlineData(LineSeparator.Crlf, "D23145890<UTO7408122F1204159AB1124<4")]
-   [InlineData(LineSeparator.Lf,   "D23145890<UTO7408122F1204159AB1124<4")]
-   public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnTrue_WhenValueContainsValidCheckDigits(
-      LineSeparator lineSeparator,
-      String mrzSecondLine)
-   {
-      // Arrange.
-      var sut = new Icao9303SizeTD2Algorithm()
-      {
-         LineSeparator = lineSeparator,
-      };
-      var value = GetTestValue(lineSeparator, _mrzFirstLine, mrzSecondLine);
-
-      // Act/assert.
-      sut.Validate(value).Should().BeTrue();
-   }
-
-   [Theory]
-   [InlineData(LineSeparator.None, "D2314589A7UTO7408122F1204159<<<<<<<6")]   // D231458907 with single char transcription error (0 -> A) with delta 10   
-   [InlineData(LineSeparator.Crlf, "N231458907UTO7408122F1204159<<<<<<<6")]   // D231458907 with single char transcription error (D -> N) with delta 10
-   [InlineData(LineSeparator.Lf,   "L89890C236UTO7408122F1204159<<<<<<<8")]   // L898902C36 with two char transposition error (2C -> C2) with delta 10
-   [InlineData(LineSeparator.None, "0000000000UTO8812728F0000000<<<<<<<0")]   // 8812278 with two char transposition error (27 -> 72) with delta 5
-   [InlineData(LineSeparator.Crlf, "0000000000UTO0000000F8812728<<<<<<<2")]   // 8812278 with two char transposition error (27 -> 72) with delta 5
-   [InlineData(LineSeparator.Lf,   "D23145890<UTO7408122F12041590B1124<4")]   // Extended document number AB1124 with single char transcription error (A -> 0) with delta 10
-   [InlineData(LineSeparator.None, "D23145890<UTO7408122F1204159AB8325<6")]   // Extended document number AB3824 with two char transposition error (38 -> 83) with delta 5
-   public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnTrue_WhenValueContainsUndetectableError(
-      LineSeparator lineSeparator,
-      String mrzSecondLine)
-   {
-      // Arrange.
-      var sut = new Icao9303SizeTD2Algorithm()
-      {
-         LineSeparator = lineSeparator,
-      };
-      var value = GetTestValue(lineSeparator, _mrzFirstLine, mrzSecondLine);
-
-      // Act/assert.
-      sut.Validate(value).Should().BeTrue();
-   }
-
-   [Theory]
-   [InlineData(LineSeparator.None, "E231458907UTO7408122F1204159<<<<<<<6")]   // D231458907 with single character transcription error (D -> E)
-   [InlineData(LineSeparator.None, "D241458907UTO7408122F1204159<<<<<<<6")]   // D231458907 with single digit transcription error (3 -> 4)
-   [InlineData(LineSeparator.None, "D231458907UTO7409122F1204159<<<<<<<6")]   // 7408122 with single digit transcription error (8 -> 9)
-   [InlineData(LineSeparator.None, "D231458907UTO7408122F1203159<<<<<<<6")]   // 1204159 with single digit transcription error (4 -> 3)
-   [InlineData(LineSeparator.None, "2D31458907UTO7408122F1204159<<<<<<<6")]   // D231458907 with two character transposition error (D2 -> 2D)
-   [InlineData(LineSeparator.None, "D231548907UTO7408122F1204159<<<<<<<6")]   // D231458907 with two digit transposition error (45 -> 54)
-   [InlineData(LineSeparator.None, "D231458907UTO7408212F1204159<<<<<<<6")]   // 7408122 with two digit transposition error (12 -> 21)
-   [InlineData(LineSeparator.None, "D231458907UTO7409122F1201459<<<<<<<6")]   // 1204159 with two digit transposition error (41 -> 14)
-   [InlineData(LineSeparator.None, "D23145890<UTO7408122F1204159AC1124<4")]   // Extended document number AB112234566 with single character transcription error (B -> C)
-   public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnFalse_WhenValueContainsDetectableError(
-      LineSeparator lineSeparator,
-      String mrzSecondLine)
-   {
-      // Arrange.
-      var sut = new Icao9303SizeTD2Algorithm()
-      {
-         LineSeparator = lineSeparator,
-      };
-      var value = GetTestValue(lineSeparator, _mrzFirstLine, mrzSecondLine);
-
-      // Act/assert.
-      sut.Validate(value).Should().BeFalse();
-   }
-
-   [Theory]
-   [InlineData(LineSeparator.None, "0000000000UTO0000000F0000000<<<<<<<0")]
-   [InlineData(LineSeparator.Crlf, "0000000000UTO0000000F0000000000000<0")]
-   public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnTrue_WhenFieldsAreAllZeros(
-      LineSeparator lineSeparator,
-      String mrzSecondLine)
-   {
-      // Arrange.
-      var sut = new Icao9303SizeTD2Algorithm()
-      {
-         LineSeparator = lineSeparator,
-      };
-      var value = GetTestValue(lineSeparator, _mrzFirstLine, mrzSecondLine);
-
-      // Act/assert.
-      sut.Validate(value).Should().BeTrue();
-   }
-
-   [Fact]
-   public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnTrue_WhenFieldsAreAllFillerCharacters()
-   {
-      // Arrange.
-      var value = GetTestValue(
-         LineSeparator.None,
-         "<<<<<<<<<0UTO<<<<<<0F<<<<<<0<<<<<<<0");
+      var value = GetTestValue(lineSeparator: lineSeparator);
 
       // Act/assert.
       _sut.Validate(value).Should().BeTrue();
    }
 
    [Theory]
-   [InlineData(LineSeparator.None, "b231458907UTO7408122F1204159<<<<<<<6")]   // D231458907 with D replaced with character 30 positions later in ASCII table
-   [InlineData(LineSeparator.Crlf, "D2314589&7UTO7408122F1204159<<<<<<<6")]   // D231458907 with 0 replaced with character 10 positions before in ASCII table
-   [InlineData(LineSeparator.Lf,   "D2314589:7UTO7408122F1204159<<<<<<<6")]   // D231458907 with 0 replaced with character 10 positions later in ASCII table
-   [InlineData(LineSeparator.None, "D231458907UTO7>08122F1204159<<<<<<<6")]   // 7408122 with 4 replaced with character 10 positions later in ASCII table
-   [InlineData(LineSeparator.Crlf, "D23145890<UTO7408122F1204159A&1124<4")]   // Extended document number AB112234 with B replaced by invalid character
-   [InlineData(LineSeparator.Lf,   "D23145890<UTO7408122F1204159A:1124<4")]   // Extended document number AB112234 with B replaced by invalid character
-   [InlineData(LineSeparator.None, "D23145890<UTO7408122F1204159A[1124<4")]   // Extended document number AB112234 with B replaced by invalid character
-   public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnFalse_WhenFieldContainsInvalidCharacter(
-      LineSeparator lineSeparator,
-      String mrzSecondLine)
+   [InlineData("X\n")]     // 'X' instead of \r
+   [InlineData(" \n")]     // Space instead of \r
+   [InlineData("\r ")]     // Space instead of \n
+   [InlineData("\n\r")]    // \n\r instead of \r\n
+   public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnFalse_WhenLineSeparatorIsValid(String lineSeparator)
    {
       // Arrange.
-      var sut = new Icao9303SizeTD2Algorithm()
-      {
-         LineSeparator = lineSeparator,
-      };
-      var value = GetTestValue(lineSeparator, _mrzFirstLine, mrzSecondLine);
+      var value = GetTestValue(lineSeparator: lineSeparator);
 
       // Act/assert.
-      sut.Validate(value).Should().BeFalse();
+      _sut.Validate(value).Should().BeFalse();
    }
 
    [Theory]
-   [InlineData(LineSeparator.None, "D23145890AUTO7408122F1204159<<<<<<<6")]   // Document number check digit is invalid character
-   [InlineData(LineSeparator.None, "D23145890&UTO7408122F1204159<<<<<<<6")]   // Document number check digit is invalid character
-   [InlineData(LineSeparator.None, "D23145890:UTO7408122F1204159<<<<<<<6")]   // Document number check digit is invalid character
-   [InlineData(LineSeparator.Crlf, "D231458907UTO740812AF1204159<<<<<<<6")]   // Date of birth check digit is invalid character
-   [InlineData(LineSeparator.Crlf, "D231458907UTO740812&F1204159<<<<<<<6")]   // Date of birth check digit is invalid character
-   [InlineData(LineSeparator.Crlf, "D231458907UTO740812<F1204159<<<<<<<6")]   // Date of birth check digit is invalid character
-   [InlineData(LineSeparator.Crlf, "D231458907UTO740812[F1204159<<<<<<<6")]   // Date of birth check digit is invalid character
-   [InlineData(LineSeparator.Crlf, "D231458907UTO7408122F120415A<<<<<<<6")]   // Date of expiry check digit is invalid character
-   [InlineData(LineSeparator.Crlf, "D231458907UTO7408122F120415&<<<<<<<6")]   // Date of expiry check digit is invalid character
-   [InlineData(LineSeparator.Crlf, "D231458907UTO7408122F120415<<<<<<<<6")]   // Date of expiry check digit is invalid character
-   [InlineData(LineSeparator.Crlf, "D231458907UTO7408122F120415[<<<<<<<6")]   // Date of expiry check digit is invalid character
-   [InlineData(LineSeparator.Crlf, "D23145890<UTO7408122F1204159AB112A<4")]   // Extended document number check digit with invalid character
-   [InlineData(LineSeparator.Crlf, "D23145890<UTO7408122F1204159AB112&<4")]   // Extended document number check digit with invalid character
-   [InlineData(LineSeparator.Crlf, "D23145890<UTO7408122F1204159AB112<<4")]   // Extended document number check digit with invalid character
-   [InlineData(LineSeparator.Crlf, "D23145890<UTO7408122F1204159AB112[<4")]   // Extended document number check digit with invalid character
-   public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnFalse_WhenRequiredFieldCheckDigitContainsNonDigitCharacter(
-      LineSeparator lineSeparator,
-      String mrzSecondLine)
+   // Third posiition has weight = 1, so easier to calculate field check digit and composite check digit
+   [InlineData("0000000000", "0")]
+   [InlineData("0010000001", "8")]
+   [InlineData("0020000002", "6")]
+   [InlineData("0030000003", "4")]
+   [InlineData("0040000004", "2")]
+   [InlineData("0050000005", "0")]
+   [InlineData("0060000006", "8")]
+   [InlineData("0070000007", "6")]
+   [InlineData("0080000008", "4")]
+   [InlineData("0090000009", "2")]
+   [InlineData("00A0000000", "0")]
+   [InlineData("00B0000001", "8")]
+   [InlineData("00C0000002", "6")]
+   [InlineData("00D0000003", "4")]
+   [InlineData("00E0000004", "2")]
+   [InlineData("00F0000005", "0")]
+   [InlineData("00G0000006", "8")]
+   [InlineData("00H0000007", "6")]
+   [InlineData("00I0000008", "4")]
+   [InlineData("00J0000009", "2")]
+   [InlineData("00K0000000", "0")]
+   [InlineData("00L0000001", "8")]
+   [InlineData("00M0000002", "6")]
+   [InlineData("00N0000003", "4")]
+   [InlineData("00O0000004", "2")]
+   [InlineData("00P0000005", "0")]
+   [InlineData("00Q0000006", "8")]
+   [InlineData("00R0000007", "6")]
+   [InlineData("00S0000008", "4")]
+   [InlineData("00T0000009", "2")]
+   [InlineData("00U0000000", "0")]
+   [InlineData("00V0000001", "8")]
+   [InlineData("00W0000002", "6")]
+   [InlineData("00X0000003", "4")]
+   [InlineData("00Y0000004", "2")]
+   [InlineData("00Z0000005", "0")]
+   [InlineData("00<0000000", "0")]
+   public void Icao9303SizeTD2Algorithm_Validate_ShouldCorrectlyMapCharactersToIntegerEquivalents(
+      String documentNumber,
+      String compositeCheckDigit)
    {
       // Arrange.
-      var sut = new Icao9303SizeTD2Algorithm()
-      {
-         LineSeparator = lineSeparator,
-      };
-      var value = GetTestValue(lineSeparator, _mrzFirstLine, mrzSecondLine);
+      var value = GetTestValue(
+         documentNumber: documentNumber, 
+         dateOfBirth: "0000000",
+         dateOfExpiry: "0000000",
+         compositeCheckDigit: compositeCheckDigit);
 
       // Act/assert.
-      sut.Validate(value).Should().BeFalse();
+      _sut.Validate(value).Should().BeTrue();
    }
+
+   [Theory]
+   // Third posiition has weight = 1, so easier to calculate field check digit and composite check digit
+   [InlineData("00a0000000", "0")]
+   [InlineData("00b0000001", "8")]
+   [InlineData("00c0000002", "6")]
+   [InlineData("00d0000003", "4")]
+   [InlineData("00e0000004", "2")]
+   [InlineData("00f0000005", "0")]
+   [InlineData("00g0000006", "8")]
+   [InlineData("00h0000007", "6")]
+   [InlineData("00i0000008", "4")]
+   [InlineData("00j0000009", "2")]
+   [InlineData("00k0000000", "0")]
+   [InlineData("00l0000001", "8")]
+   [InlineData("00m0000002", "6")]
+   [InlineData("00n0000003", "4")]
+   [InlineData("00o0000004", "2")]
+   [InlineData("00p0000005", "0")]
+   [InlineData("00q0000006", "8")]
+   [InlineData("00r0000007", "6")]
+   [InlineData("00s0000008", "4")]
+   [InlineData("00t0000009", "2")]
+   [InlineData("00u0000000", "0")]
+   [InlineData("00v0000001", "8")]
+   [InlineData("00w0000002", "6")]
+   [InlineData("00x0000003", "4")]
+   [InlineData("00y0000004", "2")]
+   [InlineData("00z0000005", "0")]
+   public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnFalse_WhenLowerCaseAlphabeticCharacterEncountered(
+      String documentNumber,
+      String compositeCheckDigit)
+   {
+      // Arrange.
+      var value = GetTestValue(
+         documentNumber: documentNumber,
+         dateOfBirth: "0000000",
+         dateOfExpiry: "0000000",
+         compositeCheckDigit: compositeCheckDigit);
+
+      // Act/assert.
+      _sut.Validate(value).Should().BeFalse();
+   }
+
+   [Theory]
+   // Check digits would be correct if alpha characters allowed
+   [InlineData("00A0000", "0000000", "0")]
+   [InlineData("00a0000", "0000000", "0")]
+   [InlineData("0000000", "00A0000", "0")]
+   [InlineData("0000000", "00a0000", "0")]
+   public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnFalse_NumericFieldContainsAlphabeticCharacter(
+      String dateOfBirth,
+      String dateOfExpiry,
+      String compositeCheckDigit)
+   {
+      // Arrange.
+      var value = GetTestValue(
+         documentNumber: "0000000000",
+         dateOfBirth: dateOfBirth,
+         dateOfExpiry: dateOfExpiry,
+         compositeCheckDigit: compositeCheckDigit);
+
+      // Act/assert.
+      _sut.Validate(value).Should().BeFalse();
+   }
+
+   [Theory]
+   // Document number field
+   [InlineData("1000000007", "0000000", "0000000", "<<<<<<<", "6")]
+   [InlineData("0100000003", "0000000", "0000000", "<<<<<<<", "4")]
+   [InlineData("0010000001", "0000000", "0000000", "<<<<<<<", "8")]
+   [InlineData("0001000007", "0000000", "0000000", "<<<<<<<", "6")]
+   [InlineData("0000100003", "0000000", "0000000", "<<<<<<<", "4")]
+   [InlineData("0000010001", "0000000", "0000000", "<<<<<<<", "8")]
+   [InlineData("0000001007", "0000000", "0000000", "<<<<<<<", "6")]
+   [InlineData("0000000103", "0000000", "0000000", "<<<<<<<", "4")]
+   [InlineData("0000000011", "0000000", "0000000", "<<<<<<<", "8")]
+   // Extended document number
+   [InlineData("000000000<", "0000000", "0000000", "100007<", "4")]
+   [InlineData("000000000<", "0000000", "0000000", "010003<", "6")]
+   [InlineData("000000000<", "0000000", "0000000", "001001<", "2")]
+   [InlineData("000000000<", "0000000", "0000000", "000107<", "4")]
+   [InlineData("000000000<", "0000000", "0000000", "000013<", "6")]
+   // Date of birth field
+   [InlineData("0000000000", "1000007", "0000000", "<<<<<<<", "4")]
+   [InlineData("0000000000", "0100003", "0000000", "<<<<<<<", "0")]
+   [InlineData("0000000000", "0010001", "0000000", "<<<<<<<", "0")]
+   [InlineData("0000000000", "0001007", "0000000", "<<<<<<<", "4")]
+   [InlineData("0000000000", "0000103", "0000000", "<<<<<<<", "0")]
+   [InlineData("0000000000", "0000011", "0000000", "<<<<<<<", "0")]
+   // Date of expiry field
+   [InlineData("0000000000", "0000000", "1000007", "<<<<<<<", "8")]
+   [InlineData("0000000000", "0000000", "0100003", "<<<<<<<", "0")]
+   [InlineData("0000000000", "0000000", "0010001", "<<<<<<<", "4")]
+   [InlineData("0000000000", "0000000", "0001007", "<<<<<<<", "8")]
+   [InlineData("0000000000", "0000000", "0000103", "<<<<<<<", "0")]
+   [InlineData("0000000000", "0000000", "0000011", "<<<<<<<", "4")]
+   public void Icao9303SizeTD2Algorithm_Validate_ShouldCorrectlyWeightByCharacterPosition(
+      String documentNumber,
+      String dateOfBirth,
+      String dateOfExpiry,
+      String optionalData,
+      String compositeCheckDigit)
+   {
+      // Arrange.
+      var value = GetTestValue(
+         lineSeparator: _lineSeparatorNone,
+         documentNumber: documentNumber,
+         dateOfBirth: dateOfBirth,
+         dateOfExpiry: dateOfExpiry,
+         optionalData: optionalData,
+         compositeCheckDigit: compositeCheckDigit);
+
+      // Act/assert.
+      _sut.Validate(value).Should().BeTrue();
+   }
+
+   [Theory]
+   [InlineData("D231458907", "7408122", "1204159", "<<<<<<<", "6")]
+   [InlineData("D23145890<", "7408122", "1204159", "AB1124<", "4")]     // Extended document number
+   public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnTrue_WhenValueContainsValidCheckDigits(
+      String documentNumber,
+      String dateOfBirth,
+      String dateOfExpiry,
+      String optionalData,
+      String compositeCheckDigit)
+   {
+      // Arrange.
+      var value = GetTestValue(
+         lineSeparator: _lineSeparatorCrlf,
+         documentNumber: documentNumber,
+         dateOfBirth: dateOfBirth,
+         dateOfExpiry: dateOfExpiry,
+         optionalData: optionalData,
+         compositeCheckDigit: compositeCheckDigit);
+
+      // Act/assert.
+      _sut.Validate(value).Should().BeTrue();
+   }
+
+   [Theory]
+   [InlineData("D2314589A7", "7408122", "1204159", "<<<<<<<", "6")]   // Document number D231458907 with single char transcription error (0 -> A) with delta 10   
+   [InlineData("N231458907", "7408122", "1204159", "<<<<<<<", "6")]   // Document number D231458907 with single char transcription error (D -> N) with delta 10
+   [InlineData("L89890C236", "7408122", "1204159", "<<<<<<<", "8")]   // Document number L898902C36 with two char transposition error (2C -> C2) with delta 10
+   [InlineData("0000000000", "8812728", "0000000", "<<<<<<<", "0")]   // Date of birth 8812278 with two char transposition error (27 -> 72) with delta 5
+   [InlineData("0000000000", "0000000", "8812728", "<<<<<<<", "2")]   // Date of expiry 8812278 with two char transposition error (27 -> 72) with delta 5
+   [InlineData("D23145890<", "7408122", "1204159", "0B1124<", "4")]   // Extended document number AB1124 with single char transcription error (A -> 0) with delta 10
+   [InlineData("D23145890<", "7408122", "1204159", "AB8325<", "6")]   // Extended document number AB3824 with two char transposition error (38 -> 83) with delta 5
+   public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnTrue_WhenValueContainsUndetectableError(
+      String documentNumber,
+      String dateOfBirth,
+      String dateOfExpiry,
+      String optionalData,
+      String compositeCheckDigit)
+   {
+      // Arrange.
+      var value = GetTestValue(
+         lineSeparator: _lineSeparatorLf,
+         documentNumber: documentNumber,
+         dateOfBirth: dateOfBirth,
+         dateOfExpiry: dateOfExpiry,
+         optionalData: optionalData,
+         compositeCheckDigit: compositeCheckDigit);
+
+      // Act/assert.
+      _sut.Validate(value).Should().BeTrue();
+   }
+
+   [Theory]
+   [InlineData("E231458907", "7408122", "1204159", "<<<<<<<", "6")]   // Document number D231458907 with single character transcription error (D -> E)
+   [InlineData("D241458907", "7408122", "1204159", "<<<<<<<", "6")]   // Document number D231458907 with single digit transcription error (3 -> 4)
+   [InlineData("D231458907", "7409122", "1204159", "<<<<<<<", "6")]   // Date of birth 7408122 with single digit transcription error (8 -> 9)
+   [InlineData("D231458907", "7408122", "1203159", "<<<<<<<", "6")]   // Date of expiry 1204159 with single digit transcription error (4 -> 3)
+   [InlineData("2D31458907", "7408122", "1204159", "<<<<<<<", "6")]   // Document number D231458907 with two character transposition error (D2 -> 2D)
+   [InlineData("D231548907", "7408122", "1204159", "<<<<<<<", "6")]   // Document number D231458907 with two digit transposition error (45 -> 54)
+   [InlineData("D231458907", "7408212", "1204159", "<<<<<<<", "6")]   // Date of birth 7408122 with two digit transposition error (12 -> 21)
+   [InlineData("D231458907", "7409122", "1201459", "<<<<<<<", "6")]   // Date of expiry 1204159 with two digit transposition error (41 -> 14)
+   [InlineData("D23145890<", "7408122", "1204159", "AC1124<", "4")]   // Extended document number AB1124 with single character transcription error (B -> C)
+   public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnFalse_WhenValueContainsDetectableError(
+      String documentNumber,
+      String dateOfBirth,
+      String dateOfExpiry,
+      String optionalData,
+      String compositeCheckDigit)
+   {
+      // Arrange.
+      var value = GetTestValue(
+         documentNumber: documentNumber,
+         dateOfBirth: dateOfBirth,
+         dateOfExpiry: dateOfExpiry,
+         optionalData: optionalData,
+         compositeCheckDigit: compositeCheckDigit);
+
+      // Act/assert.
+      _sut.Validate(value).Should().BeFalse();
+   }
+
+   [Theory]
+   [InlineData("0000000000", "0000000", "0000000", "<<<<<<<", "0")]
+   [InlineData("0000000000", "0000000", "0000000", "000000<", "0")]        // Extended document number requires at least one trailing filler character
+   public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnTrue_WhenFieldsAreAllZeros(
+      String documentNumber,
+      String dateOfBirth,
+      String dateOfExpiry,
+      String optionalData,
+      String compositeCheckDigit)
+   {
+      // Arrange.
+      var value = GetTestValue(
+         documentNumber: documentNumber,
+         dateOfBirth: dateOfBirth,
+         dateOfExpiry: dateOfExpiry,
+         optionalData: optionalData,
+         compositeCheckDigit: compositeCheckDigit);
+
+      // Act/assert.
+      _sut.Validate(value).Should().BeTrue();
+   }
+
+   [Theory]
+   [InlineData("<<<<<<<<<0", "<<<<<<0", "<<<<<<0", "<<<<<<<", "0")]
+   [InlineData("<<<<<<<<<<", "<<<<<<0", "<<<<<<0", "0<<<<<<", "0")]        // If using extended document number then must have at least one digit (the check digit) before first filler char 
+   public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnTrue_WhenFieldsAreAllFillerCharacters(
+      String documentNumber,
+      String dateOfBirth,
+      String dateOfExpiry,
+      String optionalData,
+      String compositeCheckDigit)
+   {
+      // Arrange.
+      var value = GetTestValue(
+         documentNumber: documentNumber,
+         dateOfBirth: dateOfBirth,
+         dateOfExpiry: dateOfExpiry,
+         optionalData: optionalData,
+         compositeCheckDigit: compositeCheckDigit);
+
+      // Act/assert.
+      _sut.Validate(value).Should().BeTrue();
+   }
+
+   [Theory]
+   [InlineData("b231458907", "7408122", "1204159", "<<<<<<<", "6")]   // D231458907 with D replaced with character 30 positions later in ASCII table
+   [InlineData("D2314589&7", "7408122", "1204159", "<<<<<<<", "6")]   // D231458907 with 0 replaced with character 10 positions before in ASCII table
+   [InlineData("D2314589:7", "7408122", "1204159", "<<<<<<<", "6")]   // D231458907 with 0 replaced with character 10 positions later in ASCII table
+   [InlineData("D231458907", "7>08122", "1204159", "<<<<<<<", "6")]   // 7408122 with 4 replaced with character 10 positions later in ASCII table
+   [InlineData("D23145890<", "7408122", "1204159", "A&1124<", "4")]   // Extended document number AB112234 with B replaced by invalid character
+   [InlineData("D23145890<", "7408122", "1204159", "A:1124<", "4")]   // Extended document number AB112234 with B replaced by invalid character
+   [InlineData("D23145890<", "7408122", "1204159", "A[1124<", "4")]   // Extended document number AB112234 with B replaced by invalid character
+   public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnFalse_WhenFieldContainsInvalidCharacter(
+      String documentNumber,
+      String dateOfBirth,
+      String dateOfExpiry,
+      String optionalData,
+      String compositeCheckDigit)
+   {
+      // Arrange.
+      var value = GetTestValue(
+         documentNumber: documentNumber,
+         dateOfBirth: dateOfBirth,
+         dateOfExpiry: dateOfExpiry,
+         optionalData: optionalData,
+         compositeCheckDigit: compositeCheckDigit);
+
+      // Act/assert.
+      _sut.Validate(value).Should().BeFalse();
+   }
+
+   [Theory]
+   [InlineData("D23145890A", "7408122", "1204159", "<<<<<<<", "6")]   // Document number check digit is invalid character
+   [InlineData("D23145890&", "7408122", "1204159", "<<<<<<<", "6")]   // Document number check digit is invalid character
+   [InlineData("D23145890:", "7408122", "1204159", "<<<<<<<", "6")]   // Document number check digit is invalid character
+   [InlineData("D231458907", "740812A", "1204159", "<<<<<<<", "6")]   // Date of birth check digit is invalid character
+   [InlineData("D231458907", "740812&", "1204159", "<<<<<<<", "6")]   // Date of birth check digit is invalid character
+   [InlineData("D231458907", "740812<", "1204159", "<<<<<<<", "6")]   // Date of birth check digit is invalid character
+   [InlineData("D231458907", "740812[", "1204159", "<<<<<<<", "6")]   // Date of birth check digit is invalid character
+   [InlineData("D231458907", "7408122", "120415A", "<<<<<<<", "6")]   // Date of expiry check digit is invalid character
+   [InlineData("D231458907", "7408122", "120415&", "<<<<<<<", "6")]   // Date of expiry check digit is invalid character
+   [InlineData("D231458907", "7408122", "120415<", "<<<<<<<", "6")]   // Date of expiry check digit is invalid character
+   [InlineData("D231458907", "7408122", "120415[", "<<<<<<<", "6")]   // Date of expiry check digit is invalid character
+   [InlineData("D23145890<", "7408122", "1204159", "AB112A<", "4")]   // Extended document number check digit with invalid character
+   [InlineData("D23145890<", "7408122", "1204159", "AB112&<", "4")]   // Extended document number check digit with invalid character
+   [InlineData("D23145890<", "7408122", "1204159", "AB112<<", "4")]   // Extended document number check digit with invalid character
+   [InlineData("D23145890<", "7408122", "1204159", "AB112[<", "4")]   // Extended document number check digit with invalid character
+   public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnFalse_WhenRequiredFieldCheckDigitContainsNonDigitCharacter(
+      String documentNumber,
+      String dateOfBirth,
+      String dateOfExpiry,
+      String optionalData,
+      String compositeCheckDigit)
+   {
+      // Arrange.
+      var value = GetTestValue(
+         documentNumber: documentNumber,
+         dateOfBirth: dateOfBirth,
+         dateOfExpiry: dateOfExpiry,
+         optionalData: optionalData,
+         compositeCheckDigit: compositeCheckDigit);
+
+      // Act/assert.
+      _sut.Validate(value).Should().BeFalse();
+   }
+
+   [Theory]
+   [InlineData("A")]
+   [InlineData("a")]
+   [InlineData("&")]
+   [InlineData(":")]
+   public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnFalse_WhenCompositeCheckDigitContainsNonDigitCharacter(String compositeCheckDigit)
+   {
+      // Arrange.
+      var value = GetTestValue(compositeCheckDigit: compositeCheckDigit);
+
+      // Act/assert.
+      _sut.Validate(value).Should().BeFalse();
+   }
+
+   [Theory]
+   [InlineData("I<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<D231458907UTO7408122F1204159<<<<<<<6")]
+   [InlineData("I<UTOQWERTY<<ASDF<<<<<<<<<<<<<<<<<<<\r\nD23145890<UTO7408122F1204159AB1124<4")]
+   [InlineData("I<UTOSKYWALKER<<LUKE<<<<<<<<<<<<<<<<\nSTARWARS45UTO7705256M2405252<<<<<<<4")]
+   public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnTrue_ForBenchmarkValues(String value)
+      => _sut.Validate(value).Should().BeTrue();
 
    #endregion
 }

--- a/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303SizeTD2AlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303SizeTD2AlgorithmTests.cs
@@ -63,7 +63,7 @@ public class Icao9303SizeTD2AlgorithmTests
       => _sut.Validate(String.Empty).Should().BeFalse();
 
    [Theory]
-   [InlineData("ERIKSSON<<ANNA<MARIA<<<<<<<<<<", _lineSeparatorNone)]      // Name -1 char and default line separator = total length 71
+   [InlineData("ERIKSSON<<ANNA<MARIA<<<<<<<<<<",   _lineSeparatorNone)]    // Name -1 char and default line separator = total length 71
    [InlineData("ERIKSSON<<ANNA<MARIA<<<<<<<<<<<<", _lineSeparatorCrlf)]    // Name + 1 char and CRLF separator = total length 75
    public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnFalse_WhenValueIsInvalidLength(
       String name,
@@ -74,6 +74,25 @@ public class Icao9303SizeTD2AlgorithmTests
 
       // Act/assert.
       _sut.Validate(value).Should().BeFalse();
+   }
+
+   [Theory]
+   // Test data for edge cases where separator validation cannot detect certain 
+   // issues due to length ambiguity. For example, when the first line is 
+   // shortened by exactly one character, a CRLF separator's LF character falls 
+   // at the position where an LF-only separator would be expected, making the 
+   // error undetectable by length validation alone.
+   [InlineData("ERIKSSON<<ANNA<MARIA<<<<<<<<<<", _lineSeparatorCrlf)]         // Name length -1 so total length indicates Lf only and Lf falls in correct position
+   [InlineData("ERIKSSON<<ANNA<MARIA<<<<<<<<<<", _lineSeparatorLf)]           // Name length -1 so total length indicates no separator so separator chars not checked
+   public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnTrue_WhenUndetectableInvalidSeparator(
+      String name,
+      String lineSeparator)
+   {
+      // Arrange.
+      var value = GetTestValue(name: name, lineSeparator: lineSeparator);
+
+      // Act/assert.
+      _sut.Validate(value).Should().BeTrue();
    }
 
    [Theory]

--- a/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303SizeTD3AlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303SizeTD3AlgorithmTests.cs
@@ -77,6 +77,25 @@ public class Icao9303SizeTD3AlgorithmTests
    }
 
    [Theory]
+   // Test data for edge cases where separator validation cannot detect certain 
+   // issues due to length ambiguity. For example, when the first line is 
+   // shortened by exactly one character, a CRLF separator's LF character falls 
+   // at the position where an LF-only separator would be expected, making the 
+   // error undetectable by length validation alone.
+   [InlineData("ERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<", _lineSeparatorCrlf)]         // Name length -1 so total length indicates Lf only and Lf falls in correct position
+   [InlineData("ERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<", _lineSeparatorLf)]           // Name length -1 so total length indicates no separator so separator chars not checked
+   public void Icao9303SizeTD3Algorithm_Validate_ShouldReturnTrue_WhenUndetectableInvalidSeparator(
+      String name,
+      String lineSeparator)
+   {
+      // Arrange.
+      var value = GetTestValue(name: name, lineSeparator: lineSeparator);
+
+      // Act/assert.
+      _sut.Validate(value).Should().BeTrue();
+   }
+
+   [Theory]
    [InlineData(_lineSeparatorNone)]
    [InlineData(_lineSeparatorCrlf)]
    [InlineData(_lineSeparatorLf)]

--- a/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303SizeTD3AlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303SizeTD3AlgorithmTests.cs
@@ -187,7 +187,7 @@ public class Icao9303SizeTD3AlgorithmTests
    [InlineData("00x0000003", "4")]
    [InlineData("00y0000004", "2")]
    [InlineData("00z0000005", "0")]
-   public void Icao9303SizeTD2Algorithm_Validate_ShouldReturnFalse_WhenLowerCaseAlphabeticCharacterEncountered(
+   public void Icao9303SizeTD3Algorithm_Validate_ShouldReturnFalse_WhenLowerCaseAlphabeticCharacterEncountered(
       String passportNumber,
       String compositeCheckDigit)
    {
@@ -197,6 +197,29 @@ public class Icao9303SizeTD3AlgorithmTests
          passportNumber: passportNumber,
          dateOfBirth: "0000000",
          dateOfExpiry: "0000000",
+         personalNumber: "<<<<<<<<<<<<<<<",
+         compositeCheckDigit: compositeCheckDigit);
+
+      // Act/assert.
+      _sut.Validate(value).Should().BeFalse();
+   }
+
+   [Theory]
+   // Check digits would be correct if alpha characters allowed
+   [InlineData("00A0000", "0000000", "0")]
+   [InlineData("00a0000", "0000000", "0")]
+   [InlineData("0000000", "00A0000", "0")]
+   [InlineData("0000000", "00a0000", "0")]
+   public void Icao9303SizeTD3Algorithm_Validate_ShouldReturnFalse_NumericFieldContainsAlphabeticCharacter(
+      String dateOfBirth,
+      String dateOfExpiry,
+      String compositeCheckDigit)
+   {
+      // Arrange.
+      var value = GetTestValue(
+         passportNumber: "0000000000",
+         dateOfBirth: dateOfBirth,
+         dateOfExpiry: dateOfExpiry,
          personalNumber: "<<<<<<<<<<<<<<<",
          compositeCheckDigit: compositeCheckDigit);
 
@@ -333,6 +356,16 @@ public class Icao9303SizeTD3AlgorithmTests
          dateOfExpiry: dateOfExpiry,
          personalNumber: personalNumber,
          compositeCheckDigit: compositeCheckDigit);
+
+      // Act/assert.
+      _sut.Validate(value).Should().BeFalse();
+   }
+
+   [Fact]
+   public void Icao9303SizeTD3Algorithm_Validate_ShouldReturnFalse_WhenFieldCheckDigitsAreValidButCompositeCheckDigitIsNotValid()
+   {
+      // Arrange.
+      var value = GetTestValue(compositeCheckDigit: "7");   // Composite check digit should be '0' for the default test value
 
       // Act/assert.
       _sut.Validate(value).Should().BeFalse();

--- a/CheckDigits.Net/GlobalUsings.cs
+++ b/CheckDigits.Net/GlobalUsings.cs
@@ -1,4 +1,5 @@
-﻿global using System.Runtime.CompilerServices;
+﻿global using System.Diagnostics.Contracts;
+global using System.Runtime.CompilerServices;
 
 global using CheckDigits.Net.GeneralAlgorithms;
 global using CheckDigits.Net.Iso7064;

--- a/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303Algorithm.cs
+++ b/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303Algorithm.cs
@@ -29,35 +29,14 @@ namespace CheckDigits.Net.ValueSpecificAlgorithms;
 public sealed class Icao9303Algorithm : ISingleCheckDigitAlgorithm
 {
    private static readonly Int32[] _weights = [7, 3, 1];
-   private static readonly Int32[] _charMap = Chars.Range(Chars.DigitZero, Chars.UpperCaseZ)
-      .Select(x => MapCharacter(x))
-      .ToArray();
    private const Int32 _validateMinLength = 2;
+   private const Int32 _numUpperBound = Icao9303Helpers.AlphanumericUpperBound;  // Upper bound for valid character to integer conversion
 
    /// <inheritdoc/>
    public String AlgorithmDescription => Resources.Icao9303AlgorithmDescription;
 
    /// <inheritdoc/>
    public String AlgorithmName => Resources.Icao9303AlgorithmName;
-
-   /// <summary>
-   ///   Map a character to its integer equivalent in the 
-   ///   <see cref="Icao9303Algorithm"/>. Characters that are not valid for the 
-   ///   Icao9303Algorithm are mapped to -1.
-   /// </summary>
-   /// <param name="ch">
-   ///   The character to map.
-   /// </param>
-   /// <returns>
-   ///   The integer value associated with <paramref name="ch"/>.
-   /// </returns>
-   public static Int32 MapCharacter(Char ch) => ch switch
-   {
-      var d when ch >= Chars.DigitZero && ch <= Chars.DigitNine => d.ToIntegerDigit(),
-      var c when ch >= Chars.UpperCaseA && ch <= Chars.UpperCaseZ => c - Chars.UpperCaseA + 10,
-      Chars.LeftAngleBracket => 0,
-      _ => -1
-   };
 
    /// <inheritdoc/>
    public Boolean TryCalculateCheckDigit(String value, out Char checkDigit)
@@ -68,17 +47,13 @@ public sealed class Icao9303Algorithm : ISingleCheckDigitAlgorithm
          return false;
       }
 
-      Char ch;
-      Int32 num;
       var sum = 0;
       var weightIndex = new ModulusInt32(3);
-      for (var charIndex = 0; charIndex < value.Length; charIndex++)
+      var processLength = value.Length;
+      for (var charIndex = 0; charIndex < processLength; charIndex++)
       {
-         ch = value[charIndex];
-         num = (ch >= Chars.DigitZero && ch <= Chars.UpperCaseZ)
-            ? _charMap[ch - Chars.DigitZero]
-            : -1;
-         if (num == -1)
+         var num = Icao9303Helpers.ToIcao9303IntegerValue(value[charIndex]);
+         if (Icao9303Helpers.IsInvalidValueForField(num, _numUpperBound))
          {
             return false;
          }
@@ -99,17 +74,13 @@ public sealed class Icao9303Algorithm : ISingleCheckDigitAlgorithm
          return false;
       }
 
-      Char ch;
-      Int32 num;
       var sum = 0;
       var weightIndex = new ModulusInt32(3);
-      for (var charIndex = 0; charIndex < value.Length - 1; charIndex++)
+      var processLength = value.Length - 1;
+      for (var charIndex = 0; charIndex < processLength; charIndex++)
       {
-         ch = value[charIndex];
-         num = (ch >= Chars.DigitZero && ch <= Chars.UpperCaseZ)
-            ? _charMap[ch - Chars.DigitZero]
-            : -1;
-         if (num == -1)
+         var num = Icao9303Helpers.ToIcao9303IntegerValue(value[charIndex]);
+         if (Icao9303Helpers.IsInvalidValueForField(num, _numUpperBound))
          {
             return false;
          }

--- a/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303Helpers.cs
+++ b/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303Helpers.cs
@@ -1,0 +1,80 @@
+﻿// Ignore Spelling: Icao
+
+namespace CheckDigits.Net.ValueSpecificAlgorithms;
+
+/// <summary>
+///   Shared helper methods and data for ICAO 9303 check digit algorithms.
+/// </summary>
+public static class Icao9303Helpers
+{
+   /// <summary>
+   ///   Represents the maximum allowable integer value when converting a 
+   ///   character in an ICAO 9303 alphanumeric field to its integer equivalent.
+   /// </summary>
+   public const Int32 AlphanumericUpperBound = 35;
+
+   /// <summary>
+   ///   Represents the maximum allowable integer value when converting a 
+   ///   character in an ICAO 9303 numeric field to its integer equivalent.
+   /// </summary>
+   public const Int32 NumericUpperBound = 9;
+
+   /// <summary>
+   ///   Map a character to its integer equivalent in the 
+   ///   <see cref="Icao9303Algorithm"/>. Characters that are not valid for the 
+   ///   Icao9303Algorithm are mapped to -1.
+   /// </summary>
+   /// <param name="ch">
+   ///   The character to map.
+   /// </param>
+   /// <returns>
+   ///   The integer value associated with <paramref name="ch"/>.
+   /// </returns>
+   public static Int32 MapCharacter(Char ch) => ch switch
+   {
+      var d when ch >= Chars.DigitZero && ch <= Chars.DigitNine => d.ToIntegerDigit(),
+      var c when ch >= Chars.UpperCaseA && ch <= Chars.UpperCaseZ => c - Chars.UpperCaseA + 10,
+      Chars.LeftAngleBracket => 0,
+      _ => -1
+   };
+
+   /// <summary>
+   ///   Pre-computed character-to-integer mapping for ICAO 9303 character set.
+   /// </summary>
+   internal static readonly Int32[] CharMap = 
+      [.. Chars.Range(Chars.DigitZero, Chars.UpperCaseZ).Select(MapCharacter)];
+
+   /// <summary>
+   ///   Converts an ICAO 9303 character to its integer equivalent.
+   /// </summary>
+   /// <param name="ch">
+   ///   The character to convert.
+   /// </param>
+   /// <returns>
+   ///   The integer value (0-35) if the character is valid (0-9, A-Z, or '<'), 
+   ///   otherwise -1.
+   /// </returns>
+   [MethodImpl(MethodImplOptions.AggressiveInlining)]
+   internal static Int32 ToIcao9303IntegerValue(Char ch)
+      => (ch >= Chars.DigitZero && ch <= Chars.UpperCaseZ)
+         ? CharMap[ch - Chars.DigitZero]
+         : -1;
+
+   /// <summary>
+   ///   Determines whether an integer value is invalid for a field based on 
+   ///   the field's upper bound constraint.
+   /// </summary>
+   /// <param name="value">
+   ///   The integer value to validate.
+   /// </param>
+   /// <param name="numUpperBound">
+   ///   The upper bound for valid values (9 for numeric fields, 35 for alphanumeric).
+   /// </param>
+   /// <returns>
+   ///   <see langword="true"/> if the value is invalid (less than 0 or greater 
+   ///   than the upper bound); otherwise, <see langword="false"/>.
+   /// </returns>
+   [MethodImpl(MethodImplOptions.AggressiveInlining)]
+   internal static Boolean IsInvalidValueForField(Int32 value, Int32 numUpperBound)
+      => value < 0 || value > numUpperBound;
+}

--- a/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303MachineReadableVisaAlgorithm.cs
+++ b/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303MachineReadableVisaAlgorithm.cs
@@ -21,7 +21,7 @@ namespace CheckDigits.Net.ValueSpecificAlgorithms;
 ///   Valid characters are decimal digits (0-9), uppercase alphabetic characters 
 ///   (A-Z) and a filler character ('<'). Note that characters in positions
 ///   other than the document number, date of birth and date of expiry fields 
-///   (and line separator charactors) are not validated.
+///   (and line separator characters) are not validated.
 ///   </para>
 ///   <para>
 ///   Check digit calculated by the algorithm is a decimal digit (0-9).

--- a/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303MachineReadableVisaAlgorithm.cs
+++ b/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303MachineReadableVisaAlgorithm.cs
@@ -95,17 +95,16 @@ public sealed class Icao9303MachineReadableVisaAlgorithm : ICheckDigitAlgorithm
          return false;
       }
 
-      Char ch;
-      Int32 num;
       for (var fieldIndex = 0; fieldIndex < _numFields; fieldIndex++)
       {
+         Int32 num;
          var fieldSum = 0;
          var fieldWeightIndex = new ModulusInt32(3);
          var start = _fieldStartPositions[fieldIndex] + lineLength + lineSeparatorLength;
          var end = start + _fieldLengths[fieldIndex];
          for (var charIndex = start; charIndex < end; charIndex++)
          {
-            ch = value[charIndex];
+            var ch = value[charIndex];
             num = (ch >= Chars.DigitZero && ch <= Chars.UpperCaseZ)
                ? _charMap[ch - Chars.DigitZero]
                : -1;

--- a/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303MachineReadableVisaAlgorithm.cs
+++ b/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303MachineReadableVisaAlgorithm.cs
@@ -3,13 +3,13 @@
 namespace CheckDigits.Net.ValueSpecificAlgorithms;
 
 /// <summary>
-///   Algorithm used to validate the check digits contained in the machine-readable
-///   zone of ICAO (International Civil Aviation Organization) Machine Readable 
-///   Travel Visas (both format MRV-A and format MRV-B).
+///   Algorithm used to validate the check digits contained in the MRZ (Machine
+///   Readable Zone) of ICAO (International Civil Aviation Organization) Machine 
+///   Readable Travel Visas (both format MRV-A and format MRV-B).
 /// </summary>
 /// <remarks>
 ///   <para>
-///   Validates the following fields in the machine-readable zone:
+///   Validates the following fields in the MRZ:
 ///   <list type="bullet">
 ///      <item>Document number, line 2, characters 1-9, check digit in character 10</item>
 ///      <item>Date of birth, line 2, characters 14-19, check digit in character 20</item>
@@ -36,9 +36,8 @@ public sealed class Icao9303MachineReadableVisaAlgorithm : ICheckDigitAlgorithm
    private static readonly Int32[] _weights = [7, 3, 1];
    private static readonly Int32[] _fieldStartPositions = [0, 13, 21];
    private static readonly Int32[] _fieldLengths = [9, 6, 6];
-   private static readonly Int32[] _charMap = Chars.Range(Chars.DigitZero, Chars.UpperCaseZ)
-      .Select(x => Icao9303Algorithm.MapCharacter(x))
-      .ToArray();
+   private static readonly Int32[] _charMap = 
+      [.. Chars.Range(Chars.DigitZero, Chars.UpperCaseZ).Select(x => Icao9303Algorithm.MapCharacter(x))];
 
    private const Int32 _numFields = 3;
    private const Int32 _formatALineLength = 44;

--- a/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303SizeTD1Algorithm.cs
+++ b/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303SizeTD1Algorithm.cs
@@ -185,9 +185,9 @@ public sealed class Icao9303SizeTD1Algorithm : ICheckDigitAlgorithm
       return lineSeparatorLength switch
       {
          0 => true,
-         2 => value[_lineLength] == Chars.CarriageReturn && value[_lineLength + 1] == Chars.LineFeed &&    // Expect CRLF at positions 31-32 and 62-63
+         2 => value[_lineLength] == Chars.CarriageReturn && value[_lineLength + 1] == Chars.LineFeed &&    // Expect CRLF at positions 30-31 and 62-63 (zero based)
               value[(_lineLength * 2) + 2] == Chars.CarriageReturn && value[(_lineLength * 2) + 3] == Chars.LineFeed,
-         1 => value[_lineLength] == Chars.LineFeed && value[(_lineLength * 2) + 1] == Chars.LineFeed,      // Expect LF at position 31 and 62
+         1 => value[_lineLength] == Chars.LineFeed && value[(_lineLength * 2) + 1] == Chars.LineFeed,      // Expect LF at position 30 and 61 (zero based)
          - 1 => false
       };
 #pragma warning restore CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).

--- a/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303SizeTD1Algorithm.cs
+++ b/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303SizeTD1Algorithm.cs
@@ -93,19 +93,17 @@ public sealed class Icao9303SizeTD1Algorithm : ICheckDigitAlgorithm
          return false;
       }
 
-      Char ch;
-      Int32 num;
       var compositeSum = 0;
       var compositeWeightIndex = new ModulusInt32(3);
       for (var fieldIndex = 0; fieldIndex < _numFields; fieldIndex++)
       {
+         Int32 num;
          var fieldSum = 0;
          var fieldWeightIndex = new ModulusInt32(3);
          var (start, end) = _fields[fieldIndex].GetFieldBounds(lineSeparatorLength);
          for (var charIndex = start; charIndex < end; charIndex++)
          {
-            ch = value[charIndex];
-            num = ToIcao9303IntegerValue(ch);
+            num = ToIcao9303IntegerValue(value[charIndex]);
             if (num == -1)
             {
                return false;
@@ -138,8 +136,7 @@ public sealed class Icao9303SizeTD1Algorithm : ICheckDigitAlgorithm
                   break;
                }
 
-               ch = value[charIndex];
-               num = ToIcao9303IntegerValue(ch);
+               num = ToIcao9303IntegerValue(value[charIndex]);
                if (num == -1)
                {
                   return false;

--- a/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303SizeTD1Algorithm.cs
+++ b/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303SizeTD1Algorithm.cs
@@ -21,10 +21,12 @@ namespace CheckDigits.Net.ValueSpecificAlgorithms;
 ///   </para>
 ///   <para>
 ///   Valid characters are decimal digits (0-9), uppercase alphabetic characters 
-///   (A-Z) and a filler character ('<'). Note that characters in positions
-///   other than the document number, date of birth and date of expiry fields 
-///   plus the composite check digit (and line separator characters) are not 
-///   validated.
+///   (A-Z) and a filler character ('<') for the document number/document number
+///   extension fields and decimal digits (0-9) and filler character ('<') for
+///   date of birth and date of expiry fields. Valid characters for check digits
+///   are decimal digits (0-9). Note that characters in positions other than the 
+///   document number, date of birth and date of expiry fields plus the 
+///   composite check digit (and line separator characters) are not validated.
 ///   </para>
 ///   <para>
 ///   Check digit calculated by the algorithm is a decimal digit (0-9).

--- a/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303SizeTD1Algorithm.cs
+++ b/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303SizeTD1Algorithm.cs
@@ -1,5 +1,7 @@
 ﻿// Ignore Spelling: Icao
 
+using System.Diagnostics.Contracts;
+
 namespace CheckDigits.Net.ValueSpecificAlgorithms;
 
 /// <summary>
@@ -16,11 +18,15 @@ namespace CheckDigits.Net.ValueSpecificAlgorithms;
 ///      <item>Date of birth, line 2, characters 1-6, check digit in character 7</item>
 ///      <item>Date of expiry, line 2, characters 9-14, check digit in character 15</item>
 ///      <item>Composite check digit for all of the above fields and their check digits</item>
+///      <item>Line separator characters in expected location, if length of the value indicates that a line separator was used</item>
 ///   </list>
 ///   </para>
 ///   <para>
 ///   Valid characters are decimal digits (0-9), uppercase alphabetic characters 
-///   (A-Z) and a filler character ('<').
+///   (A-Z) and a filler character ('<'). Note that characters in positions
+///   other than the document number, date of birth and date of expiry fields 
+///   plus the composite check digit (and line separator characters) are not 
+///   validated.
 ///   </para>
 ///   <para>
 ///   Check digit calculated by the algorithm is a decimal digit (0-9).
@@ -33,7 +39,7 @@ namespace CheckDigits.Net.ValueSpecificAlgorithms;
 public sealed class Icao9303SizeTD1Algorithm : ICheckDigitAlgorithm
 {
    private static readonly Int32[] _weights = [7, 3, 1];
-   private static readonly FieldDetails[] _fields = [
+   private static readonly FieldDetails[] _fields = [  // line #, starting position, field length
       new (0, 5, 9),    // Document number field
       new (1, 0, 6),    // Date of birth field
       new (1, 8, 6)];   // Date of expiry field
@@ -45,9 +51,12 @@ public sealed class Icao9303SizeTD1Algorithm : ICheckDigitAlgorithm
       .Select(x => Icao9303Algorithm.MapCharacter(x))
       .ToArray();
 
+   private const Int32 _nullSeparatorLength = _lineLength * 3;
+   private const Int32 _crLfSeparatorLength = _nullSeparatorLength + 4;    //  "\r\n" * 2
+   private const Int32 _lfSeparatorLength = _nullSeparatorLength + 2;      // "\n" * 2
+
+   // Only retained for obsolete LineSeparator property.
    private LineSeparator _lineSeparator = LineSeparator.None;
-   private Int32 _lineSeparatorLength = 0;
-   private Int32 _expectedLength = _lineLength * 3;
 
    /// <inheritdoc/>
    public String AlgorithmDescription => Resources.Icao9303SizeTD1AlgorithmDescription;
@@ -63,6 +72,8 @@ public sealed class Icao9303SizeTD1Algorithm : ICheckDigitAlgorithm
    ///   The value used to set the <see cref="LineSeparator"/> property is not
    ///   a defined member of the <see cref="LineSeparator"/> enumeration.
    /// </exception>
+   [Obsolete("The LineSeparator property is deprecated and will be removed in a future version. " +
+             "The algorithm will automatically detect the line separator used in the value being validated.")]
    public LineSeparator LineSeparator
    {
       get => _lineSeparator;
@@ -74,15 +85,13 @@ public sealed class Icao9303SizeTD1Algorithm : ICheckDigitAlgorithm
          }
 
          _lineSeparator = value;
-         _lineSeparatorLength = value.CharacterLength();
-         _expectedLength = (_lineLength * 3) + (_lineSeparatorLength * 2);
       }
    }
 
    /// <inheritdoc/>
    public Boolean Validate(String value)
    {
-      if (String.IsNullOrEmpty(value) || value.Length != _expectedLength)
+      if (String.IsNullOrEmpty(value) || !TryValidateLength(value, out var lineSeparatorLength))
       {
          return false;
       }
@@ -95,9 +104,7 @@ public sealed class Icao9303SizeTD1Algorithm : ICheckDigitAlgorithm
       {
          var fieldSum = 0;
          var fieldWeightIndex = new ModulusInt32(3);
-         var (line, charPos, length) = _fields[fieldIndex];
-         var start = (line * (_lineLength + _lineSeparatorLength)) + charPos;
-         var end = start + length;
+         var (start, end) = _fields[fieldIndex].GetFieldBounds(lineSeparatorLength);
          for (var charIndex = start; charIndex < end; charIndex++)
          {
             ch = value[charIndex];
@@ -121,11 +128,21 @@ public sealed class Icao9303SizeTD1Algorithm : ICheckDigitAlgorithm
          // note j on page 17 for details.
          if (fieldIndex == 0 && value[end] == Chars.LeftAngleBracket)
          {
-            (line, charPos, length) = _extendedDocumentNumber;
-            start = (line * (_lineLength + _lineSeparatorLength)) + charPos;
-            end = start + length;
+            (start, end) = _extendedDocumentNumber.GetFieldBounds(lineSeparatorLength);
             for (var charIndex = start; charIndex < end; charIndex++)
             {
+               // Stop processing if we've reached the check digit character
+               // before reaching the end of the field.  This is signaled by the
+               // next character after the check digit character being a filler
+               // character ('<'). This means we test by looking ahead by one
+               // character. (The definition of _extendedDocumentNumber ensures
+               // that the one character look ahead will always be in bounds.)
+               if (value[charIndex + 1] == Chars.LeftAngleBracket)
+               {
+                  end = charIndex;
+                  break;
+               }
+
                ch = value[charIndex];
                num = (ch >= Chars.DigitZero && ch <= Chars.UpperCaseZ)
                   ? _charMap[ch - Chars.DigitZero]
@@ -140,22 +157,12 @@ public sealed class Icao9303SizeTD1Algorithm : ICheckDigitAlgorithm
 
                compositeSum += num * _weights[compositeWeightIndex];
                compositeWeightIndex++;
-
-               if (value[charIndex + 2] == Chars.LeftAngleBracket)
-               {
-                  end = charIndex + 1;
-                  break;
-               }
             }
          }
 
          // Field check digit.
-         ch = value[end];
-         if (ch >= Chars.DigitZero && ch <= Chars.DigitNine)
-         {
-            num = ch.ToIntegerDigit();
-         }
-         else
+         num = value[end].ToIntegerDigit();
+         if (num.IsInvalidDigit())
          {
             return false;
          }
@@ -169,8 +176,52 @@ public sealed class Icao9303SizeTD1Algorithm : ICheckDigitAlgorithm
       }
 
       var compositeCheckDigit = compositeSum % 10;
-      return value[_compositeCheckDigitPosition + _lineSeparatorLength].ToIntegerDigit() == compositeCheckDigit;
+      return value[_compositeCheckDigitPosition + lineSeparatorLength].ToIntegerDigit() == compositeCheckDigit;
    }
 
-   private record struct FieldDetails(Int32 Line, Int32 CharPosition, Int32 Length);
+   private static Boolean TryValidateLength(String value, out Int32 lineSeparatorLength)
+   {
+      lineSeparatorLength = value.Length switch
+      {
+         _nullSeparatorLength => 0,
+         _crLfSeparatorLength => 2,
+         _lfSeparatorLength => 1,
+         _ => -1
+      };
+
+      if (lineSeparatorLength == -1)
+      {
+         return false;
+      }
+
+      // Validate separator characters if present
+      if (lineSeparatorLength == 2)
+      {
+         // Should have \r\n at positions 30 and 61
+         return value[_lineLength] == Chars.CarriageReturn
+                && value[_lineLength + 1] == Chars.LineFeed
+                && value[_lineLength * 2 + 2] == Chars.CarriageReturn
+                && value[_lineLength * 2 + 3] == Chars.LineFeed;
+      }
+      else if (lineSeparatorLength == 1)
+      {
+         // Should have \n at positions 30 and 61
+         return value[_lineLength] == Chars.LineFeed
+                && value[_lineLength * 2 + 1] == Chars.LineFeed;
+      }
+
+      return true;  // No separator to validate
+   }
+
+   private record struct FieldDetails(Int32 Line, Int32 CharPosition, Int32 Length)
+   {
+      [Pure]
+      public (Int32 start, Int32 end) GetFieldBounds(Int32 lineSeparatorLength)
+      {
+         var start = (Line * (_lineLength + lineSeparatorLength)) + CharPosition;
+         var end = start + Length;
+
+         return (start, end);
+      }
+   }
 }

--- a/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303SizeTD2Algorithm.cs
+++ b/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303SizeTD2Algorithm.cs
@@ -20,10 +20,12 @@ namespace CheckDigits.Net.ValueSpecificAlgorithms;
 ///   </para>
 ///   <para>
 ///   Valid characters are decimal digits (0-9), uppercase alphabetic characters 
-///   (A-Z) and a filler character ('<'). Note that characters in positions
-///   other than the document number, date of birth and date of expiry fields 
-///   plus the composite check digit (and line separator characters) are not 
-///   validated.
+///   (A-Z) and a filler character ('<') for the document number/document number
+///   extension fields and decimal digits (0-9) and filler character ('<') for
+///   date of birth and date of expiry fields. Valid characters for check digits
+///   are decimal digits (0-9). Note that characters in positions other than the 
+///   document number, date of birth and date of expiry fields plus the 
+///   composite check digit (and line separator characters) are not validated.
 ///   </para>
 ///   <para>
 ///   Check digit calculated by the algorithm is a decimal digit (0-9).
@@ -41,9 +43,8 @@ public sealed class Icao9303SizeTD2Algorithm : ICheckDigitAlgorithm
       new (13, 6, 9),    // Date of birth field
       new (21, 6, 9)];   // Date of expiry field
    private static readonly FieldDetails _extendedDocumentNumber = new(28, 5, 35);
-   private static readonly Int32[] _charMap = Chars.Range(Chars.DigitZero, Chars.UpperCaseZ)
-      .Select(x => Icao9303Algorithm.MapCharacter(x))
-      .ToArray();
+   private static readonly Int32[] _charMap = 
+      [.. Chars.Range(Chars.DigitZero, Chars.UpperCaseZ).Select(x => Icao9303Algorithm.MapCharacter(x))];
 
    private const Int32 _numFields = 3;
    private const Int32 _lineLength = 36;

--- a/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303SizeTD2Algorithm.cs
+++ b/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303SizeTD2Algorithm.cs
@@ -3,13 +3,13 @@
 namespace CheckDigits.Net.ValueSpecificAlgorithms;
 
 /// <summary>
-///   Algorithm used to validate the check digits contained in the machine readable
-///   zone of ICAO (International Civil Aviation Organization) Machine Readable 
-///   Travel Document Size TD2.
+///   Algorithm used to validate the check digits contained in the MRZ (Machine 
+///   Readable Zone) of ICAO (International Civil Aviation Organization) Machine 
+///   Readable Travel Document Size TD2.
 /// </summary>
 /// <remarks>
 ///   <para>
-///   Validates the following fields in the machine readable zone:
+///   Validates the following fields in the MRZ:
 ///   <list type="bullet">
 ///      <item>Document number, line 2, characters 1-9, check digit in character 10</item>
 ///      <item>Optional document number extension, line 2, characters 29-35, check digit in final non-filler character</item>
@@ -20,7 +20,10 @@ namespace CheckDigits.Net.ValueSpecificAlgorithms;
 ///   </para>
 ///   <para>
 ///   Valid characters are decimal digits (0-9), uppercase alphabetic characters 
-///   (A-Z) and a filler character ('<').
+///   (A-Z) and a filler character ('<'). Note that characters in positions
+///   other than the document number, date of birth and date of expiry fields 
+///   plus the composite check digit (and line separator characters) are not 
+///   validated.
 ///   </para>
 ///   <para>
 ///   Check digit calculated by the algorithm is a decimal digit (0-9).
@@ -33,19 +36,24 @@ namespace CheckDigits.Net.ValueSpecificAlgorithms;
 public sealed class Icao9303SizeTD2Algorithm : ICheckDigitAlgorithm
 {
    private static readonly Int32[] _weights = [7, 3, 1];
-   private static readonly Int32[] _fieldStartPositions = [0, 13, 21];
-   private static readonly Int32[] _fieldSLengths = [9, 6, 6];
+   private static readonly FieldDetails[] _fields = [  // starting position, field length, valid num upper bound
+      new (0, 9, 35),    // Document number field
+      new (13, 6, 9),    // Date of birth field
+      new (21, 6, 9)];   // Date of expiry field
+   private static readonly FieldDetails _extendedDocumentNumber = new(28, 5, 35);
    private static readonly Int32[] _charMap = Chars.Range(Chars.DigitZero, Chars.UpperCaseZ)
       .Select(x => Icao9303Algorithm.MapCharacter(x))
       .ToArray();
-   private const Int32 _extendedDocumentNumberStart = 28;
-   private const Int32 _extendedDocumentNumberLength = 5;
 
    private const Int32 _numFields = 3;
    private const Int32 _lineLength = 36;
+
+   private const Int32 _nullSeparatorLength = _lineLength * 2;
+   private const Int32 _crLfSeparatorLength = _nullSeparatorLength + 2;    // + "\r\n"
+   private const Int32 _lfSeparatorLength = _nullSeparatorLength + 1;      // + "\n"
+
+   // Only retained for obsolete LineSeparator property.
    private LineSeparator _lineSeparator = LineSeparator.None;
-   private Int32 _lineSeparatorLength = 0;
-   private Int32 _expectedLength = _lineLength * 2;
 
    /// <inheritdoc/>
    public String AlgorithmDescription => Resources.Icao9303SizeTD2AlgorithmDescription;
@@ -61,6 +69,8 @@ public sealed class Icao9303SizeTD2Algorithm : ICheckDigitAlgorithm
    ///   The value used to set the <see cref="LineSeparator"/> property is not
    ///   a defined member of the <see cref="LineSeparator"/> enumeration.
    /// </exception>
+   [Obsolete("The LineSeparator property is deprecated and will be removed in a future version. " +
+             "The algorithm will automatically detect the line separator used in the value being validated.")]
    public LineSeparator LineSeparator
    {
       get => _lineSeparator;
@@ -72,36 +82,30 @@ public sealed class Icao9303SizeTD2Algorithm : ICheckDigitAlgorithm
          }
 
          _lineSeparator = value;
-         _lineSeparatorLength = value.CharacterLength();
-         _expectedLength = (_lineLength * 2) + _lineSeparatorLength;
       }
    }
 
    /// <inheritdoc/>
    public Boolean Validate(String value)
    {
-      if (String.IsNullOrEmpty(value) || value.Length != _expectedLength)
+      if (String.IsNullOrEmpty(value) || !TryValidateLength(value, out var lineSeparatorLength))
       {
          return false;
       }
 
-      Char ch;
-      Int32 num;
       var compositeSum = 0;
       var compositeWeightIndex = new ModulusInt32(3);
       for (var fieldIndex = 0; fieldIndex < _numFields; fieldIndex++)
       {
+         Int32 num;
          var fieldSum = 0;
          var fieldWeightIndex = new ModulusInt32(3);
-         var start = _fieldStartPositions[fieldIndex] + _lineLength + _lineSeparatorLength;
-         var end = start + _fieldSLengths[fieldIndex];
+         var (start, end) = _fields[fieldIndex].GetFieldBounds(lineSeparatorLength);
+         var numUpperBound = _fields[fieldIndex].NumUpperBound;
          for (var charIndex = start; charIndex < end; charIndex++)
          {
-            ch = value[charIndex];
-            num = (ch >= Chars.DigitZero && ch <= Chars.UpperCaseZ)
-               ? _charMap[ch - Chars.DigitZero]
-               : -1;
-            if (num == -1)
+            num = ToIcao9303IntegerValue(value[charIndex]);
+            if (IsInvalidValueForField(num, numUpperBound))
             {
                return false;
             }
@@ -118,15 +122,24 @@ public sealed class Icao9303SizeTD2Algorithm : ICheckDigitAlgorithm
          // note j on page 16 for details.
          if (fieldIndex == 0 && value[end] == Chars.LeftAngleBracket)
          {
-            start = _extendedDocumentNumberStart + _lineLength + _lineSeparatorLength;
-            end = start + _extendedDocumentNumberLength;
+            (start, end) = _extendedDocumentNumber.GetFieldBounds(lineSeparatorLength);
+            numUpperBound = _extendedDocumentNumber.NumUpperBound;
             for (var charIndex = start; charIndex < end; charIndex++)
             {
-               ch = value[charIndex];
-               num = (ch >= Chars.DigitZero && ch <= Chars.UpperCaseZ)
-                  ? _charMap[ch - Chars.DigitZero]
-                  : -1;
-               if (num == -1)
+               // Stop processing if we've reached the check digit character
+               // early (i.e. before reaching the end of the field).  This is
+               // signaled by the next character after the check digit character
+               // being a filler character ('<'). This means we test by looking
+               // ahead by one character. (The definition of _extendedDocumentNumber
+               // ensures that the one character look ahead will always be in bounds.)
+               if (value[charIndex + 1] == Chars.LeftAngleBracket)
+               {
+                  end = charIndex;
+                  break;
+               }
+
+               num = ToIcao9303IntegerValue(value[charIndex]);
+               if (IsInvalidValueForField(num, numUpperBound))
                {
                   return false;
                }
@@ -136,22 +149,12 @@ public sealed class Icao9303SizeTD2Algorithm : ICheckDigitAlgorithm
 
                compositeSum += num * _weights[compositeWeightIndex];
                compositeWeightIndex++;
-
-               if (value[charIndex + 2] == Chars.LeftAngleBracket)
-               {
-                  end = charIndex + 1;
-                  break;
-               }
             }
          }
 
          // Field check digit.
-         ch = value[end];
-         if (ch >= Chars.DigitZero && ch <= Chars.DigitNine)
-         {
-            num = ch.ToIntegerDigit();
-         }
-         else
+         num = value[end].ToIntegerDigit();
+         if (num.IsInvalidDigit())
          {
             return false;
          }
@@ -167,5 +170,73 @@ public sealed class Icao9303SizeTD2Algorithm : ICheckDigitAlgorithm
       var compositeCheckDigit = compositeSum % 10;
 
       return value[^1].ToIntegerDigit() == compositeCheckDigit;
+   }
+
+   [MethodImpl(MethodImplOptions.AggressiveInlining)]
+   private static Int32 ToIcao9303IntegerValue(Char ch)
+      => (ch >= Chars.DigitZero && ch <= Chars.UpperCaseZ)
+         ? _charMap[ch - Chars.DigitZero]
+         : -1;
+
+   [MethodImpl(MethodImplOptions.AggressiveInlining)]
+   private static Boolean IsInvalidValueForField(Int32 value, Int32 numUpperBound)
+      => value < 0 || value > numUpperBound;
+
+   private static Boolean TryValidateLength(String value, out Int32 lineSeparatorLength)
+   {
+      lineSeparatorLength = value.Length switch
+      {
+         _nullSeparatorLength => 0,
+         _crLfSeparatorLength => 2,
+         _lfSeparatorLength => 1,
+         _ => -1
+      };
+
+      if (lineSeparatorLength == -1)
+      {
+         return false;
+      }
+
+      // Validate separator characters if present
+      if (lineSeparatorLength == 2)
+      {
+         // Should have \r\n at positions 37
+         return value[_lineLength] == Chars.CarriageReturn
+                && value[_lineLength + 1] == Chars.LineFeed;
+      }
+      else if (lineSeparatorLength == 1)
+      {
+         // Should have \n at positions 37
+         return value[_lineLength] == Chars.LineFeed;
+      }
+
+      return true;  // No separator to validate
+   }
+
+   /// <summary>
+   ///   Represents the positional and size information for a field within a 
+   ///   data line, including its starting character position, length, and the 
+   ///   upper bound of a field character when converted to an integer.
+   /// </summary>
+   /// <param name="CharPosition">
+   ///   The zero-based character position at which the field begins within the line.
+   /// </param>
+   /// <param name="Length">
+   ///   The number of characters that make up the field.
+   /// </param>
+   /// <param name="NumUpperBound">
+   ///   The upper bound of a field character when converted to an integer.
+   /// </param>
+   private record struct FieldDetails(Int32 CharPosition, Int32 Length, Int32 NumUpperBound)
+   {
+      [Pure]
+      public readonly (Int32 start, Int32 end) GetFieldBounds(Int32 lineSeparatorLength)
+      {
+         // Always add _lineLength because all fields are on the second line of data.
+         var start = _lineLength + lineSeparatorLength + CharPosition;
+         var end = start + Length;
+
+         return (start, end);
+      }
    }
 }

--- a/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303SizeTD2Algorithm.cs
+++ b/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303SizeTD2Algorithm.cs
@@ -185,8 +185,8 @@ public sealed class Icao9303SizeTD2Algorithm : ICheckDigitAlgorithm
       return lineSeparatorLength switch
       {
          0 => true,
-         2 => value[_lineLength] == Chars.CarriageReturn && value[_lineLength + 1] == Chars.LineFeed,    // Expect CRLF at positions 37 and 38
-         1 => value[_lineLength] == Chars.LineFeed,                                                      // Expect LF at position 37
+         2 => value[_lineLength] == Chars.CarriageReturn && value[_lineLength + 1] == Chars.LineFeed,    // Expect CRLF at positions 36 and 37 (zero based)
+         1 => value[_lineLength] == Chars.LineFeed,                                                      // Expect LF at position 36 (zero based)
          -1 => false
       };
 #pragma warning restore CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).

--- a/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303SizeTD3Algorithm.cs
+++ b/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303SizeTD3Algorithm.cs
@@ -205,8 +205,8 @@ public sealed class Icao9303SizeTD3Algorithm : ICheckDigitAlgorithm
       return lineSeparatorLength switch
       {
          0 => true,
-         2 => value[_lineLength] == Chars.CarriageReturn && value[_lineLength + 1] == Chars.LineFeed,    // Expect CRLF at positions 37 and 38
-         1 => value[_lineLength] == Chars.LineFeed,                                                      // Expect LF at position 37
+         2 => value[_lineLength] == Chars.CarriageReturn && value[_lineLength + 1] == Chars.LineFeed,    // Expect CRLF at positions 44 and 45 (zero based)
+         1 => value[_lineLength] == Chars.LineFeed,                                                      // Expect LF at position 44 (zero based)
          -1 => false
       };
 #pragma warning restore CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).

--- a/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303SizeTD3Algorithm.cs
+++ b/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303SizeTD3Algorithm.cs
@@ -27,7 +27,13 @@ namespace CheckDigits.Net.ValueSpecificAlgorithms;
 ///   </para>
 ///   <para>
 ///   Valid characters are decimal digits (0-9), uppercase alphabetic characters 
-///   (A-Z) and a filler character ('<').
+///   (A-Z) and a filler character ('<') for the document number/document number
+///   extension fields and optional person number field. The date of birth and
+///   date of expiry allow decimal digits (0-9) and filler character ('<') as
+///   valid characters. Check digits only allow decimal digits (0-9). Note that 
+///   characters in positions other than the document number, person number, 
+///   date of birth and date of expiry fields plus the composite check digit (and 
+///   line separator characters) are not validated.
 ///   </para>
 ///   <para>
 ///   Check digit calculated by the algorithm is a decimal digit (0-9).
@@ -40,14 +46,22 @@ namespace CheckDigits.Net.ValueSpecificAlgorithms;
 public sealed class Icao9303SizeTD3Algorithm : ICheckDigitAlgorithm
 {
    private static readonly Int32[] _weights = [7, 3, 1];
-   private static readonly Int32[] _fieldStartPositions = [0, 13, 21, 28];
-   private static readonly Int32[] _fieldSLengths = [9, 6, 6, 14];
-   private const Int32 _numFields = 4;
-   private const Int32 _lineLength = 44;
-   private static readonly Int32[] _charMap = Chars.Range(Chars.DigitZero, Chars.UpperCaseZ)
-      .Select(x => Icao9303Algorithm.MapCharacter(x))
-      .ToArray();
+   private static readonly FieldDetails[] _requiredFields = [  // starting position, field length, valid num upper bound
+      new (0, 9, 35),    // Document number field
+      new (13, 6, 9),    // Date of birth field
+      new (21, 6, 9)];   // Date of expiry field
+   private static readonly FieldDetails _personalNumberField = new(28, 14, 35);
+   private static readonly Int32[] _charMap = 
+      [.. Chars.Range(Chars.DigitZero, Chars.UpperCaseZ).Select(x => Icao9303Algorithm.MapCharacter(x))];
 
+   private const Int32 _numFields = 3;
+   private const Int32 _lineLength = 44;
+
+   private const Int32 _nullSeparatorLength = _lineLength * 2;
+   private const Int32 _crLfSeparatorLength = _nullSeparatorLength + 2;    // + "\r\n"
+   private const Int32 _lfSeparatorLength = _nullSeparatorLength + 1;      // + "\n"
+
+   // Only retained for obsolete LineSeparator property.
    private LineSeparator _lineSeparator = LineSeparator.None;
 
    /// <inheritdoc/>
@@ -64,6 +78,8 @@ public sealed class Icao9303SizeTD3Algorithm : ICheckDigitAlgorithm
    ///   The value used to set the <see cref="LineSeparator"/> property is not
    ///   a defined member of the <see cref="LineSeparator"/> enumeration.
    /// </exception>
+   [Obsolete("The LineSeparator property is deprecated and will be removed in a future version. " +
+             "The algorithm will automatically detect the line separator used in the value being validated.")]
    public LineSeparator LineSeparator
    {
       get => _lineSeparator;
@@ -81,35 +97,29 @@ public sealed class Icao9303SizeTD3Algorithm : ICheckDigitAlgorithm
    /// <inheritdoc/>
    public Boolean Validate(String value)
    {
-      var lineSeparatorLength = LineSeparator switch
-      {
-         LineSeparator.Crlf => 2,
-         LineSeparator.Lf => 1,
-         _ => 0
-      };
-
-      if (String.IsNullOrEmpty(value) || value.Length != (_lineLength * 2) + lineSeparatorLength)
+      if (String.IsNullOrEmpty(value) || !TryValidateLength(value, out var lineSeparatorLength))
       {
          return false;
       }
 
-      Char ch;
       Int32 num;
+      Int32 start;
+      Int32 end;
+      Int32 numUpperBound;
+      Int32 fieldSum;
+      ModulusInt32 fieldWeightIndex;
       var compositeSum = 0;
       var compositeWeightIndex = new ModulusInt32(3);
       for (var fieldIndex = 0; fieldIndex < _numFields; fieldIndex++)
       {
-         var fieldSum = 0;
-         var fieldWeightIndex = new ModulusInt32(3);
-         var start = _fieldStartPositions[fieldIndex] + _lineLength + lineSeparatorLength;
-         var end = start + _fieldSLengths[fieldIndex];
-         for(var charIndex = start; charIndex < end; charIndex++)
+         fieldSum = 0;
+         fieldWeightIndex = new ModulusInt32(3);
+         (start, end) = _requiredFields[fieldIndex].GetFieldBounds(lineSeparatorLength);
+         numUpperBound = _requiredFields[fieldIndex].NumUpperBound;
+         for (var charIndex = start; charIndex < end; charIndex++)
          {
-            ch = value[charIndex];
-            num = (ch >= Chars.DigitZero && ch <= Chars.UpperCaseZ)
-               ? _charMap[ch - Chars.DigitZero]
-               : -1;
-            if (num == -1)
+            num = ToIcao9303IntegerValue(value[charIndex]);
+            if (IsInvalidValueForField(num, numUpperBound))
             {
                return false;
             }
@@ -121,34 +131,128 @@ public sealed class Icao9303SizeTD3Algorithm : ICheckDigitAlgorithm
             compositeWeightIndex++;
          }
 
-         // Handle field check digit for composite check digit calculations.
-         ch = value[end];
-         if (ch >= Chars.DigitZero && ch <= Chars.DigitNine)
+         // Field check digit.
+         num = value[end].ToIntegerDigit();
+         if (num.IsInvalidDigit())
          {
-            num = ch.ToIntegerDigit();
+            return false;
          }
-         else if (fieldIndex == _numFields - 1 && ch == Chars.LeftAngleBracket)
-         {
-            // Only allowed for final, optional field
-            num = 0;
-         }
-         else
+         if (num != fieldSum % 10)
          {
             return false;
          }
 
          compositeSum += num * _weights[compositeWeightIndex];
          compositeWeightIndex++;
+      }
 
-         // Test field check digit.
-         if (num != fieldSum % 10)
+      // Handle optional personal number. Special handling for field consisting
+      // entirely of filler characters ('<'). In this case the check digit can
+      // be either a filler character or a digit zero.
+      (start, end) = _personalNumberField.GetFieldBounds(lineSeparatorLength);
+      numUpperBound = _personalNumberField.NumUpperBound;
+      fieldSum = 0;
+      fieldWeightIndex = new ModulusInt32(3);
+      var allFillers = true;
+      for (var charIndex = start; charIndex < end; charIndex++)
+      {
+         var ch = value[charIndex];
+         if (ch != Chars.LeftAngleBracket)
+         {
+            allFillers = false;
+         }
+         num = ToIcao9303IntegerValue(ch);
+         if (IsInvalidValueForField(num, numUpperBound))
          {
             return false;
          }
+
+         fieldSum += num * _weights[fieldWeightIndex];
+         fieldWeightIndex++;
+
+         compositeSum += num * _weights[compositeWeightIndex];
+         compositeWeightIndex++;
       }
 
+      var checkDigitChar = value[end];
+      num = allFillers && (checkDigitChar == Chars.LeftAngleBracket || checkDigitChar == Chars.DigitZero)
+         ? 0
+         : checkDigitChar.ToIntegerDigit();
+      if (num.IsInvalidDigit())
+      {
+         return false;
+      }
+      if (num != fieldSum % 10)
+      {
+         return false;
+      }
+
+      compositeSum += num * _weights[compositeWeightIndex];
       var compositeCheckDigit = compositeSum % 10;
       
       return value[^1].ToIntegerDigit() == compositeCheckDigit;
+   }
+
+   [MethodImpl(MethodImplOptions.AggressiveInlining)]
+   private static Int32 ToIcao9303IntegerValue(Char ch)
+      => (ch >= Chars.DigitZero && ch <= Chars.UpperCaseZ)
+         ? _charMap[ch - Chars.DigitZero]
+         : -1;
+
+   [MethodImpl(MethodImplOptions.AggressiveInlining)]
+   private static Boolean IsInvalidValueForField(Int32 value, Int32 numUpperBound)
+      => value < 0 || value > numUpperBound;
+
+   private static Boolean TryValidateLength(String value, out Int32 lineSeparatorLength)
+   {
+      lineSeparatorLength = value.Length switch
+      {
+         _nullSeparatorLength => 0,
+         _crLfSeparatorLength => 2,
+         _lfSeparatorLength => 1,
+         _ => -1
+      };
+
+#pragma warning disable CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
+      return lineSeparatorLength switch
+      {
+         0 => true,
+         2 => value[_lineLength] == Chars.CarriageReturn && value[_lineLength + 1] == Chars.LineFeed,    // Expect CRLF at positions 37 and 38
+         1 => value[_lineLength] == Chars.LineFeed,                                                      // Expect LF at position 37
+         -1 => false
+      };
+#pragma warning restore CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
+   }
+
+   /// <summary>
+   ///   Represents the positional and size information for a field within a 
+   ///   text document, including its line, character position, length, and the 
+   ///   upper bound of a field character when converted to an integer.
+   /// </summary>
+   /// <param name="CharPosition">
+   ///   The zero-based character position within the specified line where the 
+   ///   field starts.
+   /// </param>
+   /// <param name="Length">
+   ///   The number of characters that the field spans, starting from the 
+   ///   specified character position.
+   /// </param>
+   /// <param name="NumUpperBound">
+   ///   The upper bound of a field character when converted to an integer.
+   /// </param>
+   private record struct FieldDetails(
+      Int32 CharPosition, 
+      Int32 Length, 
+      Int32 NumUpperBound)
+   {
+      [Pure]
+      public readonly (Int32 start, Int32 end) GetFieldBounds(Int32 lineSeparatorLength)
+      {
+         // Always add _lineLength because all fields are on the second line of data.
+         var start = _lineLength + lineSeparatorLength + CharPosition;
+         var end = start + Length;
+
+         return (start, end);
+      }
    }
 }

--- a/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303SizeTD3Algorithm.cs
+++ b/CheckDigits.Net/ValueSpecificAlgorithms/Icao9303SizeTD3Algorithm.cs
@@ -47,12 +47,10 @@ public sealed class Icao9303SizeTD3Algorithm : ICheckDigitAlgorithm
 {
    private static readonly Int32[] _weights = [7, 3, 1];
    private static readonly FieldDetails[] _requiredFields = [  // starting position, field length, valid num upper bound
-      new (0, 9, 35),    // Document number field
-      new (13, 6, 9),    // Date of birth field
-      new (21, 6, 9)];   // Date of expiry field
-   private static readonly FieldDetails _personalNumberField = new(28, 14, 35);
-   private static readonly Int32[] _charMap = 
-      [.. Chars.Range(Chars.DigitZero, Chars.UpperCaseZ).Select(x => Icao9303Algorithm.MapCharacter(x))];
+      new (0, 9, Icao9303Helpers.AlphanumericUpperBound),      // Document number field
+      new (13, 6, Icao9303Helpers.NumericUpperBound),          // Date of birth field
+      new (21, 6, Icao9303Helpers.NumericUpperBound)];         // Date of expiry field
+   private static readonly FieldDetails _personalNumberField = new(28, 14, Icao9303Helpers.AlphanumericUpperBound);
 
    private const Int32 _numFields = 3;
    private const Int32 _lineLength = 44;
@@ -118,8 +116,8 @@ public sealed class Icao9303SizeTD3Algorithm : ICheckDigitAlgorithm
          numUpperBound = _requiredFields[fieldIndex].NumUpperBound;
          for (var charIndex = start; charIndex < end; charIndex++)
          {
-            num = ToIcao9303IntegerValue(value[charIndex]);
-            if (IsInvalidValueForField(num, numUpperBound))
+            num = Icao9303Helpers.ToIcao9303IntegerValue(value[charIndex]);
+            if (Icao9303Helpers.IsInvalidValueForField(num, numUpperBound))
             {
                return false;
             }
@@ -161,8 +159,8 @@ public sealed class Icao9303SizeTD3Algorithm : ICheckDigitAlgorithm
          {
             allFillers = false;
          }
-         num = ToIcao9303IntegerValue(ch);
-         if (IsInvalidValueForField(num, numUpperBound))
+         num = Icao9303Helpers.ToIcao9303IntegerValue(ch);
+         if (Icao9303Helpers.IsInvalidValueForField(num, numUpperBound))
          {
             return false;
          }
@@ -192,16 +190,6 @@ public sealed class Icao9303SizeTD3Algorithm : ICheckDigitAlgorithm
       
       return value[^1].ToIntegerDigit() == compositeCheckDigit;
    }
-
-   [MethodImpl(MethodImplOptions.AggressiveInlining)]
-   private static Int32 ToIcao9303IntegerValue(Char ch)
-      => (ch >= Chars.DigitZero && ch <= Chars.UpperCaseZ)
-         ? _charMap[ch - Chars.DigitZero]
-         : -1;
-
-   [MethodImpl(MethodImplOptions.AggressiveInlining)]
-   private static Boolean IsInvalidValueForField(Int32 value, Int32 numUpperBound)
-      => value < 0 || value > numUpperBound;
 
    private static Boolean TryValidateLength(String value, out Int32 lineSeparatorLength)
    {

--- a/README.md
+++ b/README.md
@@ -595,13 +595,14 @@ check digit are all calculated using the [ICAO 9303 Algorithm](#icao-9303-algori
 
 The machine readable zone of a Size TD1 document consists of three lines of 30
 characters. The value passed to the Validate method should contain all lines of
-data concatenated together. You can specify how the lines are separated in the
-concatenated value by setting the LineSeparator property of the algorithm class.
-The three values are None (no line separator is used and the 31st character of the
-value is the first character of the second line), Crlf (the Windows line separator,
-i.e. a carriage return character followed by a line feed character - '\r\n') and 
-Lf (the Unix line separator, i.e a line feed character - '\n').The default 
-LineSeparator is None.
+data concatenated together. You may optionally use line separator characters in 
+the concatenated value, either the Windows line separator (a carriage return 
+character followed by a line feed character - '\r\n') or the Unix line separator 
+(a line feed character - '\n'). The ICAO 9303 Document Size TD1 algorithm will
+determine the line separator used from the length the value passed to the Validate 
+method - 90 characters for no line separators, 94 characters for Windows line 
+separators and 92 characters for Unix line separators. If the length of the value 
+does not match one of these lengths then the Validate method will return `false`.
 
 The ICAO 9303 Document Size TD1 Algorithm will validate the check digits of the
 three fields (document number, date of birth and date of expiry) as well as the 
@@ -613,7 +614,9 @@ digits and does not support calculation of check digits.
 
 #### Details
 
-* Valid characters - decimal digits ('0' - '9'), upper case letters ('A' - 'Z') and a filler character ('<').
+* Valid characters - 
+  * decimal digits ('0' - '9'), upper case letters ('A' - 'Z') and a filler character ('<') for document number/extended document number field
+  * decimal digits ('0' - '9') and a filler character ('<') for date of birth and date of expiry fields
 * Check digit size - one character
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - trailing (right-most) character of individual fields, trailing character of second line for composite check digit
@@ -638,13 +641,14 @@ calculated using the [ICAO 9303 Algorithm](#icao-9303-algorithm).
 
 The machine readable zone of a Size TD2 document consists of two lines of 36
 characters. The value passed to the Validate method should contain all lines of
-data concatenated together. You can specify how the lines are separated in the
-concatenated value by setting the LineSeparator property of the algorithm class.
-The three values are None (no line separator is used and the 37th character of the
-value is the first character of the second line), Crlf (the Windows line separator,
-i.e. a carriage return character followed by a line feed character - '\r\n') and 
-Lf (the Unix line separator, i.e a line feed character - '\n').The default 
-LineSeparator is None.
+data concatenated together. You may optionally use line separator characters in 
+the concatenated value, either the Windows line separator (a carriage return 
+character followed by a line feed character - '\r\n') or the Unix line separator 
+(a line feed character - '\n'). The ICAO 9303 Document Size TD2 algorithm will
+determine the line separator used from the length the value passed to the Validate 
+method - 72 characters for no line separators, 74 characters for Windows line 
+separators and 73 characters for Unix line separators. If the length of the value 
+does not match one of these lengths then the Validate method will return `false`.
 
 The ICAO 9303 Document Size TD2 Algorithm will validate the check digits of the
 three fields (document number, date of birth and date of expiry) as well as the 
@@ -656,7 +660,9 @@ digits and does not support calculation of check digits.
 
 #### Details
 
-* Valid characters - decimal digits ('0' - '9'), upper case letters ('A' - 'Z') and a filler character ('<').
+* Valid characters - 
+  * decimal digits ('0' - '9'), upper case letters ('A' - 'Z') and a filler character ('<') for document number/extended document number field
+  * decimal digits ('0' - '9') and a filler character ('<') for date of birth and date of expiry fields
 * Check digit size - one character
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - trailing (right-most) character of individual fields, trailing character of second line for composite check digit
@@ -683,13 +689,14 @@ is also calculated using the [ICAO 9303 Algorithm](#icao-9303-algorithm).
 
 The machine readable zone of a Size TD3 document consists of two lines of 44
 characters. The value passed to the Validate method should contain both lines of
-data concatenated together. You can specify how the lines are separated in the
-concatenated value by setting the LineSeparator property of the algorithm class.
-The three values are None (no line separator is used and the 45th character of the
-value is the first character of the second line), Crlf (the Windows line separator,
-i.e. a carriage return character followed by a line feed character - '\r\n') and 
-Lf (the Unix line separator, i.e a line feed character - '\n').The default 
-LineSeparator is None.
+data concatenated together. You may optionally use line separator characters in 
+the concatenated value, either the Windows line separator (a carriage return 
+character followed by a line feed character - '\r\n') or the Unix line separator 
+(a line feed character - '\n'). The ICAO 9303 Document Size TD3 algorithm will
+determine the line separator used from the length the value passed to the Validate 
+method - 88 characters for no line separators, 90 characters for Windows line 
+separators and 89 characters for Unix line separators. If the length of the value 
+does not match one of these lengths then the Validate method will return `false`.
 
 The ICAO 9303 Document Size TD3 Algorithm will validate the check digits of the
 four fields (passport number, date of birth, date of expiry and optional personal
@@ -701,7 +708,9 @@ digits and does not support calculation of check digits.
 
 #### Details
 
-* Valid characters - decimal digits ('0' - '9'), upper case letters ('A' - 'Z') and a filler character ('<').
+* Valid characters - 
+  * decimal digits ('0' - '9'), upper case letters ('A' - 'Z') and a filler character ('<') for document number/extended document number field
+  * decimal digits ('0' - '9') and a filler character ('<') for date of birth and date of expiry fields
 * Check digit size - one character
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - trailing (right-most) character of individual fields, trailing character of entire string for composite check digit
@@ -728,17 +737,21 @@ Machine Readable Visas have two formats: MRV-A and MRV-B. The MRV-A format uses
 two lines of 44 characters while the MRV-B format uses two lines of 36 characters.
 The individual fields in the second line of the machine readable zone are located
 in the same character positions regardless of the format. The Validate method
-can validate either format.
+can validate either format and the algorithm will determine the format from the 
+length of the value passed to the Validate method.
 
 The machine readable zone of a Machine Readable Visa consists of two lines of 36
 characters. The value passed to the Validate method should contain all lines of
-data concatenated together. You can specify how the lines are separated in the
-concatenated value by setting the LineSeparator property of the algorithm class.
-The three values are None (no line separator is used and the 37th character of the
-value is the first character of the second line), Crlf (the Windows line separator,
-i.e. a carriage return character followed by a line feed character - '\r\n') and 
-Lf (the Unix line separator, i.e a line feed character - '\n').The default 
-LineSeparator is None.
+data concatenated together. You may optionally use line separator characters in 
+the concatenated value, either the Windows line separator (a carriage return 
+character followed by a line feed character - '\r\n') or the Unix line separator 
+(a line feed character - '\n'). The ICAO 9303 Machine Readable Visa algorithm will
+determine the line separator used from the length the value passed to the Validate 
+method - 88 characters (MRV-A) or 72 characters (MRV-B) for no line separators, 
+90 characters (MRV-A) or 74 characters (MRV-B) for Windows line separators and 
+89 characters (MRV-A) or 73 characters (MRV-B) for Unix line separators. If the 
+length of the value does not match one of these lengths then the Validate method 
+will return `false`.
 
 The ICAO 9303 Machine Readable Visa Algorithm will validate the check digits of 
 the three fields (document number, date of birth and date of expiry). If any of 
@@ -752,7 +765,9 @@ digits and does not support calculation of check digits.
 
 #### Details
 
-* Valid characters - decimal digits ('0' - '9'), upper case letters ('A' - 'Z') and a filler character ('<').
+* Valid characters - 
+  * decimal digits ('0' - '9'), upper case letters ('A' - 'Z') and a filler character ('<') for document number/extended document number field
+  * decimal digits ('0' - '9') and a filler character ('<') for date of birth and date of expiry fields
 * Check digit size - one character
 * Check digit value - decimal digit ('0' - '9')
 * Check digit location - trailing (right-most) character of individual fields

--- a/README.md
+++ b/README.md
@@ -2114,3 +2114,20 @@ Additional included algorithms:
 
 Added masked validation support to the following algorithms:
 * Modulus10_13 Algorithm
+
+Minor updates to the following algorithms:
+* ICAO 9303 Document Size TD1 Algorithm
+* ICAO 9303 Document Size TD2 Algorithm
+* ICAO 9303 Document Size TD3 Algorithm
+* ICAO 9303 Machine Readable Visa Algorithm
+
+The original implementation of the above algorithms allowed alphabetic characters in the date of birth/expiration date fields
+as long as the check digit(s) were valid for the characters used. The updated implementation only allows numeric characters 
+in those fields, which is consistent with the ICAO 9303 specification. 
+
+Additionally, the LineSeparator property of the above algorithms was marked Obsolete and will be removed in a future release.
+Instead, the separator used between lines in the MRZ is inferred from the length of the value being validated. 
+
+Algorithms marked as Obsolete:
+* Modulus11 Algorithm (ISBN-10/ISSN/etc.) - Replaced by the Modulus11Extended algorithm.
+* NHS (UK National Health Service) Algorithm - Replaced by the Modulus11_27Decimal algorithm.

--- a/README.md
+++ b/README.md
@@ -1682,13 +1682,13 @@ only validation of values containing check digits.
 | IBAN           | GB00WEST12345698765432          | 22.264 ns | 0.2030 ns | 0.1695 ns | -         |
 | IBAN           | SC00MCBL01031234567890123456USD | 33.121 ns | 0.1529 ns | 0.1355 ns | -         |
 |                |                                 |           |           |           |           |
-| ICAO 9303      | U7Y                             | 4.193 ns  | 0.0450 ns | 0.0421 ns | -         |
-| ICAO 9303      | U7Y8SX                          | 5.840 ns  | 0.0395 ns | 0.0370 ns | -         |
-| ICAO 9303      | U7Y8SXRC0                       | 7.757 ns  | 0.1317 ns | 0.1293 ns | -         |
-| ICAO 9303      | U7Y8SXRC0O3S                    | 9.235 ns  | 0.0897 ns | 0.0839 ns | -         |
-| ICAO 9303      | U7Y8SXRC0O3SC4I                 | 11.032 ns | 0.2064 ns | 0.1723 ns | -         |
-| ICAO 9303      | U7Y8SXRC0O3SC4IHYQ              | 12.823 ns | 0.0541 ns | 0.0452 ns | -         |
-| ICAO 9303      | U7Y8SXRC0O3SC4IHYQF4M           | 14.776 ns | 0.1006 ns | 0.0941 ns | -         |
+| ICAO 9303      | U7Y                             | 4.275 ns  | 0.0977 ns | 0.0960 ns | -         |
+| ICAO 9303      | U7Y8SX                          | 5.637 ns  | 0.0558 ns | 0.0436 ns | -         |
+| ICAO 9303      | U7Y8SXRC0                       | 7.426 ns  | 0.0747 ns | 0.0699 ns | -         |
+| ICAO 9303      | U7Y8SXRC0O3S                    | 9.916 ns  | 0.0626 ns | 0.0555 ns | -         |
+| ICAO 9303      | U7Y8SXRC0O3SC4I                 | 12.295 ns | 0.0660 ns | 0.0551 ns | -         |
+| ICAO 9303      | U7Y8SXRC0O3SC4IHYQ              | 14.716 ns | 0.1333 ns | 0.1247 ns | -         |
+| ICAO 9303      | U7Y8SXRC0O3SC4IHYQF4M           | 16.864 ns | 0.1193 ns | 0.1116 ns | -         |
 |                |                                 |           |           |           |           |
 | ISIN           | AU0000XVGZA                     | 7.917 ns  | 0.0690 ns | 0.0645 ns | -         |
 | ISIN           | GB000263494                     | 7.118 ns  | 0.0536 ns | 0.0475 ns | -         |
@@ -1899,29 +1899,29 @@ Note also that the values used for the NOID Check Digit algorithm do not include
 | IBAN                            | GB82WEST12345698765432                 | 21.263 ns | 0.2220 ns | 0.2076 ns | -         |
 | IBAN                            | SC74MCBL01031234567890123456USD        | 32.737 ns | 0.3820 ns | 0.3190 ns | -         |
 |                                 |                                        |           |           |           |           |
-| ICAO 9303                       | U7Y5                                   | 4.321 ns  | 0.0208 ns | 0.0195 ns | -         |
-| ICAO 9303                       | U7Y8SX8                                | 6.020 ns  | 0.0632 ns | 0.0591 ns | -         |
-| ICAO 9303                       | U7Y8SXRC03                             | 7.693 ns  | 0.0856 ns | 0.0801 ns | -         |
-| ICAO 9303                       | U7Y8SXRC0O3S8                          | 9.483 ns  | 0.2059 ns | 0.2749 ns | -         |
-| ICAO 9303                       | U7Y8SXRC0O3SC4I2                       | 10.983 ns | 0.0744 ns | 0.0696 ns | -         |
-| ICAO 9303                       | U7Y8SXRC0O3SC4IHYQ9                    | 12.690 ns | 0.0482 ns | 0.0427 ns | -         |
-| ICAO 9303                       | U7Y8SXRC0O3SC4IHYQF4M8                 | 14.541 ns | 0.0988 ns | 0.0876 ns | -         |
+| ICAO 9303                       | U7Y5                                   | 4.432 ns  | 0.0234 ns | 0.0182 ns | -         |
+| ICAO 9303                       | U7Y8SX8                                | 6.267 ns  | 0.0501 ns | 0.0418 ns | -         |
+| ICAO 9303                       | U7Y8SXRC03                             | 8.173 ns  | 0.0895 ns | 0.0794 ns | -         |
+| ICAO 9303                       | U7Y8SXRC0O3S8                          | 10.376 ns | 0.0802 ns | 0.0711 ns | -         |
+| ICAO 9303                       | U7Y8SXRC0O3SC4I2                       | 12.741 ns | 0.0879 ns | 0.0779 ns | -         |
+| ICAO 9303                       | U7Y8SXRC0O3SC4IHYQ9                    | 15.234 ns | 0.1390 ns | 0.1301 ns | -         |
+| ICAO 9303                       | U7Y8SXRC0O3SC4IHYQF4M8                 | 16.228 ns | 0.1301 ns | 0.1153 ns | -         |
 |                                 |                                        |           |           |           |           |
-| ICAO 9303 Machine Readable Visa | I<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<br>D231458907UTO7408122F1204159<<<<<<<<                 | 19.684 ns | 0.1291 ns | 0.1207 ns | -         |
-| ICAO 9303 Machine Readable Visa | I<UTOSKYWALKER<<LUKE<<<<<<<<<<<<<<<<<br>STARWARS45UTO7705256M2405252<<<<<<<<                 | 19.651 ns | 0.1502 ns | 0.1405 ns | -         |
-| ICAO 9303 Machine Readable Visa | V<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<<br>L898902C<3UTO6908061F9406236ZE184226B<<<<<<< | 18.538 ns | 0.2393 ns | 0.1998 ns | -         |
+| ICAO 9303 Machine Readable Visa | I<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<br>D231458907UTO7408122F1204159<<<<<<<<                 | 19.925 ns | 0.0992 ns | 0.0928 ns | -         |
+| ICAO 9303 Machine Readable Visa | I<UTOSKYWALKER<<LUKE<<<<<<<<<<<<<<<<<br>STARWARS45UTO7705256M2405252<<<<<<<<                 | 20.552 ns | 0.1990 ns | 0.1862 ns | -         |
+| ICAO 9303 Machine Readable Visa | V<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<<br>L898902C<3UTO6908061F9406236ZE184226B<<<<<<< | 20.633 ns | 0.1249 ns | 0.1107 ns | -         |
 |                                 |                                        |           |           |           |           |
-| ICAO 9303 Size TD1              | I<UTOD231458907<<<<<<<<<<<<<<<<br>7408122F1204159UTO<<<<<<<<<<<6<br>ERIKSSON<<ANNA<MARIA<<<<<<<<<< | 33.773 ns | 0.1454 ns | 0.1289 ns | -         |
-| ICAO 9303 Size TD1              | I<UTOSTARWARS45<<<<<<<<<<<<<<<<br>7705256M2405252UTO<<<<<<<<<<<4<br>SKYWALKER<<LUKE<<<<<<<<<<<<<<< | 38.206 ns | 0.1840 ns | 0.1631 ns | -         |
-| ICAO 9303 Size TD1              | I<UTOD23145890<AB112234566<<<<<br>7408122F1204159UTO<<<<<<<<<<<4<br>ERIKSSON<<ANNA<MARIA<<<<<<<<<< | 34.386 ns | 0.2079 ns | 0.1945 ns | -         |
+| ICAO 9303 Size TD1              | I<UTOD231458907<<<<<<<<<<<<<<<<br>7408122F1204159UTO<<<<<<<<<<<6<br>ERIKSSON<<ANNA<MARIA<<<<<<<<<< | 33.010 ns | 0.1887 ns | 0.1673 ns | -         |
+| ICAO 9303 Size TD1              | I<UTOSTARWARS45<<<<<<<<<<<<<<<<br>7705256M2405252UTO<<<<<<<<<<<4<br>SKYWALKER<<LUKE<<<<<<<<<<<<<<< | 39.914 ns | 0.3377 ns | 0.2994 ns | -         |
+| ICAO 9303 Size TD1              | I<UTOD23145890<AB112234566<<<<<br>7408122F1204159UTO<<<<<<<<<<<4<br>ERIKSSON<<ANNA<MARIA<<<<<<<<<< | 32.857 ns | 0.2455 ns | 0.2297 ns | -         |
 |                                 |                                        |           |           |           |           |
-| ICAO 9303 Size TD2              | I<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<br>D231458907UTO7408122F1204159<<<<<<<6 | 31.622 ns | 0.2665 ns | 0.2492 ns | -         |
-| ICAO 9303 Size TD2              | I<UTOQWERTY<<ASDF<<<<<<<<<<<<<<<<<<<<br>D23145890<UTO7408122F1204159AB1124<4 | 31.700 ns | 0.2532 ns | 0.2368 ns | -         |
-| ICAO 9303 Size TD2              | I<UTOSKYWALKER<<LUKE<<<<<<<<<<<<<<<<<br>STARWARS45UTO7705256M2405252<<<<<<<8 | 31.443 ns | 0.1810 ns | 0.1604 ns | -         |
+| ICAO 9303 Size TD2              | I<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<br>D231458907UTO7408122F1204159<<<<<<<6 | 32.312 ns | 0.2888 ns | 0.2702 ns | -         |
+| ICAO 9303 Size TD2              | I<UTOQWERTY<<ASDF<<<<<<<<<<<<<<<<<<<<br>D23145890<UTO7408122F1204159AB1124<4 | 33.326 ns | 0.2760 ns | 0.2581 ns | -         |
+| ICAO 9303 Size TD2              | I<UTOSKYWALKER<<LUKE<<<<<<<<<<<<<<<<<br>STARWARS45UTO7705256M2405252<<<<<<<8 | 32.079 ns | 0.3153 ns | 0.2950 ns | -         |
 |                                 |                                        |           |           |           |           |
-| ICAO 9303 Size TD3              | P<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<<br>L898902C36UTO7408122F1204159ZE184226B<<<<<10 | 41.579 ns | 0.2136 ns | 0.1998 ns | -         |
-| ICAO 9303 Size TD3              | P<UTOQWERTY<<ASDF<<<<<<<<<<<<<<<<<<<<<<<<<<<<br>Q123987655UTO3311226F2010201<<<<<<<<<<<<<<06 | 44.731 ns | 0.1975 ns | 0.1847 ns | -         |
-| ICAO 9303 Size TD3              | P<UTOSKYWALKER<<LUKE<<<<<<<<<<<<<<<<<<<<<<<<<br>STARWARS45UTO7705256M2405252HAN<SHOT<FIRST78 | 44.764 ns | 0.2196 ns | 0.1947 ns | -         |
+| ICAO 9303 Size TD3              | P<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<<br>L898902C36UTO7408122F1204159ZE184226B<<<<<10 | 41.611 ns | 0.2497 ns | 0.2213 ns | -         |
+| ICAO 9303 Size TD3              | P<UTOQWERTY<<ASDF<<<<<<<<<<<<<<<<<<<<<<<<<<<<br>Q123987655UTO3311226F2010201<<<<<<<<<<<<<<06 | 41.648 ns | 0.3441 ns | 0.3219 ns | -         |
+| ICAO 9303 Size TD3              | P<UTOSKYWALKER<<LUKE<<<<<<<<<<<<<<<<<<<<<<<<<br>STARWARS45UTO7705256M2405252HAN<SHOT<FIRST78 | 41.434 ns | 0.3941 ns | 0.3686 ns | -         |
 |                                 |                                        |           |           |           |           |
 | ISAN                            | C594660A8B2E5D22X6DDA3272E             | 18.823 ns | 0.2636 ns | 0.2336 ns | -         |
 | ISAN                            | D02C42E954183EE2Q1291C8AEO             | 17.367 ns | 0.1634 ns | 0.1364 ns | -         |


### PR DESCRIPTION
This pull request refactors the ICAO 9303 algorithm implementation and its associated tests, focusing on improved modularity, maintainability, and clarity. The most significant changes are the extraction of character mapping logic into a new helper class, updates to test coverage, and adjustments to benchmarks for more targeted performance testing.

Algorithm refactoring and modularization:

* Moved character mapping logic from `Icao9303Algorithm` to a new `Icao9303Helpers` class, replacing the static `MapCharacter` method and related mapping array with calls to helper methods for character-to-integer conversion and validation. (`CheckDigits.Net/ValueSpecificAlgorithms/Icao9303Algorithm.cs`, [[1]](diffhunk://#diff-0c8aee2fd6837caa5761afcde1e06965d6be33530d10b15443eb70a2e86efe57L32-L61) [[2]](diffhunk://#diff-0c8aee2fd6837caa5761afcde1e06965d6be33530d10b15443eb70a2e86efe57L71-R56) [[3]](diffhunk://#diff-0c8aee2fd6837caa5761afcde1e06965d6be33530d10b15443eb70a2e86efe57L102-R83)
* Updated global usings to include `System.Diagnostics.Contracts`, supporting code contracts and improving codebase clarity. (`CheckDigits.Net/GlobalUsings.cs`, [CheckDigits.Net/GlobalUsings.csL1-R2](diffhunk://#diff-e5be5036ee6261c6104780467b3c6ff06fef9bdafa39ccd207d2b7580232e3d8L1-R2))

Test suite improvements:

* Moved and renamed the character mapping tests from `Icao9303AlgorithmTests` to a new `Icao9303HelpersTests` class, ensuring tests target the new helper logic. (`CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303AlgorithmTests.cs`, [[1]](diffhunk://#diff-fccd5c589446dbeda0b9a7a5f9f2768bc46c699ab268339c65f5e87fc12e2b42L29-L86); `CheckDigits.Net.Tests.Unit/ValueSpecificAlgorithms/Icao9303HelpersTests.cs`, [[2]](diffhunk://#diff-ac21df004cc0a06087f4536711418868207f3cfc2482020f4a7442c1692da9f2R1-R63)

Benchmark and test data adjustments:

* Updated `OptimizeBenchmarks` to use `Icao9303SizeTD2Algorithm` and new ICAO 9303 test values, focusing performance tests on relevant data. (`CheckDigits.Net.Tests.Benchmarks/OptimizeBenchmarks.cs`, [CheckDigits.Net.Tests.Benchmarks/OptimizeBenchmarks.csL8-R13](diffhunk://#diff-bcfbf601d72d5aba080771f01eb6949556d3dd51b2870219dae9f3f8b51be450L8-R13))
* Modified `Program.cs` to run `ValueSpecificAlgorithmBenchmarks` and commented out other benchmark runners for clarity and focus. (`CheckDigits.Net.Tests.Benchmarks/Program.cs`, [CheckDigits.Net.Tests.Benchmarks/Program.csL2-R8](diffhunk://#diff-7687108d65e57c8ece664486c28509f07a7fe5f4617870bbbb743f3455783c9bL2-R8))
* Commented out or updated test cases in `ValueSpecificAlgorithmBenchmarks.cs` to focus on ICAO 9303 and related algorithms, and made test values multiline where appropriate for realistic input. (`CheckDigits.Net.Tests.Benchmarks/ValueSpecificAlgorithmBenchmarks.cs`, [[1]](diffhunk://#diff-d38793c8745252aed06ea4b2d7b8705f45081d8e8e90c2071274bb649b592d0bL22-R32) [[2]](diffhunk://#diff-d38793c8745252aed06ea4b2d7b8705f45081d8e8e90c2071274bb649b592d0bL44-R58) [[3]](diffhunk://#diff-d38793c8745252aed06ea4b2d7b8705f45081d8e8e90c2071274bb649b592d0bL69-R112) [[4]](diffhunk://#diff-d38793c8745252aed06ea4b2d7b8705f45081d8e8e90c2071274bb649b592d0bL132-R137) [[5]](diffhunk://#diff-d38793c8745252aed06ea4b2d7b8705f45081d8e8e90c2071274bb649b592d0bL146-R151)