### PR TITLE
S0071 masked verhoeff

### DIFF
--- a/CheckDigits.Net.Tests.Benchmarks/NumericAlgorithmBenchmarks.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/NumericAlgorithmBenchmarks.cs
@@ -219,53 +219,61 @@ public class NumericAlgorithmBenchmarks
       yield return [Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140 662 538 042 551 028 0"];
       yield return [Algorithms.Damm, Algorithms.Damm.AlgorithmName, "140 662 538 042 551 028 265 4"];
 
-      //yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 4"];
-      //yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 8"];
-      //yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 2"];
-      //yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 1"];
-      //yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 551 4"];
-      //yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 551 028 5"];
-      //yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 551 028 265 1"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 4"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 8"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 2"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 1"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 551 4"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 551 028 5"];
+      yield return [Algorithms.Luhn, Algorithms.Luhn.AlgorithmName, "140 662 538 042 551 028 265 1"];
 
-      //yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140 3"];
-      //yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140 662 7"];
-      //yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140 662 538 5"];
-      //yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140 662 538 042 5"];
-      //yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140 662 538 042 551 8"];
-      //yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140 662 538 042 551 028 8"];
-      //yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140 662 538 042 551 028 265 7"];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140 3"];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140 662 7"];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140 662 538 5"];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140 662 538 042 5"];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140 662 538 042 551 8"];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140 662 538 042 551 028 8"];
+      yield return [Algorithms.Modulus10_13, Algorithms.Modulus10_13.AlgorithmName, "140 662 538 042 551 028 265 7"];
 
-      //yield return [Algorithms.Modulus11_27Decimal, Algorithms.Modulus11_27Decimal.AlgorithmName, "140 6"];
-      //yield return [Algorithms.Modulus11_27Decimal, Algorithms.Modulus11_27Decimal.AlgorithmName, "140 662 0"];
-      //yield return [Algorithms.Modulus11_27Decimal, Algorithms.Modulus11_27Decimal.AlgorithmName, "140 662 538 5"];
-      //yield return [Algorithms.Modulus11_27Decimal, Algorithms.Modulus11_27Decimal.AlgorithmName, "140 662 538 042 1"];
-      //yield return [Algorithms.Modulus11_27Decimal, Algorithms.Modulus11_27Decimal.AlgorithmName, "140 662 538 042 551 0"];
-      //yield return [Algorithms.Modulus11_27Decimal, Algorithms.Modulus11_27Decimal.AlgorithmName, "140 662 538 042 551 028 8"];
-      //yield return [Algorithms.Modulus11_27Decimal, Algorithms.Modulus11_27Decimal.AlgorithmName, "140 662 538 042 551 028 265 0"];
+      yield return [Algorithms.Modulus11_27Decimal, Algorithms.Modulus11_27Decimal.AlgorithmName, "140 6"];
+      yield return [Algorithms.Modulus11_27Decimal, Algorithms.Modulus11_27Decimal.AlgorithmName, "140 662 0"];
+      yield return [Algorithms.Modulus11_27Decimal, Algorithms.Modulus11_27Decimal.AlgorithmName, "140 662 538 5"];
+      yield return [Algorithms.Modulus11_27Decimal, Algorithms.Modulus11_27Decimal.AlgorithmName, "140 662 538 042 1"];
+      yield return [Algorithms.Modulus11_27Decimal, Algorithms.Modulus11_27Decimal.AlgorithmName, "140 662 538 042 551 0"];
+      yield return [Algorithms.Modulus11_27Decimal, Algorithms.Modulus11_27Decimal.AlgorithmName, "140 662 538 042 551 028 8"];
+      yield return [Algorithms.Modulus11_27Decimal, Algorithms.Modulus11_27Decimal.AlgorithmName, "140 662 538 042 551 028 265 0"];
 
-      //yield return [Algorithms.Modulus11_27Extended, Algorithms.Modulus11_27Extended.AlgorithmName, "140 6"];
-      //yield return [Algorithms.Modulus11_27Extended, Algorithms.Modulus11_27Extended.AlgorithmName, "140 662 0"];
-      //yield return [Algorithms.Modulus11_27Extended, Algorithms.Modulus11_27Extended.AlgorithmName, "140 662 538 5"];
-      //yield return [Algorithms.Modulus11_27Extended, Algorithms.Modulus11_27Extended.AlgorithmName, "140 662 538 042 1"];
-      //yield return [Algorithms.Modulus11_27Extended, Algorithms.Modulus11_27Extended.AlgorithmName, "140 662 538 042 551 0"];
-      //yield return [Algorithms.Modulus11_27Extended, Algorithms.Modulus11_27Extended.AlgorithmName, "140 662 538 042 551 028 8"];
-      //yield return [Algorithms.Modulus11_27Extended, Algorithms.Modulus11_27Extended.AlgorithmName, "140 662 538 042 551 028 265 0"];
+      yield return [Algorithms.Modulus11_27Extended, Algorithms.Modulus11_27Extended.AlgorithmName, "140 6"];
+      yield return [Algorithms.Modulus11_27Extended, Algorithms.Modulus11_27Extended.AlgorithmName, "140 662 0"];
+      yield return [Algorithms.Modulus11_27Extended, Algorithms.Modulus11_27Extended.AlgorithmName, "140 662 538 5"];
+      yield return [Algorithms.Modulus11_27Extended, Algorithms.Modulus11_27Extended.AlgorithmName, "140 662 538 042 1"];
+      yield return [Algorithms.Modulus11_27Extended, Algorithms.Modulus11_27Extended.AlgorithmName, "140 662 538 042 551 0"];
+      yield return [Algorithms.Modulus11_27Extended, Algorithms.Modulus11_27Extended.AlgorithmName, "140 662 538 042 551 028 8"];
+      yield return [Algorithms.Modulus11_27Extended, Algorithms.Modulus11_27Extended.AlgorithmName, "140 662 538 042 551 028 265 0"];
 
-      //yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "140 6"];
-      //yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "140 662 0"];
-      //yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "140 662 538 8"];
+      yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "140 6"];
+      yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "140 662 0"];
+      yield return [Algorithms.Modulus11Decimal, Algorithms.Modulus11Decimal.AlgorithmName, "140 662 538 8"];
 
-      //yield return [Algorithms.Modulus11Extended, Algorithms.Modulus11Extended.AlgorithmName, "140 6"];
-      //yield return [Algorithms.Modulus11Extended, Algorithms.Modulus11Extended.AlgorithmName, "140 662 0"];
-      //yield return [Algorithms.Modulus11Extended, Algorithms.Modulus11Extended.AlgorithmName, "140 662 538 8"];
+      yield return [Algorithms.Modulus11Extended, Algorithms.Modulus11Extended.AlgorithmName, "140 6"];
+      yield return [Algorithms.Modulus11Extended, Algorithms.Modulus11Extended.AlgorithmName, "140 662 0"];
+      yield return [Algorithms.Modulus11Extended, Algorithms.Modulus11Extended.AlgorithmName, "140 662 538 8"];
+
+      yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140 1"];
+      yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140 662 5"];
+      yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140 662 538 8"];
+      yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140 662 538 042 6"];
+      yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140 662 538 042 551 2"];
+      yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140 662 538 042 551 028 5"];
+      yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "140 662 538 042 551 028 265 5"];
    }
 
-   [Benchmark]
-   [ArgumentsSource(nameof(TryCalculateCheckDigitArguments))]
-   public void TryCalculateCheckDigit(ISingleCheckDigitAlgorithm algorithm, String name, String value)
-   {
-      algorithm.TryCalculateCheckDigit(value, out var checkDigit);
-   }
+   //[Benchmark]
+   //[ArgumentsSource(nameof(TryCalculateCheckDigitArguments))]
+   //public void TryCalculateCheckDigit(ISingleCheckDigitAlgorithm algorithm, String name, String value)
+   //{
+   //   algorithm.TryCalculateCheckDigit(value, out var checkDigit);
+   //}
 
    //[Benchmark]
    //[ArgumentsSource(nameof(TryCalculateCheckDigitsArguments))]
@@ -274,12 +282,12 @@ public class NumericAlgorithmBenchmarks
    //   algorithm.TryCalculateCheckDigits(value, out var first, out var second);
    //}
 
-   [Benchmark]
-   [ArgumentsSource(nameof(ValidateArguments))]
-   public void Validate(ICheckDigitAlgorithm algorithm, String name, String value)
-   {
-      algorithm.Validate(value);
-   }
+   //[Benchmark]
+   //[ArgumentsSource(nameof(ValidateArguments))]
+   //public void Validate(ICheckDigitAlgorithm algorithm, String name, String value)
+   //{
+   //   algorithm.Validate(value);
+   //}
 
    [Benchmark]
    [ArgumentsSource(nameof(ValidateMaskedArguments))]

--- a/CheckDigits.Net.Tests.Benchmarks/NumericAlgorithmBenchmarks.cs
+++ b/CheckDigits.Net.Tests.Benchmarks/NumericAlgorithmBenchmarks.cs
@@ -201,7 +201,7 @@ public class NumericAlgorithmBenchmarks
       //yield return [Algorithms.Modulus11Extended, Algorithms.Modulus11Extended.AlgorithmName, "1406625388"];
 
       //yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1401"];
-      //yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406620"];
+      //yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625"];
       //yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625388"];
       //yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380426"];
       //yield return [Algorithms.Verhoeff, Algorithms.Verhoeff.AlgorithmName, "1406625380425512"];

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/DammAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/DammAlgorithmTests.cs
@@ -178,6 +178,15 @@ public class DammAlgorithmTests
    // ==========================================================================
 
    [Fact]
+   public void DammAlgorithm_ValidateMasked_ShouldThrowArgumentNullException_WhenMaskIsNull()
+      => _sut
+         .Invoking(x => x.Validate("12345", null!))
+         .Should()
+         .ThrowExactly<ArgumentNullException>()
+         .WithParameterName("mask")
+         .WithMessage(Resources.NullMaskMessage + "*");
+
+   [Fact]
    public void DammAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputIsNull()
       => _sut.Validate(null!, _acceptAllMask).Should().BeFalse();
 

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/DammCustomQuasigroupAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/DammCustomQuasigroupAlgorithmTests.cs
@@ -382,6 +382,22 @@ public class DammCustomQuasigroupAlgorithmTests
    [Theory]
    [InlineData(10)]
    [InlineData(16)]
+   public void DammAlgorithm_ValidateMasked_ShouldThrowArgumentNullException_WhenMaskIsNull(Int32 order)
+   {
+      // Arrange.
+      var sut = GetAlgorithm(order);
+
+      // Act/assert.
+      sut.Invoking(x => x.Validate("12345", null!))
+         .Should()
+         .ThrowExactly<ArgumentNullException>()
+         .WithParameterName("mask")
+         .WithMessage(Resources.NullMaskMessage + "*");
+   }
+
+   [Theory]
+   [InlineData(10)]
+   [InlineData(16)]
    public void DammCustomQuasigroupAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputIsNull(Int32 order)
    {
       // Arrange.

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/LuhnAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/LuhnAlgorithmTests.cs
@@ -287,6 +287,12 @@ public class LuhnAlgorithmTests
    public void LuhnAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputIsEmpty()
       => _sut.Validate(String.Empty, _acceptAllMask).Should().BeFalse();
 
+   [Theory]
+   [InlineData("0")]    // "0" is the only digit that would pass unless length is checked explicitly
+   [InlineData("1")]
+   public void LuhnAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInsufficientUnmaskedCharactersToCalculateCheckDigit(String value)
+      => _sut.Validate(value, _acceptAllMask).Should().BeFalse();
+
    [Fact]
    public void LuhnAlgorithm_ValidateMasked_ShouldReturnFalse_WhenAllNonCheckDigitCharactersAreMaskedOut()
       => _sut.Validate("0000 0000 0000 0000", _rejectAllMask).Should().BeFalse();

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/LuhnAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/LuhnAlgorithmTests.cs
@@ -271,6 +271,15 @@ public class LuhnAlgorithmTests
    // ==========================================================================
 
    [Fact]
+   public void LuhnAlgorithm_ValidateMasked_ShouldThrowArgumentNullException_WhenMaskIsNull()
+      => _sut
+         .Invoking(x => x.Validate("12345", null!))
+         .Should()
+         .ThrowExactly<ArgumentNullException>()
+         .WithParameterName("mask")
+         .WithMessage(Resources.NullMaskMessage + "*");
+
+   [Fact]
    public void LuhnAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputIsNull()
       => _sut.Validate(null!, _acceptAllMask).Should().BeFalse();
 
@@ -326,6 +335,20 @@ public class LuhnAlgorithmTests
    [InlineData("5117 0095 7")]            // "   Note CSIN is normally formatted as XXX XXX XXX and the groups of four used here is to allow the same mask for all test cases 
    public void LuhnAlgorithm_ValidateMasked_ShouldReturnTrue_WhenValueContainsValidCheckDigit(String value)
       => _sut.Validate(value, _creditCardMask).Should().BeTrue();
+
+   [Theory]
+   [InlineData("378282246310005")]     // American Express test credit card number
+   [InlineData("6011111111111117")]    // Discover test credit card number
+   [InlineData("5555555555554444")]    // MasterCard test credit card number
+   [InlineData("4012888888881881")]    // Visa test credit card number
+   [InlineData("3056930009020004")]    // Diners Club test credit card number
+   [InlineData("3566111111111113")]    // JCB test credit card number
+   [InlineData("808401234567893")]     // NPI (National Provider Identifier), including 80840 prefix
+   [InlineData("490154203237518")]     // IMEI (International Mobile Equipment Identity)
+   [InlineData("293443438")]           // Canadian Social Insurance Number from https://www.ibm.com/docs/en/sga?topic=patterns-canada-social-insurance-number
+   [InlineData("511700957")]           // "
+   public void LuhnAlgorithm_ValidateMasked_ShouldReturnTrue_WhenValueContainsValidCheckDigitAndMaskAcceptsAllCharacters(String value)
+      => _sut.Validate(value, _acceptAllMask).Should().BeTrue();
 
    [Theory]
    [InlineData("3056 9300 9002 0004")]    // Diners Club test card number with two digit transposition 09 -> 90

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus10_13AlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus10_13AlgorithmTests.cs
@@ -111,6 +111,17 @@ public class Modulus10_13AlgorithmTests
       checkDigit.Should().Be('\0');
    }
 
+   [Theory]
+   [InlineData("140")]
+   [InlineData("140662")]
+   [InlineData("140662538")]
+   [InlineData("140662538042")]
+   [InlineData("140662538042551")]
+   [InlineData("140662538042551028")]
+   [InlineData("140662538042551028265")]
+   public void Modulus10_13Algorithm_TryCalculateValue_ShouldReturnTrue_ForBenchmarkValues(String value)
+      => _sut.TryCalculateCheckDigit(value, out _).Should().BeTrue();
+
    #endregion
 
    #region Validate Tests
@@ -189,6 +200,17 @@ public class Modulus10_13AlgorithmTests
    [Fact]
    public void Modulus10_13Algorithm_Validate_ShouldReturnFalse_WhenCheckDigitCharacterIsNonDigit()
       => _sut.Validate("03600029145A").Should().BeFalse();
+
+   [Theory]
+   [InlineData("1403")]           
+   [InlineData("1406627")]        
+   [InlineData("1406625385")]     
+   [InlineData("1406625380425")]   
+   [InlineData("1406625380425518")]
+   [InlineData("1406625380425510288")]  
+   [InlineData("1406625380425510282657")]
+   public void Modulus10_13Algorithm_Validate_ShouldReturnTrue_ForBenchmarkValues(String value)
+      => _sut.Validate(value).Should().BeTrue();
 
    #endregion
 
@@ -291,6 +313,17 @@ public class Modulus10_13AlgorithmTests
    [Fact]
    public void Modulus10_13Algorithm_ValidateMasked_ShouldReturnFalse_WhenCheckDigitCharacterIsNonDigit()
       => _sut.Validate("036 000 291 45A", _groupsOfThreeMask).Should().BeFalse();
+
+   [Theory]
+   [InlineData("140 3")]           
+   [InlineData("140 662 7")]        
+   [InlineData("140 662 538 5")]     
+   [InlineData("140 662 538 042 5")]   
+   [InlineData("140 662 538 042 551 8")]
+   [InlineData("140 662 538 042 551 028 8")]  
+   [InlineData("140 662 538 042 551 028 265 7")]
+   public void Modulus10_13Algorithm_ValidateMasked_ShouldReturnTrue_ForBenchmarkValues(String value)
+      => _sut.Validate(value, _groupsOfThreeMask).Should().BeTrue();
 
    #endregion
 }

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus10_13AlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus10_13AlgorithmTests.cs
@@ -197,12 +197,27 @@ public class Modulus10_13AlgorithmTests
    // ==========================================================================
 
    [Fact]
+   public void Modulus10_13Algorithm_ValidateMasked_ShouldThrowArgumentNullException_WhenMaskIsNull()
+      => _sut
+         .Invoking(x => x.Validate("12345", null!))
+         .Should()
+         .ThrowExactly<ArgumentNullException>()
+         .WithParameterName("mask")
+         .WithMessage(Resources.NullMaskMessage + "*");
+
+   [Fact]
    public void Modulus10_13Algorithm_ValidateMasked_ShouldReturnFalse_WhenInputIsNull()
       => _sut.Validate(null!, _acceptAllMask).Should().BeFalse();
 
    [Fact]
    public void Modulus10_13Algorithm_ValidateMasked_ShouldReturnFalse_WhenInputIsEmpty()
       => _sut.Validate(String.Empty, _acceptAllMask).Should().BeFalse();
+
+   [Theory]
+   [InlineData("0")]
+   [InlineData("1")]
+   public void Modulus10_13Algorithm_ValidateMasked_ShouldReturnFalse_WhenInsufficientUnmaskedCharactersToCalculateCheckDigit(String value)
+      => _sut.Validate(value, _acceptAllMask).Should().BeFalse();
 
    [Fact]
    public void Modulus10_13Algorithm_ValidateMasked_ShouldReturnFalse_WhenAllNonCheckDigitCharactersAreMaskedOut()

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11DecimalAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11DecimalAlgorithmTests.cs
@@ -281,6 +281,15 @@ public class Modulus11DecimalAlgorithmTests
    // ==========================================================================
 
    [Fact]
+   public void Modulus11DecimalAlgorithm_ValidateMasked_ShouldThrowArgumentNullException_WhenMaskIsNull()
+      => _sut
+         .Invoking(x => x.Validate("12345", null!))
+         .Should()
+         .ThrowExactly<ArgumentNullException>()
+         .WithParameterName("mask")
+         .WithMessage(Resources.NullMaskMessage + "*");
+
+   [Fact]
    public void Modulus11DecimalAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputIsNull()
       => _sut.Validate(null!, _acceptAllMask).Should().BeFalse();
 

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11ExtendedAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11ExtendedAlgorithmTests.cs
@@ -321,6 +321,15 @@ public class Modulus11ExtendedAlgorithmTests
    // ==========================================================================
 
    [Fact]
+   public void Modulus11ExtendedAlgorithm_ValidateMasked_ShouldThrowArgumentNullException_WhenMaskIsNull()
+      => _sut
+         .Invoking(x => x.Validate("12345", null!))
+         .Should()
+         .ThrowExactly<ArgumentNullException>()
+         .WithParameterName("mask")
+         .WithMessage(Resources.NullMaskMessage + "*");
+
+   [Fact]
    public void Modulus11ExtendedAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputIsNull()
       => _sut.Validate(null!, _acceptAllMask).Should().BeFalse();
 

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11_27DecimalAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11_27DecimalAlgorithmTests.cs
@@ -237,7 +237,7 @@ public class Modulus11_27DecimalAlgorithmTests
    // ==========================================================================
 
    [Fact]
-   public void Modulus11_27Algorithm_ValidateMasked_ShouldThrowArgumentNullException_WhenMaskIsNull()
+   public void Modulus11_27DecimalAlgorithm_ValidateMasked_ShouldThrowArgumentNullException_WhenMaskIsNull()
       => _sut
          .Invoking(x => x.Validate("12345", null!))
          .Should()
@@ -252,12 +252,6 @@ public class Modulus11_27DecimalAlgorithmTests
    [Fact]
    public void Modulus11_27DecimalAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputIsEmpty()
       => _sut.Validate(String.Empty, _acceptAllMask).Should().BeFalse();
-
-   [Theory]
-   [InlineData("0")]       // Zero would return true unless length is explicitly checked.
-   [InlineData("1")]
-   public void Modulus11_27Algorithm_ValidateMasked_ShouldReturnFalse_WhenInsufficientUnmaskedCharactersToCalculateCheckDigit(String value)
-      => _sut.Validate(value, _acceptAllMask).Should().BeFalse();
 
    [Fact]
    public void Modulus11_27DecimalAlgorithm_ValidateMasked_ShouldReturnFalse_WhenAllNonCheckDigitCharactersAreMaskedOut()

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11_27DecimalAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11_27DecimalAlgorithmTests.cs
@@ -237,12 +237,27 @@ public class Modulus11_27DecimalAlgorithmTests
    // ==========================================================================
 
    [Fact]
+   public void Modulus11_27Algorithm_ValidateMasked_ShouldThrowArgumentNullException_WhenMaskIsNull()
+      => _sut
+         .Invoking(x => x.Validate("12345", null!))
+         .Should()
+         .ThrowExactly<ArgumentNullException>()
+         .WithParameterName("mask")
+         .WithMessage(Resources.NullMaskMessage + "*");
+
+   [Fact]
    public void Modulus11_27DecimalAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputIsNull()
       => _sut.Validate(null!, _acceptAllMask).Should().BeFalse();
 
    [Fact]
    public void Modulus11_27DecimalAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputIsEmpty()
       => _sut.Validate(String.Empty, _acceptAllMask).Should().BeFalse();
+
+   [Theory]
+   [InlineData("0")]       // Zero would return true unless length is explicitly checked.
+   [InlineData("1")]
+   public void Modulus11_27Algorithm_ValidateMasked_ShouldReturnFalse_WhenInsufficientUnmaskedCharactersToCalculateCheckDigit(String value)
+      => _sut.Validate(value, _acceptAllMask).Should().BeFalse();
 
    [Fact]
    public void Modulus11_27DecimalAlgorithm_ValidateMasked_ShouldReturnFalse_WhenAllNonCheckDigitCharactersAreMaskedOut()

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11_27ExtendedAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11_27ExtendedAlgorithmTests.cs
@@ -248,7 +248,7 @@ public class Modulus11_27ExtendedAlgorithmTests
    // ==========================================================================
 
    [Fact]
-   public void  Modulus11_27ExtendedAlgorithm_ValidateMasked_ShouldThrowArgumentNullException_WhenMaskIsNull()
+   public void Modulus11_27ExtendedAlgorithm_ValidateMasked_ShouldThrowArgumentNullException_WhenMaskIsNull()
       => _sut
          .Invoking(x => x.Validate("12345", null!))
          .Should()

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11_27ExtendedAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/Modulus11_27ExtendedAlgorithmTests.cs
@@ -248,6 +248,15 @@ public class Modulus11_27ExtendedAlgorithmTests
    // ==========================================================================
 
    [Fact]
+   public void  Modulus11_27ExtendedAlgorithm_ValidateMasked_ShouldThrowArgumentNullException_WhenMaskIsNull()
+      => _sut
+         .Invoking(x => x.Validate("12345", null!))
+         .Should()
+         .ThrowExactly<ArgumentNullException>()
+         .WithParameterName("mask")
+         .WithMessage(Resources.NullMaskMessage + "*");
+
+   [Fact]
    public void Modulus11_27ExtendedAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputIsNull()
       => _sut.Validate(null!, _acceptAllMask).Should().BeFalse();
 

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/VerhoeffAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/VerhoeffAlgorithmTests.cs
@@ -213,6 +213,15 @@ public class VerhoeffAlgorithmTests
    public void VerhoeffAlgorithm_ValidateMasked_ShouldReturnTrue_WhenValueContainsValidCheckDigit(String value)
       => _sut.Validate(value, _groupsOfThreeMask).Should().BeTrue();
 
+   [Theory]
+   [InlineData("2363")]                      // Worked example from Wikipedia
+   [InlineData("04")]
+   [InlineData("123451")]                    // Test data from https://rosettacode.org/wiki/Verhoeff_algorithm
+   [InlineData("758722")]                    // Test data from https://codereview.stackexchange.com/questions/221229/verhoeff-check-digit-algorithm
+   [InlineData("1428570")]                   // "
+   public void VerhoeffAlgorithm_ValidateMasked_ShouldReturnTrue_WhenValueContainsValidCheckDigitAndMaskAcceptsAllCharacters(String value)
+      => _sut.Validate(value, _acceptAllMask).Should().BeTrue();
+
    // NOTE: algorithm applies mod 8 to the index when indexing into the permutation table
    [Theory]
    [InlineData("123 456 789 012 0")]               // Test data from https://rosettacode.org/wiki/Verhoeff_algorithm

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/VerhoeffAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/VerhoeffAlgorithmTests.cs
@@ -4,85 +4,99 @@ namespace CheckDigits.Net.Tests.Unit.GeneralAlgorithms;
 
 public class VerhoeffAlgorithmTests
 {
-    private readonly VerhoeffAlgorithm _sut = new();
+   private readonly VerhoeffAlgorithm _sut = new();
+   private readonly ICheckDigitMask _acceptAllMask = new AcceptAllMask();
+   private readonly ICheckDigitMask _groupsOfThreeMask = new GroupsOfThreeCheckDigitMask();
+   private readonly ICheckDigitMask _rejectAllMask = new RejectAllMask();
 
-    #region AlgorithmDescription Property Tests
-    // ==========================================================================
-    // ==========================================================================
+   #region AlgorithmDescription Property Tests
+   // ==========================================================================
+   // ==========================================================================
 
-    [Fact]
-    public void VerhoeffAlgorithm_AlgorithmDescription_ShouldReturnExpectedValue()
-       => _sut.AlgorithmDescription.Should().Be(Resources.VerhoeffAlgorithmDescription);
+   [Fact]
+   public void VerhoeffAlgorithm_AlgorithmDescription_ShouldReturnExpectedValue()
+      => _sut.AlgorithmDescription.Should().Be(Resources.VerhoeffAlgorithmDescription);
 
-    #endregion
+   #endregion
 
-    #region AlgorithmName Property Tests
-    // ==========================================================================
-    // ==========================================================================
+   #region AlgorithmName Property Tests
+   // ==========================================================================
+   // ==========================================================================
 
-    [Fact]
-    public void VerhoeffAlgorithm_AlgorithmName_ShouldReturnExpectedValue()
-       => _sut.AlgorithmName.Should().Be(Resources.VerhoeffAlgorithmName);
+   [Fact]
+   public void VerhoeffAlgorithm_AlgorithmName_ShouldReturnExpectedValue()
+      => _sut.AlgorithmName.Should().Be(Resources.VerhoeffAlgorithmName);
 
-    #endregion
+   #endregion
 
-    #region TryCalculateCheckDigit Tests
-    // ==========================================================================
-    // ==========================================================================
+   #region TryCalculateCheckDigit Tests
+   // ==========================================================================
+   // ==========================================================================
 
-    [Fact]
-    public void VerhoeffAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenInputIsNull()
-    {
-        // Act/assert.
-        _sut.TryCalculateCheckDigit(null!, out var checkDigit).Should().BeFalse();
-        checkDigit.Should().Be('\0');
-    }
+   [Fact]
+   public void VerhoeffAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenInputIsNull()
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(null!, out var checkDigit).Should().BeFalse();
+      checkDigit.Should().Be('\0');
+   }
 
-    [Fact]
-    public void VerhoeffAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenInputIsEmpty()
-    {
-        // Act/assert.
-        _sut.TryCalculateCheckDigit(String.Empty, out var checkDigit).Should().BeFalse();
-        checkDigit.Should().Be('\0');
-    }
+   [Fact]
+   public void VerhoeffAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenInputIsEmpty()
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(String.Empty, out var checkDigit).Should().BeFalse();
+      checkDigit.Should().Be('\0');
+   }
 
-    [Theory]
-    [InlineData("236", '3')]                      // Worked example from Wikipedia
-    [InlineData("0", '4')]
-    [InlineData("12345", '1')]                    // Test data from https://rosettacode.org/wiki/Verhoeff_algorithm
-    [InlineData("75872", '2')]                    // Test data from https://codereview.stackexchange.com/questions/221229/verhoeff-check-digit-algorithm
-    [InlineData("142857", '0')]                   // "
-    public void VerhoeffAlgorithm_TryCalculateCheckDigit_ShouldCalculateExpectedCheckDigit(
-       String value,
-       Char expectedCheckDigit)
-    {
-        // Act/assert.
-        _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
-        checkDigit.Should().Be(expectedCheckDigit);
-    }
+   [Theory]
+   [InlineData("236", '3')]                      // Worked example from Wikipedia
+   [InlineData("0", '4')]
+   [InlineData("12345", '1')]                    // Test data from https://rosettacode.org/wiki/Verhoeff_algorithm
+   [InlineData("75872", '2')]                    // Test data from https://codereview.stackexchange.com/questions/221229/verhoeff-check-digit-algorithm
+   [InlineData("142857", '0')]                   // "
+   public void VerhoeffAlgorithm_TryCalculateCheckDigit_ShouldCalculateExpectedCheckDigit(
+      String value,
+      Char expectedCheckDigit)
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
+      checkDigit.Should().Be(expectedCheckDigit);
+   }
 
-    // NOTE: algorithm applies mod 8 to the index when indexing into the permutation table
-    [Theory]
-    [InlineData("123456789012", '0')]             // Test data from https://rosettacode.org/wiki/Verhoeff_algorithm
-    [InlineData("8473643095483728456789", '2')]   // Test data from https://codereview.stackexchange.com/questions/221229/verhoeff-check-digit-algorithm
-    [InlineData("11223344556677889900", '9')]     // Value calculated by https://kik.amc.nl/home/rcornet/verhoeff.html
-    public void VerhoeffAlgorithm_TryCalculateCheckDigit_ShouldCalculateExpectedCheckDigit_WhenValueHasLengthGreaterThanEight(
-       String value,
-       Char expectedCheckDigit)
-    {
-        // Act/assert.
-        _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
-        checkDigit.Should().Be(expectedCheckDigit);
-    }
+   // NOTE: algorithm applies mod 8 to the index when indexing into the permutation table
+   [Theory]
+   [InlineData("123456789012", '0')]             // Test data from https://rosettacode.org/wiki/Verhoeff_algorithm
+   [InlineData("8473643095483728456789", '2')]   // Test data from https://codereview.stackexchange.com/questions/221229/verhoeff-check-digit-algorithm
+   [InlineData("11223344556677889900", '9')]     // Value calculated by https://kik.amc.nl/home/rcornet/verhoeff.html
+   public void VerhoeffAlgorithm_TryCalculateCheckDigit_ShouldCalculateExpectedCheckDigit_WhenValueHasLengthGreaterThanEight(
+      String value,
+      Char expectedCheckDigit)
+   {
+      // Act/assert.
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeTrue();
+      checkDigit.Should().Be(expectedCheckDigit);
+   }
 
-    [Theory]
-    [InlineData("12G45")]
-    [InlineData("12)45")]
-    public void VerhoeffAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenInputContainsNonDigitCharacter(String value)
-    {
-        _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeFalse();
-        checkDigit.Should().Be('\0');
-    }
+   [Theory]
+   [InlineData("12G45")]
+   [InlineData("12)45")]
+   public void VerhoeffAlgorithm_TryCalculateCheckDigit_ShouldReturnFalse_WhenInputContainsNonDigitCharacter(String value)
+   {
+      _sut.TryCalculateCheckDigit(value, out var checkDigit).Should().BeFalse();
+      checkDigit.Should().Be('\0');
+   }
+
+   [Theory]
+   [InlineData("140")]
+   [InlineData("140662")]
+   [InlineData("140662538")]
+   [InlineData("140662538042")]
+   [InlineData("140662538042551")]
+   [InlineData("140662538042551028")]
+   [InlineData("140662538042551028265")]
+   public void VerhoeffAlgorithm_TryCalculateValue_ShouldReturnTrue_ForBenchmarkValues(String value)
+      => _sut.TryCalculateCheckDigit(value, out _).Should().BeTrue();
 
    #endregion
 
@@ -91,66 +105,167 @@ public class VerhoeffAlgorithmTests
    // ==========================================================================
 
    [Fact]
-    public void VerhoeffAlgorithm_Validate_ShouldReturnFalse_WhenInputIsNull()
-       => _sut.Validate(null!).Should().BeFalse();
+   public void VerhoeffAlgorithm_Validate_ShouldReturnFalse_WhenInputIsNull()
+      => _sut.Validate(null!).Should().BeFalse();
 
-    [Fact]
-    public void VerhoeffAlgorithm_Validate_ShouldReturnFalse_WhenInputIsEmpty()
-       => _sut.Validate(String.Empty).Should().BeFalse();
+   [Fact]
+   public void VerhoeffAlgorithm_Validate_ShouldReturnFalse_WhenInputIsEmpty()
+      => _sut.Validate(String.Empty).Should().BeFalse();
 
-    [Theory]
-    [InlineData("0")]    // "0" is the only digit that would pass unless length is checked explicitly
-    [InlineData("1")]
-    public void VerhoeffAlgorithm_Validate_ShouldReturnFalse_WhenInputIsLengthOne(String value)
-       => _sut.Validate(value).Should().BeFalse();
+   [Theory]
+   [InlineData("0")]    // "0" is the only digit that would pass unless length is checked explicitly
+   [InlineData("1")]
+   public void VerhoeffAlgorithm_Validate_ShouldReturnFalse_WhenInputIsLengthOne(String value)
+      => _sut.Validate(value).Should().BeFalse();
 
-    [Theory]
-    [InlineData("2363")]                      // Worked example from Wikipedia
-    [InlineData("04")]
-    [InlineData("123451")]                    // Test data from https://rosettacode.org/wiki/Verhoeff_algorithm
-    [InlineData("758722")]                    // Test data from https://codereview.stackexchange.com/questions/221229/verhoeff-check-digit-algorithm
-    [InlineData("1428570")]                   // "
-    public void VerhoeffAlgorithm_Validate_ShouldReturnTrue_WhenValueContainsValidCheckDigit(String value)
-       => _sut.Validate(value).Should().BeTrue();
+   [Theory]
+   [InlineData("2363")]                      // Worked example from Wikipedia
+   [InlineData("04")]
+   [InlineData("123451")]                    // Test data from https://rosettacode.org/wiki/Verhoeff_algorithm
+   [InlineData("758722")]                    // Test data from https://codereview.stackexchange.com/questions/221229/verhoeff-check-digit-algorithm
+   [InlineData("1428570")]                   // "
+   public void VerhoeffAlgorithm_Validate_ShouldReturnTrue_WhenValueContainsValidCheckDigit(String value)
+      => _sut.Validate(value).Should().BeTrue();
 
-    // NOTE: algorithm applies mod 8 to the index when indexing into the permutation table
-    [Theory]
-    [InlineData("1234567890120")]             // Test data from https://rosettacode.org/wiki/Verhoeff_algorithm
-    [InlineData("84736430954837284567892")]   // Test data from https://codereview.stackexchange.com/questions/221229/verhoeff-check-digit-algorithm
-    [InlineData("112233445566778899009")]     // Value calculated by https://kik.amc.nl/home/rcornet/verhoeff.html
-    public void VerhoeffAlgorithm_Validate_ShouldReturnTrue_WhenValueWithLengthGreaterThanEightContainsValidCheckDigit(String value)
-       => _sut.Validate(value).Should().BeTrue();
+   // NOTE: algorithm applies mod 8 to the index when indexing into the permutation table
+   [Theory]
+   [InlineData("1234567890120")]             // Test data from https://rosettacode.org/wiki/Verhoeff_algorithm
+   [InlineData("84736430954837284567892")]   // Test data from https://codereview.stackexchange.com/questions/221229/verhoeff-check-digit-algorithm
+   [InlineData("112233445566778899009")]     // Value calculated by https://kik.amc.nl/home/rcornet/verhoeff.html
+   public void VerhoeffAlgorithm_Validate_ShouldReturnTrue_WhenValueWithLengthGreaterThanEightContainsValidCheckDigit(String value)
+      => _sut.Validate(value).Should().BeTrue();
 
-    [Theory]
-    [InlineData("112233445566778899019")]     // Single digit errors (using "112233445566778899009" as a valid value)
-    [InlineData("112233445566778892009")]     // "
-    [InlineData("112233445566778399009")]     // "
-    [InlineData("112233445566748899009")]     // "
-    [InlineData("112233445565778899009")]     // "
-    [InlineData("112233445666778899009")]     // "
-    [InlineData("112233475566778899009")]     // "
-    [InlineData("112238445566778899009")]     // "
-    [InlineData("112933445566778899009")]     // "
-    [InlineData("102233445566778899009")]     // "
-    [InlineData("121233445566778899009")]     // Transposition errors (using "112233445566778899009" as a valid value)
-    [InlineData("112323445566778899009")]     // "
-    [InlineData("112234345566778899009")]     // "
-    [InlineData("112233454566778899009")]     // "
-    [InlineData("112233445656778899009")]     // "
-    [InlineData("112233445567678899009")]     // "
-    [InlineData("112233445566787899009")]     // "
-    [InlineData("112233445566778989009")]     // "
-    [InlineData("112233445566778890909")]     // "
-    [InlineData("84736430459837284567892")]   // Jump transposition error using "84736430954837284567892" as a valid value (954 -> 459)
-    [InlineData("112255445566778899009")]     // Twin error using "112233445566778899009" as a valid value (33 -> 55)
-    public void VerhoeffAlgorithm_Validate_ShouldReturnFalse_WhenInputContainsDetectableError(String value)
-       => _sut.Validate(value).Should().BeFalse();
+   [Theory]
+   [InlineData("112233445566778899019")]     // Single digit errors (using "112233445566778899009" as a valid value)
+   [InlineData("112233445566778892009")]     // "
+   [InlineData("112233445566778399009")]     // "
+   [InlineData("112233445566748899009")]     // "
+   [InlineData("112233445565778899009")]     // "
+   [InlineData("112233445666778899009")]     // "
+   [InlineData("112233475566778899009")]     // "
+   [InlineData("112238445566778899009")]     // "
+   [InlineData("112933445566778899009")]     // "
+   [InlineData("102233445566778899009")]     // "
+   [InlineData("121233445566778899009")]     // Transposition errors (using "112233445566778899009" as a valid value)
+   [InlineData("112323445566778899009")]     // "
+   [InlineData("112234345566778899009")]     // "
+   [InlineData("112233454566778899009")]     // "
+   [InlineData("112233445656778899009")]     // "
+   [InlineData("112233445567678899009")]     // "
+   [InlineData("112233445566787899009")]     // "
+   [InlineData("112233445566778989009")]     // "
+   [InlineData("112233445566778890909")]     // "
+   [InlineData("84736430459837284567892")]   // Jump transposition error using "84736430954837284567892" as a valid value (954 -> 459)
+   [InlineData("112255445566778899009")]     // Twin error using "112233445566778899009" as a valid value (33 -> 55)
+   public void VerhoeffAlgorithm_Validate_ShouldReturnFalse_WhenInputContainsDetectableError(String value)
+      => _sut.Validate(value).Should().BeFalse();
 
-    [Theory]
-    [InlineData("12G455")]
-    [InlineData("12)455")]
-    public void VerhoeffAlgorithm_Validate_ShouldReturnFalse_WhenInputContainsNonDigitCharacter(String value)
-       => _sut.Validate(value).Should().BeFalse();
+   [Theory]
+   [InlineData("12G455")]
+   [InlineData("12)455")]
+   public void VerhoeffAlgorithm_Validate_ShouldReturnFalse_WhenInputContainsNonDigitCharacter(String value)
+      => _sut.Validate(value).Should().BeFalse();
+
+   [Theory]
+   [InlineData("1401")]
+   [InlineData("1406625")]
+   [InlineData("1406625388")]
+   [InlineData("1406625380426")]
+   [InlineData("1406625380425512")]
+   [InlineData("1406625380425510285")]
+   [InlineData("1406625380425510282655")]
+   public void VerhoeffAlgorithm_Validate_ShouldReturnTrue_ForBenchmarkValues(String value)
+      => _sut.Validate(value).Should().BeTrue();
+
+   #endregion
+
+   #region Validate (ICheckDigitMask Overload) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void VerhoeffAlgorithm_ValidateMasked_ShouldThrowArgumentNullException_WhenMaskIsNull()
+      => _sut
+      .Invoking(x => x.Validate("12345", null!))
+      .Should()
+      .ThrowExactly<ArgumentNullException>()
+      .WithParameterName("mask")
+      .WithMessage(Resources.NullMaskMessage + "*");
+
+   [Fact]
+   public void VerhoeffAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputIsNull()
+      => _sut.Validate(null!, _acceptAllMask).Should().BeFalse();
+
+   [Fact]
+   public void VerhoeffAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputIsEmpty()
+      => _sut.Validate(String.Empty, _acceptAllMask).Should().BeFalse();
+
+   [Fact]
+   public void VerhoeffAlgorithm_ValidateMasked_ShouldReturnFalse_WhenAllNonCheckDigitCharactersAreMaskedOut()
+      => _sut.Validate("000 000 0000 000 000", _rejectAllMask).Should().BeFalse();
+
+   [Theory]
+   [InlineData("236 3")]                     // Worked example from Wikipedia
+   [InlineData("04")]
+   [InlineData("123 451")]                   // Test data from https://rosettacode.org/wiki/Verhoeff_algorithm
+   [InlineData("758 722")]                   // Test data from https://codereview.stackexchange.com/questions/221229/verhoeff-check-digit-algorithm
+   [InlineData("142 857 0")]                 // "
+   public void VerhoeffAlgorithm_ValidateMasked_ShouldReturnTrue_WhenValueContainsValidCheckDigit(String value)
+      => _sut.Validate(value, _groupsOfThreeMask).Should().BeTrue();
+
+   // NOTE: algorithm applies mod 8 to the index when indexing into the permutation table
+   [Theory]
+   [InlineData("123 456 789 012 0")]               // Test data from https://rosettacode.org/wiki/Verhoeff_algorithm
+   [InlineData("847 364 309 548 372 845 678 92")]  // Test data from https://codereview.stackexchange.com/questions/221229/verhoeff-check-digit-algorithm
+   [InlineData("112 233 445 566 778 899 009")]     // Value calculated by https://kik.amc.nl/home/rcornet/verhoeff.html
+   public void VerhoeffAlgorithm_ValidateMasked_ShouldReturnTrue_WhenValueWithLengthGreaterThanEightContainsValidCheckDigit(String value)
+      => _sut.Validate(value, _groupsOfThreeMask).Should().BeTrue();
+
+   [Theory]
+   [InlineData("112 233 445 566 778 899 019")]     // Single digit errors (using "112233445566778899009" as a valid value)
+   [InlineData("112 233 445 566 778 892 009")]     // "
+   [InlineData("112 233 445 566 778 399 009")]     // "
+   [InlineData("112 233 445 566 748 899 009")]     // "
+   [InlineData("112 233 445 565 778 899 009")]     // "
+   [InlineData("112 233 445 666 778 899 009")]     // "
+   [InlineData("112 233 475 566 778 899 009")]     // "
+   [InlineData("112 238 445 566 778 899 009")]     // "
+   [InlineData("112 933 445 566 778 899 009")]     // "
+   [InlineData("102 233 445 566 778 899 009")]     // "
+   [InlineData("121 233 445 566 778 899 009")]     // Transposition errors (using "112233445566778899009" as a valid value)
+   [InlineData("112 323 445 566 778 899 009")]     // "
+   [InlineData("112 234 345 566 778 899 009")]     // "
+   [InlineData("112 233 454 566 778 899 009")]     // "
+   [InlineData("112 233 445 656 778 899 009")]     // "
+   [InlineData("112 233 445 567 678 899 009")]     // "
+   [InlineData("112 233 445 566 787 899 009")]     // "
+   [InlineData("112 233 445 566 778 989 009")]     // "
+   [InlineData("112 233 445 566 778 890 909")]     // "
+   [InlineData("847 364 304 598 372 845 678 92")]  // Jump transposition error using "84736430954837284567892" as a valid value (954 -> 459)
+   [InlineData("112 255 445 566 778 899 009")]     // Twin error using "112233445566778899009" as a valid value (33 -> 55)
+   public void VerhoeffAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputContainsDetectableError(String value)
+      => _sut.Validate(value, _groupsOfThreeMask).Should().BeFalse();
+
+   [Theory]
+   [InlineData("12G 455")]
+   [InlineData("12) 455")]
+   public void VerhoeffAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputContainsNonDigitCharacter(String value)
+      => _sut.Validate(value, _groupsOfThreeMask).Should().BeFalse();
+
+   [Fact]
+   public void VerhoeffAlgorithm_ValidateMasked_ShouldReturnFalse_WhenCheckDigitCharacterIsNonDigit()
+      => _sut.Validate("123 45A", _groupsOfThreeMask).Should().BeFalse();
+
+   [Theory]
+   [InlineData("140 1")]
+   [InlineData("140 662 5")]
+   [InlineData("140 662 538 8")]
+   [InlineData("140 662 538 042 6")]
+   [InlineData("140 662 538 042 551 2")]
+   [InlineData("140 662 538 042 551 028 5")]
+   [InlineData("140 662 538 042 551 028 265 5")]
+   public void VerhoeffAlgorithm_ValidateMasked_ShouldReturnTrue_ForBenchmarkValues(String value)
+      => _sut.Validate(value, _groupsOfThreeMask).Should().BeTrue();
 
    #endregion
 }

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/VerhoeffAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/VerhoeffAlgorithmTests.cs
@@ -186,11 +186,11 @@ public class VerhoeffAlgorithmTests
    [Fact]
    public void VerhoeffAlgorithm_ValidateMasked_ShouldThrowArgumentNullException_WhenMaskIsNull()
       => _sut
-      .Invoking(x => x.Validate("12345", null!))
-      .Should()
-      .ThrowExactly<ArgumentNullException>()
-      .WithParameterName("mask")
-      .WithMessage(Resources.NullMaskMessage + "*");
+         .Invoking(x => x.Validate("12345", null!))
+         .Should()
+         .ThrowExactly<ArgumentNullException>()
+         .WithParameterName("mask")
+         .WithMessage(Resources.NullMaskMessage + "*");
 
    [Fact]
    public void VerhoeffAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputIsNull()

--- a/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/VerhoeffAlgorithmTests.cs
+++ b/CheckDigits.Net.Tests.Unit/GeneralAlgorithms/VerhoeffAlgorithmTests.cs
@@ -200,6 +200,12 @@ public class VerhoeffAlgorithmTests
    public void VerhoeffAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInputIsEmpty()
       => _sut.Validate(String.Empty, _acceptAllMask).Should().BeFalse();
 
+   [Theory]
+   [InlineData("0")]    // "0" is the only digit that would pass unless length is checked explicitly
+   [InlineData("1")]
+   public void VerhoeffAlgorithm_ValidateMasked_ShouldReturnFalse_WhenInsufficientUnmaskedCharactersToCalculateCheckDigit(String value)
+      => _sut.Validate(value, _acceptAllMask).Should().BeFalse();
+
    [Fact]
    public void VerhoeffAlgorithm_ValidateMasked_ShouldReturnFalse_WhenAllNonCheckDigitCharactersAreMaskedOut()
       => _sut.Validate("000 000 0000 000 000", _rejectAllMask).Should().BeFalse();

--- a/CheckDigits.Net.Tests.Unit/MaskedAlgorithmsTests.cs
+++ b/CheckDigits.Net.Tests.Unit/MaskedAlgorithmsTests.cs
@@ -1,4 +1,4 @@
-﻿// Ignore Spelling: Damm Luhn
+﻿// Ignore Spelling: Damm Luhn Verhoeff
 
 namespace CheckDigits.Net.Tests.Unit;
 
@@ -99,6 +99,20 @@ public class MaskedAlgorithmsTests
    [Fact]
    public void MaskedAlgorithms_Modulus11Extended_ShouldBeExpectedType()
       => MaskedAlgorithms.Modulus11Extended.Should().BeOfType<Modulus11ExtendedAlgorithm>();
+
+   #endregion
+
+   #region Verhoeff Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void MaskedAlgorithms_Verhoeff_ShouldNotBeNull()
+      => MaskedAlgorithms.Verhoeff.Should().NotBeNull();
+
+   [Fact]
+   public void MaskedAlgorithms_Verhoeff_ShouldBeExpectedType()
+      => MaskedAlgorithms.Verhoeff.Should().BeOfType<VerhoeffAlgorithm>();
 
    #endregion
 }

--- a/CheckDigits.Net.Tests.Unit/MaskedAlgorithmsTests.cs
+++ b/CheckDigits.Net.Tests.Unit/MaskedAlgorithmsTests.cs
@@ -1,9 +1,23 @@
-﻿// Ignore Spelling: Luhn
+﻿// Ignore Spelling: Damm Luhn
 
 namespace CheckDigits.Net.Tests.Unit;
 
 public class MaskedAlgorithmsTests
 {
+   #region Damm Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void MaskedAlgorithms_Damm_ShouldNotBeNull()
+      => MaskedAlgorithms.Damm.Should().NotBeNull();
+
+   [Fact]
+   public void MaskedAlgorithms_Damm_ShouldBeExpectedType()
+      => MaskedAlgorithms.Damm.Should().BeOfType<DammAlgorithm>();
+
+   #endregion
+
    #region Luhn Property Tests
    // ==========================================================================
    // ==========================================================================

--- a/CheckDigits.Net/GeneralAlgorithms/DammAlgorithm.cs
+++ b/CheckDigits.Net/GeneralAlgorithms/DammAlgorithm.cs
@@ -85,7 +85,11 @@ public sealed class DammAlgorithm : ISingleCheckDigitAlgorithm, IMaskedCheckDigi
    /// <inheritdoc/>
    public Boolean Validate(String value, ICheckDigitMask mask)
    {
-      if (String.IsNullOrEmpty(value) || value.Length < _validateMinLength)
+      if (mask is null)
+      {
+         throw new ArgumentNullException(nameof(mask), Resources.NullMaskMessage);
+      }
+      if (String.IsNullOrEmpty(value))
       {
          return false;
       }

--- a/CheckDigits.Net/GeneralAlgorithms/DammCustomQuasigroupAlgorithm.cs
+++ b/CheckDigits.Net/GeneralAlgorithms/DammCustomQuasigroupAlgorithm.cs
@@ -99,7 +99,11 @@ public sealed class DammCustomQuasigroupAlgorithm(IDammQuasigroup quasigroup) : 
    /// <inheritdoc/>
    public Boolean Validate(String value, ICheckDigitMask mask)
    {
-      if (String.IsNullOrEmpty(value) || value.Length < _validateMinLength)
+      if (mask is null)
+      {
+         throw new ArgumentNullException(nameof(mask), Resources.NullMaskMessage);
+      }
+      if (String.IsNullOrEmpty(value))
       {
          return false;
       }

--- a/CheckDigits.Net/GeneralAlgorithms/LuhnAlgorithm.cs
+++ b/CheckDigits.Net/GeneralAlgorithms/LuhnAlgorithm.cs
@@ -92,6 +92,10 @@ public sealed class LuhnAlgorithm : ISingleCheckDigitAlgorithm, IMaskedCheckDigi
    /// <inheritdoc/>
    public Boolean Validate(String value, ICheckDigitMask mask)
    {
+      if (mask is null)
+      {
+         throw new ArgumentNullException(nameof(mask), Resources.NullMaskMessage);
+      }
       if (String.IsNullOrEmpty(value))
       {
          return false;

--- a/CheckDigits.Net/GeneralAlgorithms/Modulus10_13Algorithm.cs
+++ b/CheckDigits.Net/GeneralAlgorithms/Modulus10_13Algorithm.cs
@@ -86,6 +86,10 @@ public sealed class Modulus10_13Algorithm : ISingleCheckDigitAlgorithm, IMaskedC
    /// <inheritdoc/>
    public Boolean Validate(String value, ICheckDigitMask mask)
    {
+      if (mask is null)
+      {
+         throw new ArgumentNullException(nameof(mask), Resources.NullMaskMessage);
+      }
       if (String.IsNullOrEmpty(value))
       {
          return false;

--- a/CheckDigits.Net/GeneralAlgorithms/Modulus11DecimalAlgorithm.cs
+++ b/CheckDigits.Net/GeneralAlgorithms/Modulus11DecimalAlgorithm.cs
@@ -121,6 +121,10 @@ public sealed class Modulus11DecimalAlgorithm : ISingleCheckDigitAlgorithm, IMas
    /// <inheritdoc/>
    public Boolean Validate(String value, ICheckDigitMask mask)
    {
+      if (mask is null)
+      {
+         throw new ArgumentNullException(nameof(mask), Resources.NullMaskMessage);
+      }
       if (String.IsNullOrEmpty(value))
       {
          return false;

--- a/CheckDigits.Net/GeneralAlgorithms/Modulus11ExtendedAlgorithm.cs
+++ b/CheckDigits.Net/GeneralAlgorithms/Modulus11ExtendedAlgorithm.cs
@@ -119,6 +119,10 @@ public sealed class Modulus11ExtendedAlgorithm : ISingleCheckDigitAlgorithm, IMa
    /// <inheritdoc/>
    public Boolean Validate(String value, ICheckDigitMask mask)
    {
+      if (mask is null)
+      {
+         throw new ArgumentNullException(nameof(mask), Resources.NullMaskMessage);
+      }
       if (String.IsNullOrEmpty(value))
       {
          return false;

--- a/CheckDigits.Net/GeneralAlgorithms/Modulus11_27DecimalAlgorithm.cs
+++ b/CheckDigits.Net/GeneralAlgorithms/Modulus11_27DecimalAlgorithm.cs
@@ -117,6 +117,10 @@ public sealed class Modulus11_27DecimalAlgorithm : ISingleCheckDigitAlgorithm, I
    /// <inheritdoc/>
    public Boolean Validate(String value, ICheckDigitMask mask)
    {
+      if (mask is null)
+      {
+         throw new ArgumentNullException(nameof(mask), Resources.NullMaskMessage);
+      }
       if (String.IsNullOrEmpty(value))
       {
          return false;

--- a/CheckDigits.Net/GeneralAlgorithms/Modulus11_27ExtendedAlgorithm.cs
+++ b/CheckDigits.Net/GeneralAlgorithms/Modulus11_27ExtendedAlgorithm.cs
@@ -111,6 +111,10 @@ public sealed class Modulus11_27ExtendedAlgorithm : ISingleCheckDigitAlgorithm, 
    /// <inheritdoc/>
    public Boolean Validate(String value, ICheckDigitMask mask)
    {
+      if (mask is null)
+      {
+         throw new ArgumentNullException(nameof(mask), Resources.NullMaskMessage);
+      }
       if (String.IsNullOrEmpty(value))
       {
          return false;

--- a/CheckDigits.Net/GeneralAlgorithms/VerhoeffAlgorithm.cs
+++ b/CheckDigits.Net/GeneralAlgorithms/VerhoeffAlgorithm.cs
@@ -19,7 +19,7 @@ namespace CheckDigits.Net.GeneralAlgorithms;
 ///   </para>
 ///   <para>
 ///   Will detect all single-digit transcription errors and all two digit 
-///   transpositions of adjacent digits
+///   transpositions of adjacent digits.
 ///   </para>
 /// </remarks>
 public sealed class VerhoeffAlgorithm : ISingleCheckDigitAlgorithm, IMaskedCheckDigitAlgorithm
@@ -52,7 +52,7 @@ public sealed class VerhoeffAlgorithm : ISingleCheckDigitAlgorithm, IMaskedCheck
       for (var index = value.Length - 1; index >= 0; index--)
       {
          var n = value![index].ToIntegerDigit();
-         if (n < 0 || n > 9)
+         if (n.IsInvalidDigit())
          {
             return false;
          }
@@ -80,7 +80,7 @@ public sealed class VerhoeffAlgorithm : ISingleCheckDigitAlgorithm, IMaskedCheck
       for (var index = value.Length - 1; index >= 0; index--)
       {
          var n = value![index].ToIntegerDigit();
-         if (n < 0 || n > 9)
+         if (n.IsInvalidDigit())
          {
             return false;
          }
@@ -111,7 +111,7 @@ public sealed class VerhoeffAlgorithm : ISingleCheckDigitAlgorithm, IMaskedCheck
 
       // Handle check digit outside of loop to prevent the mask from excluding it.
       var n = value[^1].ToIntegerDigit();
-      if (n < 0 || n > 9)
+      if (n.IsInvalidDigit())
       {
          return false;
       }
@@ -120,15 +120,14 @@ public sealed class VerhoeffAlgorithm : ISingleCheckDigitAlgorithm, IMaskedCheck
       i++;
 
       var processedDigits = 0;
-      var processedLength = value.Length - 2;      // Minus 2 because check digit is handled outside
-      for (var index = processedLength; index >= 0; index--)
+      for (var index = value.Length - 2; index >= 0; index--)     // Minus 2 because check digit is handled outside of loop
       {
          if (mask.ExcludeCharacter(index))
          {
             continue;
          }
          n = value[index].ToIntegerDigit();
-         if (n < 0 || n > 9)
+         if (n.IsInvalidDigit())
          {
             return false;
          }

--- a/CheckDigits.Net/GeneralAlgorithms/VerhoeffAlgorithm.cs
+++ b/CheckDigits.Net/GeneralAlgorithms/VerhoeffAlgorithm.cs
@@ -22,7 +22,7 @@ namespace CheckDigits.Net.GeneralAlgorithms;
 ///   transpositions of adjacent digits
 ///   </para>
 /// </remarks>
-public sealed class VerhoeffAlgorithm : ISingleCheckDigitAlgorithm
+public sealed class VerhoeffAlgorithm : ISingleCheckDigitAlgorithm, IMaskedCheckDigitAlgorithm
 {
    private static readonly VerhoeffInverseTable _inverseTable =
       VerhoeffInverseTable.Instance;
@@ -89,6 +89,59 @@ public sealed class VerhoeffAlgorithm : ISingleCheckDigitAlgorithm
          c = _multiplicationTable[c, p];
 
          i++;
+      }
+
+      return c == 0;
+   }
+ 
+   /// <inheritdoc/>
+   public Boolean Validate(String value, ICheckDigitMask mask)
+   {
+      if (mask is null)
+      {
+         throw new ArgumentNullException(nameof(mask), Resources.NullMaskMessage);
+      }
+      if (String.IsNullOrEmpty(value))
+      {
+         return false;
+      }
+
+      var c = 0;
+      var i = 0;
+
+      // Handle check digit outside of loop to prevent the mask from excluding it.
+      var n = value[^1].ToIntegerDigit();
+      if (n < 0 || n > 9)
+      {
+         return false;
+      }
+      var p = _permutationTable[i % 8, n];
+      c = _multiplicationTable[c, p];
+      i++;
+
+      var processedDigits = 0;
+      var processedLength = value.Length - 2;      // Minus 2 because check digit is handled outside
+      for (var index = processedLength; index >= 0; index--)
+      {
+         if (mask.ExcludeCharacter(index))
+         {
+            continue;
+         }
+         n = value[index].ToIntegerDigit();
+         if (n < 0 || n > 9)
+         {
+            return false;
+         }
+
+         p = _permutationTable[i % 8, n];
+         c = _multiplicationTable[c, p];
+
+         i++;
+         processedDigits ++;
+      }
+      if (processedDigits == 0)
+      {
+         return false;
       }
 
       return c == 0;

--- a/CheckDigits.Net/GeneralAlgorithms/VerhoeffAlgorithm.cs
+++ b/CheckDigits.Net/GeneralAlgorithms/VerhoeffAlgorithm.cs
@@ -136,7 +136,7 @@ public sealed class VerhoeffAlgorithm : ISingleCheckDigitAlgorithm, IMaskedCheck
          c = _multiplicationTable[c, p];
 
          i++;
-         processedDigits ++;
+         processedDigits++;
       }
       if (processedDigits == 0)
       {

--- a/CheckDigits.Net/IMaskedCheckDigitAlgorithm.cs
+++ b/CheckDigits.Net/IMaskedCheckDigitAlgorithm.cs
@@ -31,5 +31,8 @@ public interface IMaskedCheckDigitAlgorithm : ICheckDigitAlgorithm
    ///   <see cref="String.Empty"/> or a string that is of invalid length for 
    ///   this algorithm.
    /// </remarks>
+   /// <exception cref="ArgumentNullException">
+   ///   <paramref name="mask"/> is <see langword="null"/>.
+   /// </exception>
    Boolean Validate(String value, ICheckDigitMask mask);
 }

--- a/CheckDigits.Net/MaskedAlgorithms.cs
+++ b/CheckDigits.Net/MaskedAlgorithms.cs
@@ -1,4 +1,4 @@
-﻿// Ignore Spelling: Luhn
+﻿// Ignore Spelling: Damm Luhn Verhoeff
 
 namespace CheckDigits.Net;
 
@@ -28,6 +28,9 @@ public static class MaskedAlgorithms
 
    private static readonly Lazy<IMaskedCheckDigitAlgorithm> _modulus11Extended =
       new(() => new Modulus11ExtendedAlgorithm());
+
+   private static readonly Lazy<IMaskedCheckDigitAlgorithm> _verhoeff =
+      new(() => new VerhoeffAlgorithm());
 
    /// <summary>
    ///   Damm algorithm.
@@ -64,4 +67,8 @@ public static class MaskedAlgorithms
    /// </summary>
    public static IMaskedCheckDigitAlgorithm Modulus11Extended => _modulus11Extended.Value;
 
+   /// <summary>
+   ///   Verhoeff algorithm.
+   /// </summary>
+   public static IMaskedCheckDigitAlgorithm Verhoeff => _verhoeff.Value;
 }

--- a/CheckDigits.Net/MaskedAlgorithms.cs
+++ b/CheckDigits.Net/MaskedAlgorithms.cs
@@ -8,6 +8,9 @@ namespace CheckDigits.Net;
 /// </summary>
 public static class MaskedAlgorithms
 {
+   private static readonly Lazy<IMaskedCheckDigitAlgorithm> _damm =
+      new(() => new DammAlgorithm());
+
    private static readonly Lazy<IMaskedCheckDigitAlgorithm> _luhn =
       new(() => new LuhnAlgorithm());
 
@@ -25,6 +28,11 @@ public static class MaskedAlgorithms
 
    private static readonly Lazy<IMaskedCheckDigitAlgorithm> _modulus11Extended =
       new(() => new Modulus11ExtendedAlgorithm());
+
+   /// <summary>
+   ///   Damm algorithm.
+   /// </summary>
+   public static IMaskedCheckDigitAlgorithm Damm => _damm.Value;
 
    /// <summary>
    ///   Luhn algorithm.

--- a/CheckDigits.Net/Resources.Designer.cs
+++ b/CheckDigits.Net/Resources.Designer.cs
@@ -799,6 +799,15 @@ namespace CheckDigits.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Mask may not be null.
+        /// </summary>
+        internal static string NullMaskMessage {
+            get {
+                return ResourceManager.GetString("NullMaskMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Quasigroup definition may not be null.
         /// </summary>
         internal static string QuasigroupDefinitionRequiredMessage {

--- a/CheckDigits.Net/Resources.resx
+++ b/CheckDigits.Net/Resources.resx
@@ -402,4 +402,7 @@
   <data name="QuasigroupMinimumOrder2Message" xml:space="preserve">
     <value>Quasigroup minimum order is 2 (i.e. 2x2 matrix)</value>
   </data>
+  <data name="NullMaskMessage" xml:space="preserve">
+    <value>Mask may not be null</value>
+  </data>
 </root>

--- a/README.md
+++ b/README.md
@@ -328,11 +328,12 @@ following algorithms implement `IMaskedCheckDigitAlgorithm`:
 * [Damm Algorithm](#damm-algorithm)
 * [Damm Custom Quasigroup Algorithm](#damm-custom-quasigroup-algorithm)
 * [Luhn Algorithm](#luhn-algorithm)
-* [Modulus10_13 Algorithm (UPC/EAN/ISBN-13/etc.)](#modulus10_13-algorithm)
+* [Modulus10_13 Algorithm](#modulus10_13-algorithm)
 * [Modulus11_27Decimal Algorithm](#modulus11_27decimal-algorithm)
 * [Modulus11_27Extended Algorithm](#modulus11_27extended-algorithm)
-* [Modulus11Decimal Algorithm (NHS Number/etc.)](#modulus11decimal-algorithm)
-* [Modulus11Extended Algorithm (ISBN-10/ISSN/etc.)](#modulus11extended-algorithm)
+* [Modulus11Decimal Algorithm](#modulus11decimal-algorithm)
+* [Modulus11Extended Algorithm)](#modulus11extended-algorithm)
+* [Verhoeff Algorithm](#verhoeff-algorithm)
 
 ### ICheckDigitMask
 
@@ -1729,6 +1730,10 @@ implemented as a set of lookup tables). Additionally, Verhoeff's algorithm can
 detect many, though not all, twin errors, two digit jump transpositions and jump
 twin errors.
 
+`VerhoeffAlgorithm` implements [IMaskedCheckDigitAlgorithm](#imaskedcheckdigitalgorithm) and can be used 
+to validate values that are formatted with non-check digit characters (for example,
+a credit card number formatted with spaces or dashes).
+
 #### Details
 
 * Valid characters - decimal digits ('0' - '9')
@@ -2497,6 +2502,7 @@ Additional included algorithms:
 Added masked validation support to the following algorithms:
 * Damm Algorithm
 * Modulus10_13 Algorithm
+* Verhoeff Algorithm
 
 Minor updates to the following algorithms:
 * ICAO 9303 Document Size TD1 Algorithm

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ let us know. Or contribute to the CheckDigits.Net repository: https://github.com
     - [v2.3.0](#v2.3.0)
     - [v2.3.1](#v2.3.1)
     - [v3.0.0](#v3.0.0)
+    - [v3.1.0](#v3.1.0)
 
 ## Check Digit Overview
 
@@ -332,7 +333,7 @@ following algorithms implement `IMaskedCheckDigitAlgorithm`:
 * [Modulus11_27Decimal Algorithm](#modulus11_27decimal-algorithm)
 * [Modulus11_27Extended Algorithm](#modulus11_27extended-algorithm)
 * [Modulus11Decimal Algorithm](#modulus11decimal-algorithm)
-* [Modulus11Extended Algorithm)](#modulus11extended-algorithm)
+* [Modulus11Extended Algorithm](#modulus11extended-algorithm)
 * [Verhoeff Algorithm](#verhoeff-algorithm)
 
 ### ICheckDigitMask

--- a/README.md
+++ b/README.md
@@ -2360,6 +2360,14 @@ public class GroupsOfThreeCheckDigitMask : ICheckDigitMask
 | Modulus11Extended     | 140 6                         |  4.317 ns | 0.0073 ns | 0.0068 ns | -         |
 | Modulus11Extended     | 140 662 0                     |  5.268 ns | 0.0358 ns | 0.0335 ns | -         |
 | Modulus11Extended     | 140 662 538 8                 |  6.603 ns | 0.0696 ns | 0.0651 ns | -         |
+|                       |                               |           |           |           |           |
+| Verhoeff              | 140 1                         |  5.549 ns | 0.0181 ns | 0.0151 ns | -         |
+| Verhoeff              | 140 662 5                     |  8.417 ns | 0.0464 ns | 0.0434 ns | -         |
+| Verhoeff              | 140 662 538 8                 | 11.810 ns | 0.0828 ns | 0.0734 ns | -         |
+| Verhoeff              | 140 662 538 042 6             | 15.582 ns | 0.0920 ns | 0.0768 ns | -         |
+| Verhoeff              | 140 662 538 042 551 2         | 19.340 ns | 0.0857 ns | 0.0760 ns | -         |
+| Verhoeff              | 140 662 538 042 551 028 5     | 23.305 ns | 0.1805 ns | 0.1600 ns | -         |
+| Verhoeff              | 140 662 538 042 551 028 265 5 | 27.167 ns | 0.0691 ns | 0.0647 ns | -         |
 
 #### Damm Custom Quasigroup Algorithm
 


### PR DESCRIPTION
This pull request adds masked validation support to the Verhoeff algorithm, along with comprehensive unit tests, readme updates and benchmark results. Also corrects an oversight in earlier masked validation changes by adding explicit tests for a null check digit mask as well as unit tests for that case.